### PR TITLE
[SB-1323] force skills dev to implement will-send-training event.

### DIFF
--- a/packages/sprucebot-skills-kit/README.md
+++ b/packages/sprucebot-skills-kit/README.md
@@ -47,6 +47,18 @@ Just before a vip alert is triggered when a `guest` or `teammate` arrives. Honor
 ]
 ```
 
+#### `will-send-training`
+This event can be configured to remind teammates to do something, or if none of the settings are set yet, remind the owner to either finish their settings or turn off the skill. 
+
+**Payload**
+
+```js
+{
+    teammate: ctx.event, // teammate receiving the alert
+    body: String // the message
+}
+```
+
 #### `my-slug:custom-event`
 This is just a placeholder for now, put in yours! Honors `preventDefault`.
 

--- a/packages/sprucebot-skills-kit/server/events/will-send-training.js
+++ b/packages/sprucebot-skills-kit/server/events/will-send-training.js
@@ -1,0 +1,22 @@
+module.exports = async (ctx, next) => {
+	throw new Error('Please implement a will-send-training event on your skill!')
+
+	// const payload = {
+	// 	...ctx.event.payload
+	// }
+
+	// if (ctx.event.role === 'teammate') {
+	// 	payload.message = ctx.utilities.lang.getText('teammateTrainingMessage', {
+	// 		teammate: ctx.event,
+	// 		body: String
+	// 	})
+	// } else if (ctx.event.role === 'owner') {
+	// 	payload.message = ctx.utilities.lang.getText('ownerTrainingMessage', {
+	// 		owner: ctx.event,
+	// 		body: String
+	// 	})
+	// }
+	// ctx.body = payload
+
+	await next()
+}


### PR DESCRIPTION
[SB-1323](https://jira.sprucelabs.ai/jira/browse/SB-1323)

@sprucelabsai/engineers

## Description 
force skills dev to implement will-send-training event.

## Type
- [x] Feature
- [ ] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
When you create a new skill or update an existing skill, this file will be added.
When the skill dev runs the skill, the error will be thrown to remind them to implement the event.
