### PR TITLE
chore(SB-1112): travis deploy uses build commit hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ jobs:
       git: # Allow us to checkout Branch
         depth: false
       before_script:
-        - git checkout $TRAVIS_BRANCH
+        - git checkout $TRAVIS_BRANCH # Checkout branch from detached state
+        - git reset --hard $TRAVIS_COMMIT # Make sure we are still building the commit that triggered it
         - npx set-auth-token-var-name
       deploy:
         - provider: script


### PR DESCRIPTION
[SB-1112](https://jira.sprucelabs.ai/jira/browse/SB-1112)

@sprucelabsai/engineers

## Description 
Allows us to merge PRs before other travis builds have completed

This fixes a race condition that would cause multiple dev builds to deploy the same sha

## Type
- [ ] Feature
- [ ] Bug
- [x] Tech debt

## Steps to Test or Reproduce
The first dev build queued. (This build checks out the latest dev when it clones)
The second PR was merged before the first dev build started.
The second PR is queued.
The first dev build pulls the latest dev.
The first dev build release the second PR.
The second build starts and attempts to release. :boom:
