### PR TITLE
feat(SB-1312): add static prop check to remove click/hover

### DIFF
--- a/packages/react-sprucebot/lib/components/Stars/Stars.js
+++ b/packages/react-sprucebot/lib/components/Stars/Stars.js
@@ -44,32 +44,38 @@ var Stars = function (_Component) {
 		value: function onClickStar(score, e) {
 			var _this2 = this;
 
-			this.setState(function (prevState) {
-				if (prevState.score !== score) {
-					if (_this2.props.onChange) {
-						_this2.props.onChange(score, e);
+			if (!this.props.static) {
+				this.setState(function (prevState) {
+					if (prevState.score !== score) {
+						if (_this2.props.onChange) {
+							_this2.props.onChange(score, e);
+						}
+						return {
+							score: score
+						};
 					}
-					return {
-						score: score
-					};
-				}
 
-				return {};
-			});
+					return {};
+				});
+			}
 		}
 	}, {
 		key: 'onMouseOverStar',
 		value: function onMouseOverStar(score, e) {
-			this.setState({
-				hover: score
-			});
+			if (!this.props.static) {
+				this.setState({
+					hover: score
+				});
+			}
 		}
 	}, {
 		key: 'onMouseLeave',
 		value: function onMouseLeave(e) {
-			this.setState({
-				hover: 0
-			});
+			if (!this.props.static) {
+				this.setState({
+					hover: 0
+				});
+			}
 		}
 	}, {
 		key: 'render',
@@ -143,5 +149,6 @@ Stars.propTypes = {
 Stars.defaultProps = {
 	max: 5,
 	score: 0,
+	static: false,
 	onChange: function onChange(score, e) {}
 };

--- a/packages/react-sprucebot/lib/components/Styleguide/Styleguide.js
+++ b/packages/react-sprucebot/lib/components/Styleguide/Styleguide.js
@@ -969,6 +969,7 @@ var Styleguide = function (_Component) {
 					_react2.default.createElement(_Stars2.default, {
 						max: 4,
 						score: 2,
+						'static': false,
 						onChange: function onChange(score, e) {
 							console.log('score:', score, 'event:', e);
 						}
@@ -976,7 +977,25 @@ var Styleguide = function (_Component) {
 					_react2.default.createElement(
 						_Pre2.default,
 						null,
-						'<Stars\n\tmax={4}\n\tscore={2}\n\tonChange={(score, e) => {\n\t\tconsole.log(\'score:\', score, \'event:\', e)\n\t}}\n/>'
+						'<Stars\n\tmax={4}\n\tscore={2}\n\tstatic={false}\n\tonChange={(score, e) => {\n\t\tconsole.log(\'score:\', score, \'event:\', e)\n\t}}\n/>'
+					),
+					_react2.default.createElement(
+						_BotText2.default,
+						null,
+						'You can also make Stars static so the rating cannot be changed!'
+					),
+					_react2.default.createElement(_Stars2.default, {
+						max: 4,
+						score: 2,
+						'static': true,
+						onChange: function onChange(score, e) {
+							console.log('score:', score, 'event:', e);
+						}
+					}),
+					_react2.default.createElement(
+						_Pre2.default,
+						null,
+						'<Stars\n\tmax={4}\n\tscore={2}\n\tstatic={true}\n\tonChange={(score, e) => {\n\t\tconsole.log(\'score:\', score, \'event:\', e)\n\t}}\n/>'
 					)
 				),
 				_react2.default.createElement(

--- a/packages/react-sprucebot/src/components/Stars/Stars.js
+++ b/packages/react-sprucebot/src/components/Stars/Stars.js
@@ -10,28 +10,34 @@ export default class Stars extends Component {
 		}
 	}
 	onClickStar(score, e) {
-		this.setState(prevState => {
-			if (prevState.score !== score) {
-				if (this.props.onChange) {
-					this.props.onChange(score, e)
+		if (!this.props.static) {
+			this.setState(prevState => {
+				if (prevState.score !== score) {
+					if (this.props.onChange) {
+						this.props.onChange(score, e)
+					}
+					return {
+						score
+					}
 				}
-				return {
-					score
-				}
-			}
 
-			return {}
-		})
+				return {}
+			})
+		}
 	}
 	onMouseOverStar(score, e) {
-		this.setState({
-			hover: score
-		})
+		if (!this.props.static) {
+			this.setState({
+				hover: score
+			})
+		}
 	}
 	onMouseLeave(e) {
-		this.setState({
-			hover: 0
-		})
+		if (!this.props.static) {
+			this.setState({
+				hover: 0
+			})
+		}
 	}
 	render() {
 		const props = Object.assign({}, this.props)
@@ -88,5 +94,6 @@ Stars.propTypes = {
 Stars.defaultProps = {
 	max: 5,
 	score: 0,
+	static: false,
 	onChange: (score, e) => {}
 }

--- a/packages/react-sprucebot/src/components/Styleguide/Styleguide.js
+++ b/packages/react-sprucebot/src/components/Styleguide/Styleguide.js
@@ -571,6 +571,7 @@ export default class Styleguide extends Component {
 					<Stars
 						max={4}
 						score={2}
+						static={false}
 						onChange={(score, e) => {
 							console.log('score:', score, 'event:', e)
 						}}
@@ -578,6 +579,26 @@ export default class Styleguide extends Component {
 					<Pre>{`<Stars
 	max={4}
 	score={2}
+	static={false}
+	onChange={(score, e) => {
+		console.log('score:', score, 'event:', e)
+	}}
+/>`}</Pre>
+					<BotText>
+						You can also make Stars static so the rating cannot be changed!
+					</BotText>
+					<Stars
+						max={4}
+						score={2}
+						static={true}
+						onChange={(score, e) => {
+							console.log('score:', score, 'event:', e)
+						}}
+					/>
+					<Pre>{`<Stars
+	max={4}
+	score={2}
+	static={true}
 	onChange={(score, e) => {
 		console.log('score:', score, 'event:', e)
 	}}


### PR DESCRIPTION
[SB-1312](https://jira.sprucelabs.ai/jira/browse/SB-1312)

@sprucelabsai/engineers

## Description 
Add static prop check to remove click/hover if dev wants stars to be static

## Type
- [x] Feature
- [ ] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
1. Add prop static={true} to a Stars component.
2. Notice onclick and hover no longer works.
