### PR TITLE
feat(SB-889): add sequelizerc to work with cli

### DIFF
--- a/packages/sprucebot-skills-kit/.sequelizerc
+++ b/packages/sprucebot-skills-kit/.sequelizerc
@@ -1,0 +1,15 @@
+var path = require('path');
+var fs = require('fs');
+var env = './.env';
+var opts = {
+	path: env
+};
+
+if (fs.existsSync(env)) require('dotenv').config(opts);
+
+module.exports = {
+  'config': path.resolve('config', 'database.js'),
+  'migrations-path': path.resolve('server', 'migrations'),
+  'seeders-path': path.resolve('server', 'seeders'),
+  'models-path': path.resolve('server', 'models')
+}

--- a/packages/sprucebot-skills-kit/config/database.js
+++ b/packages/sprucebot-skills-kit/config/database.js
@@ -1,0 +1,8 @@
+/**
+ * Used to configure the sequelize cli
+ * https://github.com/sequelize/cli
+ */
+
+module.exports = {
+	dialect: 'postgres'
+}


### PR DESCRIPTION
[SB-889](https://jira.sprucelabs.ai/jira/browse/SB-889)

@sprucelabsai/engineers

## Description 
Used in tandem with the sequelize cli to configure model, migrations, config and seeders directories.
Allows database configuration via `config/database.js`

## Type
- [x] Feature
- [ ] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
`sequelize db:create --name Test --attributes title:string`
