### PR TITLE
fix(SB-594): onboarding component scrolls with the "next" cta

### DIFF
--- a/packages/react-sprucebot/lib/components/TrainingGuide/TrainingGuide.js
+++ b/packages/react-sprucebot/lib/components/TrainingGuide/TrainingGuide.js
@@ -26,6 +26,10 @@ var _BotText = require('../BotText/BotText');
 
 var _BotText2 = _interopRequireDefault(_BotText);
 
+var _index = require('../../skillskit/index');
+
+var _index2 = _interopRequireDefault(_index);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -69,7 +73,6 @@ var TrainingGuide = function (_Component) {
 			stepWidths: props.steps.map(function () {
 				return 0;
 			}),
-			scrollInterval: null,
 			transitioning: false
 		};
 		return _this;
@@ -94,31 +97,12 @@ var TrainingGuide = function (_Component) {
 
 			// Scroll to next/done buttons if the current step has changed
 			if (this.state.currentStep !== prevState.currentStep) {
-				if (this.state.scrollInterval) {
-					clearInterval(this.state.scrollInterval);
-					this.setState({ scrollInterval: false });
-				}
-
-				// wait a sec to allow css animations to finish
-				var scrollInterval = setInterval(this.scrollToGuideBottom.bind(this), 5);
-				this.setState({ scrollInterval: scrollInterval, transitioning: true });
+				this.setState({ transitioning: true });
 
 				setTimeout(function () {
-					clearInterval(_this2.state.scrollInterval);
-					_this2.setState({ scrollInterval: false, transitioning: false });
+					_index2.default.scrollTo(_reactDom2.default.findDOMNode(_this2.button).offsetTop - window.screen.height * 0.5);
+					_this2.setState({ transitioning: false });
 				}, 1500);
-			}
-		}
-	}, {
-		key: 'scrollToGuideBottom',
-		value: function scrollToGuideBottom() {
-			// where do i scroll to?
-			var node = _reactDom2.default.findDOMNode(this);
-			var bounds = node.getBoundingClientRect();
-			var bottom = window.document.body.scrollTop + bounds.y + bounds.height;
-			var windowBottom = window.document.body.scrollTop + window.innerHeight;
-			if (bottom > windowBottom) {
-				window.document.body.scrollTop = bottom - window.innerHeight + 20; // random padding for now
 			}
 		}
 	}, {
@@ -194,6 +178,9 @@ var TrainingGuide = function (_Component) {
 						{
 							alt: true,
 							busy: transitioning,
+							ref: function ref(_ref) {
+								_this3.button = _ref;
+							},
 							onClick: function onClick() {
 								if (!transitioning) _this3.next();
 							}
@@ -205,6 +192,9 @@ var TrainingGuide = function (_Component) {
 						{
 							primary: true,
 							busy: transitioning,
+							ref: function ref(_ref2) {
+								_this3.button = _ref2;
+							},
 							onClick: function onClick() {
 								if (!transitioning) onComplete();
 							}

--- a/packages/react-sprucebot/src/components/TrainingGuide/TrainingGuide.js
+++ b/packages/react-sprucebot/src/components/TrainingGuide/TrainingGuide.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
 import Button from '../Button/Button'
 import BotText from '../BotText/BotText'
+import skill from '../../skillskit/index'
 
 // what is the correct way to add functionality like this?
 function height(elm) {
@@ -48,7 +49,6 @@ export default class TrainingGuide extends Component {
 			currentStep: 0,
 			stepHeights: props.steps.map(() => 0),
 			stepWidths: props.steps.map(() => 0),
-			scrollInterval: null,
 			transitioning: false
 		}
 	}
@@ -73,30 +73,15 @@ export default class TrainingGuide extends Component {
 	componentDidUpdate(prevProps, prevState) {
 		// Scroll to next/done buttons if the current step has changed
 		if (this.state.currentStep !== prevState.currentStep) {
-			if (this.state.scrollInterval) {
-				clearInterval(this.state.scrollInterval)
-				this.setState({ scrollInterval: false })
-			}
-
-			// wait a sec to allow css animations to finish
-			const scrollInterval = setInterval(this.scrollToGuideBottom.bind(this), 5)
-			this.setState({ scrollInterval, transitioning: true })
+			this.setState({ transitioning: true })
 
 			setTimeout(() => {
-				clearInterval(this.state.scrollInterval)
-				this.setState({ scrollInterval: false, transitioning: false })
+				skill.scrollTo(
+					ReactDOM.findDOMNode(this.button).offsetTop -
+						window.screen.height * 0.5
+				)
+				this.setState({ transitioning: false })
 			}, 1500)
-		}
-	}
-
-	scrollToGuideBottom() {
-		// where do i scroll to?
-		const node = ReactDOM.findDOMNode(this)
-		const bounds = node.getBoundingClientRect()
-		const bottom = window.document.body.scrollTop + bounds.y + bounds.height
-		const windowBottom = window.document.body.scrollTop + window.innerHeight
-		if (bottom > windowBottom) {
-			window.document.body.scrollTop = bottom - window.innerHeight + 20 // random padding for now
 		}
 	}
 
@@ -149,6 +134,9 @@ export default class TrainingGuide extends Component {
 						<Button
 							alt
 							busy={transitioning}
+							ref={ref => {
+								this.button = ref
+							}}
 							onClick={() => {
 								if (!transitioning) this.next()
 							}}
@@ -161,6 +149,9 @@ export default class TrainingGuide extends Component {
 						<Button
 							primary
 							busy={transitioning}
+							ref={ref => {
+								this.button = ref
+							}}
 							onClick={() => {
 								if (!transitioning) onComplete()
 							}}


### PR DESCRIPTION
[SB-594](https://jira.sprucelabs.ai/jira/browse/SB-594)

@sprucelabsai/engineers

## Description 
onboarding component scrolls with the "next" cta
Removed extra code that wasn't working.  scrollToGuideBottom function was never working correctly due to window.document.body.scrollTop never being set.  scrollInterval wasn't affecting how the functionality so this was removed as well.

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
1. Login as an owner
2. Scroll down to Skills Marketplace and select VIP Skill
3. Enable VIP Skill
4. On the onboarding view, tap the Next CTA a couple of times without manually scrolling
5. Notice it scrolls automatically so that the Next CTA is always visible at the bottom
