### PR TITLE
fix(SB-315): cropping stops when moved outside of iframe

### DIFF
--- a/packages/react-sprucebot/lib/components/ImageCropper/ImageCropper.js
+++ b/packages/react-sprucebot/lib/components/ImageCropper/ImageCropper.js
@@ -125,6 +125,14 @@ var ImageCropper = function (_Component) {
 	}, {
 		key: 'onCropChange',
 		value: function onCropChange(crop, pixelCrop) {
+			var maxWidth = window.innerWidth - 20;
+			var maxHeight = window.innerHeight - 20;
+			var x = window.event.x;
+			var y = window.event.y;
+
+			if (x > maxWidth || x < 20 || y < 20 || y > maxHeight) {
+				this.cropper.onDocMouseTouchEnd();
+			}
 			this.setState({ crop: crop, pixelCrop: pixelCrop, changed: true });
 		}
 	}, {

--- a/packages/react-sprucebot/src/components/ImageCropper/ImageCropper.js
+++ b/packages/react-sprucebot/src/components/ImageCropper/ImageCropper.js
@@ -71,6 +71,14 @@ export default class ImageCropper extends Component {
 	}
 
 	onCropChange(crop, pixelCrop) {
+		const maxWidth = window.innerWidth - 20
+		const maxHeight = window.innerHeight - 20
+		const x = window.event.x
+		const y = window.event.y
+
+		if (x > maxWidth || x < 20 || y < 20 || y > maxHeight) {
+			this.cropper.onDocMouseTouchEnd()
+		}
 		this.setState({ crop, pixelCrop, changed: true })
 	}
 


### PR DESCRIPTION
[SB-315](https://jira.sprucelabs.ai/jira/browse/SB-315)

@sprucelabsai/engineers

## Description 
Image cropping selection no longer continues after moving cursor outside of image area on Desktop

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
1. Navigate to Sprucebot dashboard as an Owner on Chrome
2. Select Scratch and Win skill
3. Select Settings
4. Select Crop
5. Select a corner of the crop selection and drag it outside of the image area
6. Move the cursor back into the image area
7. Observe the selection area no longer continues to follow the cursor
