### PR TITLE
fix(SB-1130): fix exif orientation of uploaded images

### DIFF
--- a/packages/react-sprucebot/lib/components/ImageCropper/ImageCropper.js
+++ b/packages/react-sprucebot/lib/components/ImageCropper/ImageCropper.js
@@ -30,6 +30,10 @@ var _reactImageCrop = require('react-image-crop');
 
 var _reactImageCrop2 = _interopRequireDefault(_reactImageCrop);
 
+var _exifOrientationImage = require('exif-orientation-image');
+
+var _exifOrientationImage2 = _interopRequireDefault(_exifOrientationImage);
+
 var _styledComponents = require('styled-components');
 
 var _styledComponents2 = _interopRequireDefault(_styledComponents);
@@ -94,14 +98,22 @@ var ImageCropper = function (_Component) {
 	}, {
 		key: 'onChange',
 		value: function onChange(e) {
+			var _this2 = this;
+
 			var file = e.target.files[0];
 			if (!file.type.match('image.*')) {
 				alert(this.props.badImageMessage);
 				return;
 			}
 
-			this.setState({ changed: true, newFile: true });
-			this.reader.readAsDataURL(file);
+			(0, _exifOrientationImage2.default)(file, function (err, canvas) {
+				if (!err) {
+					_this2.setState({ changed: true, newFile: true });
+					canvas.toBlob(function (blob) {
+						return _this2.reader.readAsDataURL(blob);
+					});
+				}
+			});
 		}
 	}, {
 		key: 'onFileReaderLoadImage',
@@ -176,7 +188,7 @@ var ImageCropper = function (_Component) {
 		key: 'onSave',
 		value: function () {
 			var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
-				var _this2 = this;
+				var _this3 = this;
 
 				var _state, pixelCrop, type, image, canvas, ctx, cropped;
 
@@ -210,7 +222,7 @@ var ImageCropper = function (_Component) {
 									image.onerror = function (err) {
 										reject(err);
 									};
-									image.src = _this2.cropper.imageRef.src;
+									image.src = _this3.cropper.imageRef.src;
 								});
 
 							case 8:
@@ -276,7 +288,7 @@ var ImageCropper = function (_Component) {
 	}, {
 		key: 'render',
 		value: function render() {
-			var _this3 = this;
+			var _this4 = this;
 
 			var _props = this.props,
 			    accept = _props.accept,
@@ -314,7 +326,7 @@ var ImageCropper = function (_Component) {
 					_react2.default.createElement(_reactImageCrop2.default, {
 						crossorigin: 'Anonymous',
 						ref: function ref(cropper) {
-							return _this3.cropper = cropper;
+							return _this4.cropper = cropper;
 						},
 						keepSelection: true,
 						onImageLoaded: this.onImageLoadedFromCropper.bind(this),
@@ -336,7 +348,7 @@ var ImageCropper = function (_Component) {
 					style: { display: 'none' },
 					type: 'file',
 					ref: function ref(input) {
-						_this3.input = input;
+						_this4.input = input;
 					},
 					accept: accept,
 					onChange: this.onChange.bind(this)

--- a/packages/react-sprucebot/package.json
+++ b/packages/react-sprucebot/package.json
@@ -60,6 +60,7 @@
         "classnames": "^2.2.5",
         "cookies": "^0.7.1",
         "debug": "^3.1.0",
+        "exif-orientation-image": "^1.0.1",
         "imagesloaded": "^4.1.4",
         "js-cookies": "^1.0.4",
         "moment": "^2.19.3",

--- a/packages/react-sprucebot/src/components/ImageCropper/ImageCropper.js
+++ b/packages/react-sprucebot/src/components/ImageCropper/ImageCropper.js
@@ -4,6 +4,7 @@ import BotText from '../BotText/BotText'
 import Loader from '../Loader/Loader'
 import Button from '../Button/Button'
 import ReactCrop, { makeAspectCrop } from 'react-image-crop'
+import getOrientedImage from 'exif-orientation-image'
 import styled from 'styled-components'
 import SubmitWrapper from '../SubmitWrapper/SubmitWrapper'
 
@@ -49,8 +50,12 @@ export default class ImageCropper extends Component {
 			return
 		}
 
-		this.setState({ changed: true, newFile: true })
-		this.reader.readAsDataURL(file)
+		getOrientedImage(file, (err, canvas) => {
+			if (!err) {
+				this.setState({ changed: true, newFile: true })
+				canvas.toBlob(blob => this.reader.readAsDataURL(blob))
+			}
+		})
 	}
 
 	onFileReaderLoadImage(e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,6 +3727,22 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exif-js@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/exif-js/-/exif-js-2.3.0.tgz#9d10819bf571f873813e7640241255ab9ce1a814"
+
+exif-orientation-image@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exif-orientation-image/-/exif-orientation-image-1.0.1.tgz#c0876ffcc7dda530ab23c959762ced4cc1771fd9"
+  dependencies:
+    exif-orientation "^1.0.0"
+
+exif-orientation@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/exif-orientation/-/exif-orientation-1.0.0.tgz#9f1b76c745001539a16ccab04ed8f16e58e4e801"
+  dependencies:
+    exif-js "^2.1.1"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"


### PR DESCRIPTION
[SB-1130](https://jira.sprucelabs.ai/jira/browse/SB-1130)

@sprucelabsai/engineers

## Description 
Fix exif orientation of uploaded images.

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
Go to scratch and win skill and upload the keyboard image posted on the ticket.  Notice the orientation is correct.  (Note: the keyboard now looks upside down rather than sideways, which is correct).
