### PR TITLE
chore(SB-1112): add ignored skills directory to workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # npm lock file
 package-lock.json
+
+# Third party skills
+skills/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "packages/sprucebot-skills-kit",
     "packages/sprucebot-node",
     "packages/sprucebot-skills-kit-server",
-    "packages/react-sprucebot"
+    "packages/react-sprucebot",
+    "skills/*"
   ],
   "scripts": {
     "local": "pm2 start ecosystem.config.js && echo 'run `yarn run log` to tail the logs'",


### PR DESCRIPTION
Adds a "skills/" workspace for developing skills that is `.gitignored`

This approach will have side-effects into the main workspace since it will install any extra dependencies into the main workspace. The workspace `yarn.lock` specifically will add any dependency any of the `skills/*`

Is there a better solution to linking the packages here with any of our already created skills?