### PR TITLE
fix(SB-886): fix extended text box for teammate reviews

### DIFF
--- a/packages/react-sprucebot/lib/components/Input/Input.js
+++ b/packages/react-sprucebot/lib/components/Input/Input.js
@@ -90,12 +90,22 @@ var Input = function (_Component) {
 			}
 		}
 	}, {
-		key: 'componentDidMount',
-		value: function componentDidMount() {
-			if (this.props.multiline) {
+		key: 'handleMultiline',
+		value: function handleMultiline(props) {
+			if (props.multiline) {
 				this._textAreaTransition = this.input.style.transition;
 				this.sizeTextarea();
 			}
+		}
+	}, {
+		key: 'componentDidMount',
+		value: function componentDidMount() {
+			this.handleMultiline(this.props);
+		}
+	}, {
+		key: 'componentDidUpdate',
+		value: function componentDidUpdate() {
+			this.handleMultiline(this.props);
 		}
 	}, {
 		key: 'render',

--- a/packages/react-sprucebot/src/components/Input/Input.js
+++ b/packages/react-sprucebot/src/components/Input/Input.js
@@ -56,11 +56,17 @@ export default class Input extends Component {
 			}, 250)
 		}
 	}
-	componentDidMount() {
-		if (this.props.multiline) {
+	handleMultiline(props) {
+		if (props.multiline) {
 			this._textAreaTransition = this.input.style.transition
 			this.sizeTextarea()
 		}
+	}
+	componentDidMount() {
+		this.handleMultiline(this.props)
+	}
+	componentDidUpdate() {
+		this.handleMultiline(this.props)
 	}
 	render() {
 		const props = Object.assign({}, this.props)


### PR DESCRIPTION
[SB-886](https://jira.sprucelabs.ai/jira/browse/SB-886)

@sprucelabsai/engineers

## Description 
Fix extended text box for teammate reviews.
Functionality was great, but function wasn't being fired when switching from one teammate to the next.  Needed to call componentDidUpdate instead of componentDidMount.

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
1. Connect to the Sprucebot as an Owner/Teammate with Teammate Reviews active
2. Select Teammate Reviews
3. Start reviewing teammates
4. Enter a number of line breaks
5. Submit the review
6. Observe the text box is no longer extended for the next teammate
