### PR TITLE
fix(sb-792): Cors enabled images were unable to load

### DIFF
--- a/packages/react-sprucebot/lib/components/ImageCropper/ImageCropper.js
+++ b/packages/react-sprucebot/lib/components/ImageCropper/ImageCropper.js
@@ -204,7 +204,6 @@ var ImageCropper = function (_Component) {
 								_context.next = 8;
 								return new Promise(function (resolve, reject) {
 									var image = new Image();
-									image.crossOrigin = 'Anonymous';
 									image.onload = function () {
 										resolve(image);
 									};

--- a/packages/react-sprucebot/src/components/ImageCropper/ImageCropper.js
+++ b/packages/react-sprucebot/src/components/ImageCropper/ImageCropper.js
@@ -132,7 +132,6 @@ export default class ImageCropper extends Component {
 
 			const image = await new Promise((resolve, reject) => {
 				const image = new Image()
-				image.crossOrigin = 'Anonymous'
 				image.onload = () => {
 					resolve(image)
 				}


### PR DESCRIPTION
[SB-792](https://jira.sprucelabs.ai/jira/browse/SB-792)

@sprucelabsai/engineers

## Description 
Cors enabled images were not loading causing the image cropper to malfunction in ios 9 safari.

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
Run a skill that uses Image cropper like scratch and win in older ios(9) safari and upload a different image and it should work.