### PR TITLE
fix: pm2 package is production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "commit": "git-cz"
   },
+  "dependencies": {
+    "pm2": "^2.10.1"
+  },
   "devDependencies": {
     "@commitlint/cli": "^6.1.3",
     "@commitlint/config-conventional": "^6.1.3",
@@ -30,7 +33,6 @@
     "cz-conventional-changelog": "^2.1.0",
     "husky": "^0.14.3",
     "lerna": "^2.9.0",
-    "pm2": "^2.10.1",
     "semantic-release": "^15.0.3",
     "semantic-release-monorepo": "^6.0.0"
   },


### PR DESCRIPTION
@sprucelabsai/engineers

## Description 
The heroku deployment can't start the server since pm2 is undefined

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
Deploy to heroku
