### PR TITLE
chore(SB-1254): bump nextjs to resolve ie11 issues

### DIFF
--- a/packages/react-sprucebot/package.json
+++ b/packages/react-sprucebot/package.json
@@ -66,7 +66,7 @@
         "imagesloaded": "^4.1.4",
         "js-cookies": "^1.0.4",
         "moment": "^2.19.3",
-        "next": "^5.0.0",
+        "next": "^5.1.0",
         "next-redux-wrapper": "^1.3.5",
         "prop-types": "^15.6.0",
         "qs": "^6.5.1",

--- a/packages/sprucebot-skills-kit-server/package.json
+++ b/packages/sprucebot-skills-kit-server/package.json
@@ -28,7 +28,7 @@
         "koa-bodyparser": "^4.2.0",
         "koa-router": "^7.2.1",
         "koa-static": "^4.0.1",
-        "next": "^5.0.0",
+        "next": "^5.1.0",
         "node-cron": "^1.2.1",
         "pg": "^7.4.1",
         "react": "^16.2.0",

--- a/packages/sprucebot-skills-kit/package.json
+++ b/packages/sprucebot-skills-kit/package.json
@@ -38,7 +38,7 @@
     "jsonwebtoken": "^8.1.0",
     "lodash": "^4.17.4",
     "moment-timezone": "^0.5.14",
-    "next": "^5.0.0",
+    "next": "^5.1.0",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6473,7 +6473,7 @@ next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
-next@^5.0.0:
+next@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/next/-/next-5.1.0.tgz#9f79f095b28e1be568ba6fc61ec807409ec77e0a"
   dependencies:


### PR DESCRIPTION
[SB-1254](https://jira.sprucelabs.ai/jira/browse/SB-1254)

@sprucelabsai/engineers

## Description 
bump nextjs to resolve ie11 issues
Once this is merged, I will update vip and awards.

## Type
- [ ] Feature
- [ ] Bug
- [x] Tech debt

## Steps to Test or Reproduce
Test to make sure skills will run on ie11.
