### PR TITLE
fix(SB-1135): prepublish command runs on every install

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "prepush": "npm run lint && npm run test",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "commit": "git-cz",
-    "prepublish": "yarn run build",
     "publish": "lerna publish"
   },
   "dependencies": {


### PR DESCRIPTION
[SB-1135](https://jira.sprucelabs.ai/jira/browse/SB-1135)

@sprucelabsai/engineers

## Description 
`yarn install` runs `prepublish` by design and isn't very intuitive. I'm removing this step since it's redundant to our travis-ci build scripts

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
`yarn install` and notice build doesn't run
