### PR TITLE
feat(SB-918): refactor dialog to use flexbox

### DIFF
--- a/packages/react-sprucebot/lib/components/Dialog/Dialog.js
+++ b/packages/react-sprucebot/lib/components/Dialog/Dialog.js
@@ -12,6 +12,14 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _styledComponents = require('styled-components');
+
+var _styledComponents2 = _interopRequireDefault(_styledComponents);
+
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
 var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
@@ -19,6 +27,10 @@ var _propTypes2 = _interopRequireDefault(_propTypes);
 var _reactDom = require('react-dom');
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
+
+var _index = require('../../skillskit/index');
+
+var _index2 = _interopRequireDefault(_index);
 
 var _reactMeasure = require('react-measure');
 
@@ -38,6 +50,40 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+var DialogUnderlay = _styledComponents2.default.div.attrs({
+	className: function className(_ref) {
+		var show = _ref.show;
+		return (0, _classnames2.default)('dialog_underlay', show ? 'on' : 'off');
+	}
+}).withConfig({
+	displayName: 'Dialog__DialogUnderlay',
+	componentId: 'q9geqg-0'
+})(['&&{position:absolute;left:0;top:0;bottom:0;right:0;z-index:1;background-color:rgba(0,0,0,0.6);display:flex;justify-content:center;align-items:flex-start;min-height:', 'px;padding:20px 0;}'], function (_ref2) {
+	var height = _ref2.height;
+	return height + 40;
+});
+
+var DialogContainer = _styledComponents2.default.div.attrs({
+	className: function className(_ref3) {
+		var show = _ref3.show,
+		    _className = _ref3.className;
+		return (0, _classnames2.default)('dialog', _className, show ? 'on' : 'off');
+	}
+}).withConfig({
+	displayName: 'Dialog__DialogContainer',
+	componentId: 'q9geqg-1'
+})(['&&{position:relative;transition:opacity 1s ease-in-out;opacity:', ';background-color:#fff;border-radius:4px;z-index:2;padding:20px;margin:0 auto;width:90%;max-width:500px;}'], function (_ref4) {
+	var opacity = _ref4.opacity;
+	return opacity || 0;
+});
+var DialogCloseButton = (0, _styledComponents2.default)(_Button2.default).attrs({
+	className: 'btn__close_dialog',
+	remove: true
+}).withConfig({
+	displayName: 'Dialog__DialogCloseButton',
+	componentId: 'q9geqg-2'
+})(['display:block;position:absolute;top:15px;right:20px;']);
+
 var Dialog = function (_Component) {
 	_inherits(Dialog, _Component);
 
@@ -46,98 +92,38 @@ var Dialog = function (_Component) {
 
 		var _this = _possibleConstructorReturn(this, (Dialog.__proto__ || Object.getPrototypeOf(Dialog)).call(this, props));
 
-		_this.showing = false;
-		_this.wrapper = false;
 		_this.state = {
-			top: -1,
-			left: -1,
 			width: -1,
-			height: 500,
-			opacity: 0
-
-			// for resize callbacks
-		};_this.position = _this.position.bind(_this);
+			height: 500
+		};
 		return _this;
 	}
 
 	_createClass(Dialog, [{
-		key: 'componentDidUpdate',
-		value: function componentDidUpdate(prevProps, prevState) {
-			if (!this.showing && this.props.show) {
-				this.position();
+		key: 'componentWillReceiveProps',
+		value: function componentWillReceiveProps(nextProps) {
+			var _this2 = this;
+
+			if (this.props.show !== nextProps.show) {
+				setTimeout(function () {
+					return _this2.setState({ opacity: nextProps.show ? 1 : 0 });
+				}, 100);
+
+				// Port of SB-661 for all dialogs
+				// if (nextProps.show) {
+				// 	requestAnimationFrame(() => {
+				// 		skill.scrollTo(ReactDOM.findDOMNode(this.underlay).offsetTop)
+				// 	})
+				// }
 			}
-			this.showing = this.props.show;
-		}
-	}, {
-		key: 'position',
-		value: function position() {
-			if (!this.wrapper) return;
-			// don't resize if we are not showing
-			var positionedParent = void 0;
-			var node = this.wrapper.parentNode;
-
-			while (node && node !== document.body) {
-				var pos = window.getComputedStyle(node).getPropertyValue('position').toLowerCase();
-
-				if (pos === 'relative' || pos === 'absolute') {
-					positionedParent = node;
-					node = null;
-				} else {
-					node = node.parentNode;
-				}
-			}
-
-			var screenWidth = void 0,
-			    scrollTop = document.body.scrollTop;
-
-			var w = window,
-			    d = document,
-			    e = d.documentElement,
-			    g = d.getElementsByTagName('body')[0],
-			    screenHeight = w.innerHeight || e.clientHeight || g.clientHeight;
-
-			if (!positionedParent) {
-				screenWidth = w.innerWidth || e.clientWidth || g.clientWidth;
-			} else {
-				screenWidth = positionedParent.offsetWidth;
-				scrollTop = document.body.scrollTop - positionedParent.offsetTop;
-			}
-
-			// center horizontally
-			var width = this.state.width > 0 ? this.state.width : Math.min(500, screenWidth * 0.9);
-			var left = (screenWidth - width) / 2;
-			var top = this.state.height >= screenHeight - 20 ? 20 : scrollTop + (screenHeight - this.state.height) / 2;
-
-			this.setState({ left: left, top: top });
 		}
 	}, {
 		key: 'setSize',
-		value: function setSize(_ref) {
-			var _this2 = this;
-
-			var width = _ref.width,
-			    height = _ref.height;
+		value: function setSize(_ref5) {
+			var width = _ref5.width,
+			    height = _ref5.height;
 
 			this.setState({ width: width, height: height });
-
-			// give dialog time to position itself before being shown
-			if (this.state.opacity === 0) {
-				this.position();
-				setTimeout(function () {
-					return _this2.setState({ opacity: 1 });
-				}, 0);
-			}
-		}
-	}, {
-		key: 'componentDidMount',
-		value: function componentDidMount() {
-			window.addEventListener('resize', this.position);
-			this.position();
-		}
-	}, {
-		key: 'componentWillUnmount',
-		value: function componentWillUnmount() {
-			window.removeEventListener('resize', this.position);
 		}
 	}, {
 		key: 'render',
@@ -153,9 +139,8 @@ var Dialog = function (_Component) {
 			    props = _objectWithoutProperties(_props, ['tag', 'children', 'className', 'show', 'onTapClose']);
 
 			var _state = this.state,
-			    top = _state.top,
-			    left = _state.left,
-			    opacity = _state.opacity;
+			    opacity = _state.opacity,
+			    height = _state.height;
 
 			var Tag = tag;
 
@@ -164,13 +149,14 @@ var Dialog = function (_Component) {
 			}
 
 			return _react2.default.createElement(
-				'div',
+				DialogUnderlay,
 				{
-					ref: function ref(node) {
-						_this3.wrapper = node;
-					}
+					ref: function ref(_ref7) {
+						return _this3.underlay = _ref7;
+					},
+					show: show,
+					height: height
 				},
-				_react2.default.createElement('div', { className: 'dialog_underlay ' + (show ? 'on' : 'off') }),
 				_react2.default.createElement(
 					_reactMeasure2.default,
 					{
@@ -182,20 +168,17 @@ var Dialog = function (_Component) {
 							});
 						}
 					},
-					function (_ref2) {
-						var measureRef = _ref2.measureRef;
+					function (_ref6) {
+						var measureRef = _ref6.measureRef;
 						return _react2.default.createElement(
-							Tag,
+							DialogContainer,
 							_extends({
-								style: { top: top, left: left, opacity: opacity },
-								ref: measureRef,
-								className: 'dialog ' + (className || '') + ' ' + (show ? 'on' : 'off')
+								innerRef: measureRef,
+								className: className,
+								show: show,
+								opacity: opacity
 							}, props),
-							onTapClose && _react2.default.createElement(_Button2.default, {
-								className: 'btn__close_dialog',
-								remove: true,
-								onClick: onTapClose
-							}),
+							onTapClose && _react2.default.createElement(DialogCloseButton, { onClick: onTapClose }),
 							children
 						);
 					}

--- a/packages/react-sprucebot/lib/skillskit/index.js
+++ b/packages/react-sprucebot/lib/skillskit/index.js
@@ -29,8 +29,8 @@ exports.default = {
 			return bottom;
 		}
 
-		Array.from(window.document.querySelectorAll('.container, .dialog')).forEach(function (container) {
-			var bottom = getBottom(container) + 20;
+		Array.from(window.document.querySelectorAll('.container, .dialog_underlay')).forEach(function (container) {
+			var bottom = getBottom(container);
 			if (bottom > height) {
 				height = bottom;
 			}

--- a/packages/react-sprucebot/src/components/Dialog/Dialog.js
+++ b/packages/react-sprucebot/src/components/Dialog/Dialog.js
@@ -1,98 +1,84 @@
 import React, { Component } from 'react'
+import styled from 'styled-components'
+import classnames from 'classnames'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
+import skill from '../../skillskit/index'
 import Measure from 'react-measure'
 import Button from '../Button/Button'
+
+const DialogUnderlay = styled.div.attrs({
+	className: ({ show }) => classnames('dialog_underlay', show ? 'on' : 'off')
+})`
+	&& {
+		position: absolute;
+		left: 0;
+		top: 0;
+		bottom: 0;
+		right: 0;
+		z-index: 1;
+		background-color: rgba(0, 0, 0, 0.6);
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+		min-height: ${({ height }) => height + 40}px;
+		padding: 20px 0;
+	}
+`
+
+const DialogContainer = styled.div.attrs({
+	className: ({ show, className }) =>
+		classnames('dialog', className, show ? 'on' : 'off')
+})`
+	&& {
+		position: relative;
+		transition: opacity 1s ease-in-out;
+		opacity: ${({ opacity }) => opacity || 0};
+		background-color: #fff;
+		border-radius: 4px;
+		z-index: 2;
+		padding: 20px;
+		margin: 0 auto;
+		width: 90%;
+		max-width: 500px;
+	}
+`
+const DialogCloseButton = styled(Button).attrs({
+	className: 'btn__close_dialog',
+	remove: true
+})`
+	display: block;
+	position: absolute;
+	top: 15px;
+	right: 20px;
+`
 
 export default class Dialog extends Component {
 	constructor(props) {
 		super(props)
-		this.showing = false
-		this.wrapper = false
 		this.state = {
-			top: -1,
-			left: -1,
 			width: -1,
-			height: 500,
-			opacity: 0
+			height: 500
 		}
-
-		// for resize callbacks
-		this.position = this.position.bind(this)
 	}
-	componentDidUpdate(prevProps, prevState) {
-		if (!this.showing && this.props.show) {
-			this.position()
+	componentWillReceiveProps(nextProps) {
+		if (this.props.show !== nextProps.show) {
+			setTimeout(() => this.setState({ opacity: nextProps.show ? 1 : 0 }), 100)
+
+			// Port of SB-661 for all dialogs
+			// if (nextProps.show) {
+			// 	requestAnimationFrame(() => {
+			// 		skill.scrollTo(ReactDOM.findDOMNode(this.underlay).offsetTop)
+			// 	})
+			// }
 		}
-		this.showing = this.props.show
-	}
-	position() {
-		if (!this.wrapper) return
-		// don't resize if we are not showing
-		let positionedParent
-		let node = this.wrapper.parentNode
-
-		while (node && node !== document.body) {
-			const pos = window
-				.getComputedStyle(node)
-				.getPropertyValue('position')
-				.toLowerCase()
-
-			if (pos === 'relative' || pos === 'absolute') {
-				positionedParent = node
-				node = null
-			} else {
-				node = node.parentNode
-			}
-		}
-
-		let screenWidth,
-			scrollTop = document.body.scrollTop
-
-		const w = window,
-			d = document,
-			e = d.documentElement,
-			g = d.getElementsByTagName('body')[0],
-			screenHeight = w.innerHeight || e.clientHeight || g.clientHeight
-
-		if (!positionedParent) {
-			screenWidth = w.innerWidth || e.clientWidth || g.clientWidth
-		} else {
-			screenWidth = positionedParent.offsetWidth
-			scrollTop = document.body.scrollTop - positionedParent.offsetTop
-		}
-
-		// center horizontally
-		const width =
-			this.state.width > 0 ? this.state.width : Math.min(500, screenWidth * 0.9)
-		const left = (screenWidth - width) / 2
-		const top =
-			this.state.height >= screenHeight - 20
-				? 20
-				: scrollTop + (screenHeight - this.state.height) / 2
-
-		this.setState({ left, top })
 	}
 	setSize({ width, height }) {
 		this.setState({ width, height })
-
-		// give dialog time to position itself before being shown
-		if (this.state.opacity === 0) {
-			this.position()
-			setTimeout(() => this.setState({ opacity: 1 }), 0)
-		}
-	}
-	componentDidMount() {
-		window.addEventListener('resize', this.position)
-		this.position()
-	}
-
-	componentWillUnmount() {
-		window.removeEventListener('resize', this.position)
 	}
 	render() {
 		const { tag, children, className, show, onTapClose, ...props } = this.props
-		const { top, left, opacity } = this.state
+		const { opacity, height } = this.state
 		const Tag = tag
 
 		if (!show) {
@@ -100,12 +86,11 @@ export default class Dialog extends Component {
 		}
 
 		return (
-			<div
-				ref={node => {
-					this.wrapper = node
-				}}
+			<DialogUnderlay
+				ref={ref => (this.underlay = ref)}
+				show={show}
+				height={height}
 			>
-				<div className={`dialog_underlay ${show ? 'on' : 'off'}`} />
 				<Measure
 					bounds
 					onResize={contentRect => {
@@ -116,24 +101,19 @@ export default class Dialog extends Component {
 					}}
 				>
 					{({ measureRef }) => (
-						<Tag
-							style={{ top, left, opacity }}
-							ref={measureRef}
-							className={`dialog ${className || ''} ${show ? 'on' : 'off'}`}
+						<DialogContainer
+							innerRef={measureRef}
+							className={className}
+							show={show}
+							opacity={opacity}
 							{...props}
 						>
-							{onTapClose && (
-								<Button
-									className="btn__close_dialog"
-									remove
-									onClick={onTapClose}
-								/>
-							)}
+							{onTapClose && <DialogCloseButton onClick={onTapClose} />}
 							{children}
-						</Tag>
+						</DialogContainer>
 					)}
 				</Measure>
-			</div>
+			</DialogUnderlay>
 		)
 	}
 }

--- a/packages/react-sprucebot/src/skillskit/index.js
+++ b/packages/react-sprucebot/src/skillskit/index.js
@@ -24,14 +24,14 @@ export default {
 			return bottom
 		}
 
-		Array.from(window.document.querySelectorAll('.container, .dialog')).forEach(
-			container => {
-				let bottom = getBottom(container) + 20
-				if (bottom > height) {
-					height = bottom
-				}
+		Array.from(
+			window.document.querySelectorAll('.container, .dialog_underlay')
+		).forEach(container => {
+			let bottom = getBottom(container)
+			if (bottom > height) {
+				height = bottom
 			}
-		)
+		})
 
 		if (height != this.height) {
 			this.height = height


### PR DESCRIPTION
[SB-918](https://jira.sprucelabs.ai/jira/browse/SB-918)

@sprucelabsai/engineers

## Description 
Uses flexbox in place of the if the styles from skill.css.

Basically re-implements https://github.com/sprucelabsai/react-sprucebot/pull/34 which got reverted

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
Render the styleguide and find the `Callout` or `Error` sections
Click the `show alert` or `show error message` buttons
Scroll to the top of the page to see the dialogs render

