### PR TITLE
feat(SB-1333): onboarding completion is checked server-side

### DIFF
--- a/packages/react-sprucebot/lib/components/Onboarding/Onboarding.js
+++ b/packages/react-sprucebot/lib/components/Onboarding/Onboarding.js
@@ -44,7 +44,8 @@ var Onboarding = function (_Component) {
 			    heading = _props.heading,
 			    steps = _props.steps,
 			    onComplete = _props.onComplete,
-			    doneButtonLabel = _props.doneButtonLabel;
+			    doneButtonLabel = _props.doneButtonLabel,
+			    onboardingComplete = _props.onboardingComplete;
 
 			return _react2.default.createElement(
 				'div',
@@ -57,7 +58,8 @@ var Onboarding = function (_Component) {
 				_react2.default.createElement(_TrainingGuide2.default, {
 					steps: steps,
 					onComplete: onComplete,
-					doneButtonLabel: doneButtonLabel
+					doneButtonLabel: doneButtonLabel,
+					onboardingComplete: onboardingComplete
 				})
 			);
 		}

--- a/packages/react-sprucebot/lib/components/Styleguide/Styleguide.js
+++ b/packages/react-sprucebot/lib/components/Styleguide/Styleguide.js
@@ -118,9 +118,23 @@ var _index = require('../../skillskit/index');
 
 var _index2 = _interopRequireDefault(_index);
 
+var _actions = require('../../skillskit/store/actions');
+
+var actions = _interopRequireWildcard(_actions);
+
+var _reducers = require('../../skillskit/store/reducers');
+
+var _reducers2 = _interopRequireDefault(_reducers);
+
+var _withStore = require('../../skillskit/store/withStore');
+
+var _withStore2 = _interopRequireDefault(_withStore);
+
 var _FormExample = require('./FormExample');
 
 var _FormExample2 = _interopRequireDefault(_FormExample);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -195,10 +209,23 @@ var Styleguide = function (_Component) {
 			calloutOn: false,
 			errorMessage: ''
 		};
+		_this.didCompleteOnboarding = _this.didCompleteOnboarding.bind(_this);
 		return _this;
 	}
 
 	_createClass(Styleguide, [{
+		key: 'didCompleteOnboarding',
+		value: function didCompleteOnboarding() {
+			var onboardingComplete = this.props.onboarding.onboardingComplete;
+
+			if (!onboardingComplete) {
+				this.props.actions.onboarding.finishOnboarding();
+				console.log('Posting to your database that you completed onboarding.  Check your Skill Data now!');
+			} else {
+				console.log("You've already completed the onboarding.  Check your Skill Data now!");
+			}
+		}
+	}, {
 		key: 'render',
 		value: function render() {
 			var _this2 = this;
@@ -1179,16 +1206,15 @@ var Styleguide = function (_Component) {
 					null,
 					_react2.default.createElement(_Onboarding2.default, {
 						heading: 'Onboarding',
-						steps: ['This is an onboarding component.', 'It has a heading', 'And "guides" you through the steps like the TrainingGuide', 'You can also change the label of the done button.'],
-						onComplete: function onComplete() {
-							return alert('Done!');
-						},
-						doneButtonLabel: 'Finish'
+						steps: ['This is an onboarding component.', 'It has a heading.', 'And "guides" you through the steps like the TrainingGuide.', 'You can also change the label of the done button.', 'Additionally, you can pass a boolean prop to say if onboarding has been completed.', 'If the owner/teammate has done onboarding already, all of the messages will be displayed.'],
+						onComplete: this.didCompleteOnboarding,
+						doneButtonLabel: 'Finish',
+						onboardingComplete: this.props.onboarding.onboardingComplete
 					}),
 					_react2.default.createElement(
 						_Pre2.default,
 						null,
-						'<Onboarding\n\theading={\'Onboarding\'}\n\tsteps={[\n\t\t\'This is an onboarding component.\',\n\t\t\'It has a heading\',\n\t\t\'And "guides" you through the steps like the TrainingGuide\',\n\t\t\'You can also change the label of the done button.\'\n\t]}\n\tonComplete={() => alert(\'Done!\')}\n\tdoneButtonLabel={\'Finish\'}\n/>'
+						'<Onboarding\n\theading={\'Onboarding\'}\n\tsteps={[\n\t\t\'This is an onboarding component.\',\n\t\t\'It has a heading\',\n\t\t\'And "guides" you through the steps like the TrainingGuide\',\n\t\t\'You can also change the label of the done button.\',\n\t\t\'Additionally, you can pass a boolean prop to say if onboarding has been completed.\',\n\t\t\'If the owner/teammate has done onboarding already, all of the messages will be displayed.\'\n\t]}\n\tonComplete={this.didCompleteOnboarding}\n\tdoneButtonLabel={\'Finish\'}\n\tonboardingComplete={this.props.onboarding.onboardingComplete}\t\n/>'
 					)
 				),
 				_react2.default.createElement(
@@ -1343,4 +1369,8 @@ var Styleguide = function (_Component) {
 	return Styleguide;
 }(_react.Component);
 
-exports.default = Styleguide;
+exports.default = (0, _withStore2.default)(Styleguide, {
+	actions: actions,
+	reducers: _reducers2.default,
+	config: { SERVER_HOST: 'https://example.com' }
+});

--- a/packages/react-sprucebot/lib/components/TrainingGuide/TrainingGuide.js
+++ b/packages/react-sprucebot/lib/components/TrainingGuide/TrainingGuide.js
@@ -108,7 +108,12 @@ var TrainingGuide = function (_Component) {
 	}, {
 		key: 'componentDidMount',
 		value: function componentDidMount() {
+			var _props = this.props,
+			    steps = _props.steps,
+			    onboardingComplete = _props.onboardingComplete;
+			var currentStep = this.state.currentStep;
 			// calculate height of first element in each step
+
 			var stepHeights = this.stepDomNodes.map(function (node) {
 				var first = node.children[0];
 				return height(first);
@@ -120,8 +125,10 @@ var TrainingGuide = function (_Component) {
 				return span.offsetWidth;
 			});
 
-			this.setState(function () {
-				return { stepHeights: stepHeights, stepWidths: stepWidths };
+			this.setState({
+				stepHeights: stepHeights,
+				stepWidths: stepWidths,
+				currentStep: onboardingComplete ? steps.length - 1 : currentStep
 			});
 		}
 	}, {
@@ -129,11 +136,12 @@ var TrainingGuide = function (_Component) {
 		value: function render() {
 			var _this3 = this;
 
-			var _props = this.props,
-			    steps = _props.steps,
-			    nextButtonLabel = _props.nextButtonLabel,
-			    doneButtonLabel = _props.doneButtonLabel,
-			    onComplete = _props.onComplete;
+			var _props2 = this.props,
+			    steps = _props2.steps,
+			    nextButtonLabel = _props2.nextButtonLabel,
+			    doneButtonLabel = _props2.doneButtonLabel,
+			    onComplete = _props2.onComplete,
+			    onboardingComplete = _props2.onboardingComplete;
 			var _state = this.state,
 			    currentStep = _state.currentStep,
 			    stepHeights = _state.stepHeights,
@@ -204,13 +212,6 @@ var TrainingGuide = function (_Component) {
 				)
 			);
 		}
-	}], [{
-		key: 'importSteps',
-		value: function importSteps(steps) {
-			return steps.map(function (step, idx) {
-				return { key: 'step-' + idx, value: step };
-			});
-		}
 	}]);
 
 	return TrainingGuide;
@@ -223,10 +224,12 @@ TrainingGuide.propTypes = {
 	steps: _propTypes2.default.array.isRequired,
 	nextButtonLabel: _propTypes2.default.string.isRequired,
 	doneButtonLabel: _propTypes2.default.string.isRequired,
-	onComplete: _propTypes2.default.func.isRequired
+	onComplete: _propTypes2.default.func.isRequired,
+	onboardingComplete: _propTypes2.default.bool.isRequired
 };
 
 TrainingGuide.defaultProps = {
 	nextButtonLabel: 'Next',
-	doneButtonLabel: 'Done'
+	doneButtonLabel: 'Done',
+	onboardingComplete: false
 };

--- a/packages/react-sprucebot/lib/skillskit/next/Page.js
+++ b/packages/react-sprucebot/lib/skillskit/next/Page.js
@@ -196,7 +196,7 @@ var Page = function Page(Wrapped) {
 									jwt = query.jwt || getCookie('jwt', req, res);
 
 									if (!jwt) {
-										_context2.next = 15;
+										_context2.next = 17;
 										break;
 									}
 
@@ -205,29 +205,33 @@ var Page = function Page(Wrapped) {
 									return store.dispatch(actions.auth.go(jwt));
 
 								case 6:
+									_context2.next = 8;
+									return store.dispatch(actions.onboarding.didOnboarding());
+
+								case 8:
 
 									// only save cookie if a new one has been passed
 									if (query.jwt) {
 										setCookie('jwt', query.jwt, req, res);
 									}
-									_context2.next = 13;
+									_context2.next = 15;
 									break;
 
-								case 9:
-									_context2.prev = 9;
+								case 11:
+									_context2.prev = 11;
 									_context2.t0 = _context2['catch'](3);
 
 									debug(_context2.t0);
 									debug('Error fetching user from jwt');
 
-								case 13:
-									_context2.next = 16;
+								case 15:
+									_context2.next = 18;
 									break;
 
-								case 15:
+								case 17:
 									debug('This looks pretty bad. You are missing a jwt and will probably be unauthorized');
 
-								case 16:
+								case 18:
 									state = store.getState();
 
 
@@ -236,7 +240,7 @@ var Page = function Page(Wrapped) {
 									}
 
 									if (!ConnectedWrapped.getInitialProps) {
-										_context2.next = 28;
+										_context2.next = 30;
 										break;
 									}
 
@@ -246,14 +250,14 @@ var Page = function Page(Wrapped) {
 									_context2.t1 = _extends;
 									_context2.t2 = {};
 									_context2.t3 = props;
-									_context2.next = 26;
+									_context2.next = 28;
 									return ConnectedWrapped.getInitialProps.apply(this, args);
 
-								case 26:
+								case 28:
 									_context2.t4 = _context2.sent;
 									props = (0, _context2.t1)(_context2.t2, _context2.t3, _context2.t4);
 
-								case 28:
+								case 30:
 									redirect = props.redirect || false;
 
 
@@ -280,7 +284,7 @@ var Page = function Page(Wrapped) {
 									}
 
 									if (!(redirect && res)) {
-										_context2.next = 37;
+										_context2.next = 39;
 										break;
 									}
 
@@ -291,12 +295,12 @@ var Page = function Page(Wrapped) {
 									res.finished = true;
 									return _context2.abrupt('return');
 
-								case 37:
+								case 39:
 									if (redirect) {
 										window.location.href = redirect;
 									}
 
-								case 38:
+								case 40:
 									// if we are /unauthorized, don't have a cookie, but have NOT done cookie check
 									if (props.pathname === '/unauthorized' && (!state.auth || !state.auth.role)) {
 										props.attemptingReAuth = true;
@@ -306,12 +310,12 @@ var Page = function Page(Wrapped) {
 									// No circular dependencies
 									return _context2.abrupt('return', props);
 
-								case 40:
+								case 42:
 								case 'end':
 									return _context2.stop();
 							}
 						}
-					}, _callee2, this, [[3, 9]]);
+					}, _callee2, this, [[3, 11]]);
 				}));
 
 				function getInitialProps(_x) {

--- a/packages/react-sprucebot/lib/skillskit/store/actions/index.js
+++ b/packages/react-sprucebot/lib/skillskit/store/actions/index.js
@@ -4,8 +4,13 @@ var _auth = require('./auth');
 
 var auth = _interopRequireWildcard(_auth);
 
+var _onboarding = require('./onboarding');
+
+var onboarding = _interopRequireWildcard(_onboarding);
+
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
 module.exports = {
-	auth: auth
+	auth: auth,
+	onboarding: onboarding
 };

--- a/packages/react-sprucebot/lib/skillskit/store/actions/onboarding.js
+++ b/packages/react-sprucebot/lib/skillskit/store/actions/onboarding.js
@@ -1,0 +1,32 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});
+exports.didOnboarding = didOnboarding;
+exports.finishOnboarding = finishOnboarding;
+var DID_ONBOARDING_REQUEST = exports.DID_ONBOARDING_REQUEST = 'onboarding/DID_ONBOARDING_REQUEST';
+var DID_ONBOARDING_SUCCESS = exports.DID_ONBOARDING_SUCCESS = 'onboarding/DID_ONBOARDING_SUCCESS';
+var DID_ONBOARDING_ERROR = exports.DID_ONBOARDING_ERROR = 'onboarding/DID_ONBOARDING_ERROR';
+
+var FINISH_ONBOARDING_REQUEST = exports.FINISH_ONBOARDING_REQUEST = 'onboarding/FINISH_ONBOARDING_REQUEST';
+var FINISH_ONBOARDING_SUCCESS = exports.FINISH_ONBOARDING_SUCCESS = 'onboarding/FINISH_ONBOARDING_SUCCESS';
+var FINISH_ONBOARDING_ERROR = exports.FINISH_ONBOARDING_ERROR = 'onboarding/FINISH_ONBOARDING_ERROR';
+
+function didOnboarding() {
+	return {
+		types: [DID_ONBOARDING_REQUEST, DID_ONBOARDING_SUCCESS, DID_ONBOARDING_ERROR],
+		promise: function promise(client, auth) {
+			return client.get('/api/1.0/guest/onboarding.json');
+		}
+	};
+}
+
+function finishOnboarding() {
+	return {
+		types: [FINISH_ONBOARDING_REQUEST, FINISH_ONBOARDING_SUCCESS, FINISH_ONBOARDING_ERROR],
+		promise: function promise(client, auth) {
+			return client.post('/api/1.0/guest/onboarding.json');
+		}
+	};
+}

--- a/packages/react-sprucebot/lib/skillskit/store/reducers/index.js
+++ b/packages/react-sprucebot/lib/skillskit/store/reducers/index.js
@@ -12,8 +12,12 @@ var _config = require('./config');
 
 var _config2 = _interopRequireDefault(_config);
 
+var _onboarding = require('./onboarding');
+
+var _onboarding2 = _interopRequireDefault(_onboarding);
+
 var _reduxForm = require('redux-form');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-exports.default = { auth: _auth2.default, config: _config2.default, form: _reduxForm.reducer };
+exports.default = { auth: _auth2.default, config: _config2.default, onboarding: _onboarding2.default, form: _reduxForm.reducer };

--- a/packages/react-sprucebot/lib/skillskit/store/reducers/onboarding.js
+++ b/packages/react-sprucebot/lib/skillskit/store/reducers/onboarding.js
@@ -1,0 +1,59 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+exports.default = reducer;
+
+var _onboarding = require('../actions/onboarding');
+
+function reducer() {
+	var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
+	var action = arguments[1];
+
+	switch (action.type) {
+		case _onboarding.DID_ONBOARDING_REQUEST:
+			return _extends({}, state, {
+				onboardingError: undefined,
+				onboardingLoading: true,
+				onboardingLoaded: false
+			});
+		case _onboarding.DID_ONBOARDING_SUCCESS:
+			return _extends({}, state, {
+				onboardingComplete: action.result.finishedOnboarding,
+				onboardingError: undefined,
+				onboardingLoading: false,
+				onboardingLoaded: true
+			});
+		case _onboarding.DID_ONBOARDING_ERROR:
+			return _extends({}, state, {
+				onboardingError: action.error,
+				onboardingLoading: false,
+				onboardingLoaded: false
+			});
+		case _onboarding.FINISH_ONBOARDING_REQUEST:
+			return _extends({}, state, {
+				onboardingError: undefined,
+				onboardingSaving: true,
+				onboardingSaved: false
+			});
+		case _onboarding.FINISH_ONBOARDING_SUCCESS:
+			return _extends({}, state, {
+				onboardingComplete: action.result.finishedOnboarding,
+				onboardingError: undefined,
+				onboardingSaving: false,
+				onboardingSaved: true
+			});
+		case _onboarding.FINISH_ONBOARDING_ERROR:
+			return _extends({}, state, {
+				onboardingError: action.error,
+				onboardingSaving: false,
+				onboardingSaved: false
+			});
+		default:
+			return state;
+	}
+}

--- a/packages/react-sprucebot/src/components/Onboarding/Onboarding.js
+++ b/packages/react-sprucebot/src/components/Onboarding/Onboarding.js
@@ -5,7 +5,13 @@ import TrainingGuide from '../TrainingGuide/TrainingGuide'
 
 export default class Onboarding extends Component {
 	render() {
-		const { heading, steps, onComplete, doneButtonLabel } = this.props
+		const {
+			heading,
+			steps,
+			onComplete,
+			doneButtonLabel,
+			onboardingComplete
+		} = this.props
 		return (
 			<div>
 				<H1>{heading}</H1>
@@ -13,6 +19,7 @@ export default class Onboarding extends Component {
 					steps={steps}
 					onComplete={onComplete}
 					doneButtonLabel={doneButtonLabel}
+					onboardingComplete={onboardingComplete}
 				/>
 			</div>
 		)

--- a/packages/react-sprucebot/src/components/Styleguide/Styleguide.js
+++ b/packages/react-sprucebot/src/components/Styleguide/Styleguide.js
@@ -38,6 +38,9 @@ import Dialog from '../Dialog/Dialog'
 import Pre from '../Pre/Pre'
 import Error from '../Error/Error'
 import skill from '../../skillskit/index'
+import * as actions from '../../skillskit/store/actions'
+import reducers from '../../skillskit/store/reducers'
+import withStore from '../../skillskit/store/withStore'
 
 import FormExample from './FormExample'
 
@@ -98,12 +101,26 @@ if (process.env.NODE_ENV === 'test') {
 	NOW = new Date()
 }
 
-export default class Styleguide extends Component {
+class Styleguide extends Component {
 	constructor(props) {
 		super(props)
 		this.state = {
 			calloutOn: false,
 			errorMessage: ''
+		}
+		this.didCompleteOnboarding = this.didCompleteOnboarding.bind(this)
+	}
+	didCompleteOnboarding() {
+		const { onboardingComplete } = this.props.onboarding
+		if (!onboardingComplete) {
+			this.props.actions.onboarding.finishOnboarding()
+			console.log(
+				'Posting to your database that you completed onboarding.  Check your Skill Data now!'
+			)
+		} else {
+			console.log(
+				"You've already completed the onboarding.  Check your Skill Data now!"
+			)
 		}
 	}
 	render() {
@@ -841,12 +858,15 @@ export default class Styleguide extends Component {
 						heading={'Onboarding'}
 						steps={[
 							'This is an onboarding component.',
-							'It has a heading',
-							'And "guides" you through the steps like the TrainingGuide',
-							'You can also change the label of the done button.'
+							'It has a heading.',
+							'And "guides" you through the steps like the TrainingGuide.',
+							'You can also change the label of the done button.',
+							'Additionally, you can pass a boolean prop to say if onboarding has been completed.',
+							'If the owner/teammate has done onboarding already, all of the messages will be displayed.'
 						]}
-						onComplete={() => alert('Done!')}
+						onComplete={this.didCompleteOnboarding}
 						doneButtonLabel={'Finish'}
+						onboardingComplete={this.props.onboarding.onboardingComplete}
 					/>
 					<Pre>
 						{`<Onboarding
@@ -855,10 +875,13 @@ export default class Styleguide extends Component {
 		'This is an onboarding component.',
 		'It has a heading',
 		'And "guides" you through the steps like the TrainingGuide',
-		'You can also change the label of the done button.'
+		'You can also change the label of the done button.',
+		'Additionally, you can pass a boolean prop to say if onboarding has been completed.',
+		'If the owner/teammate has done onboarding already, all of the messages will be displayed.'
 	]}
-	onComplete={() => alert('Done!')}
+	onComplete={this.didCompleteOnboarding}
 	doneButtonLabel={'Finish'}
+	onboardingComplete={this.props.onboarding.onboardingComplete}	
 />`}
 					</Pre>
 				</Container>
@@ -976,3 +999,9 @@ export default class Styleguide extends Component {
 		)
 	}
 }
+
+export default withStore(Styleguide, {
+	actions,
+	reducers,
+	config: { SERVER_HOST: 'https://example.com' }
+})

--- a/packages/react-sprucebot/src/components/Styleguide/__snapshots__/FormExample.test.js.snap
+++ b/packages/react-sprucebot/src/components/Styleguide/__snapshots__/FormExample.test.js.snap
@@ -20,6 +20,10 @@ exports[`FormExample it renders 1`] = `
             "auth": Object {
               "go": [Function],
             },
+            "onboarding": Object {
+              "didOnboarding": [Function],
+              "finishOnboarding": [Function],
+            },
           }
         }
         auth={Object {}}
@@ -71,6 +75,7 @@ exports[`FormExample it renders 1`] = `
             },
           }
         }
+        onboarding={Object {}}
       >
         <ReduxForm
           onSubmit={[MockFunction]}

--- a/packages/react-sprucebot/src/components/TrainingGuide/TrainingGuide.js
+++ b/packages/react-sprucebot/src/components/TrainingGuide/TrainingGuide.js
@@ -53,12 +53,6 @@ export default class TrainingGuide extends Component {
 		}
 	}
 
-	static importSteps(steps) {
-		return steps.map((step, idx) => {
-			return { key: `step-${idx}`, value: step }
-		})
-	}
-
 	next() {
 		this.setState((prevState, props) => {
 			if (prevState.currentStep < props.steps.length - 1) {
@@ -86,6 +80,8 @@ export default class TrainingGuide extends Component {
 	}
 
 	componentDidMount() {
+		const { steps, onboardingComplete } = this.props
+		const { currentStep } = this.state
 		// calculate height of first element in each step
 		const stepHeights = this.stepDomNodes.map(node => {
 			const first = node.children[0]
@@ -98,13 +94,21 @@ export default class TrainingGuide extends Component {
 			return span.offsetWidth
 		})
 
-		this.setState(() => {
-			return { stepHeights, stepWidths }
+		this.setState({
+			stepHeights,
+			stepWidths,
+			currentStep: onboardingComplete ? steps.length - 1 : currentStep
 		})
 	}
 
 	render() {
-		const { steps, nextButtonLabel, doneButtonLabel, onComplete } = this.props
+		const {
+			steps,
+			nextButtonLabel,
+			doneButtonLabel,
+			onComplete,
+			onboardingComplete
+		} = this.props
 		const { currentStep, stepHeights, stepWidths, transitioning } = this.state
 		const last = currentStep === steps.length - 1
 
@@ -169,10 +173,12 @@ TrainingGuide.propTypes = {
 	steps: PropTypes.array.isRequired,
 	nextButtonLabel: PropTypes.string.isRequired,
 	doneButtonLabel: PropTypes.string.isRequired,
-	onComplete: PropTypes.func.isRequired
+	onComplete: PropTypes.func.isRequired,
+	onboardingComplete: PropTypes.bool.isRequired
 }
 
 TrainingGuide.defaultProps = {
 	nextButtonLabel: 'Next',
-	doneButtonLabel: 'Done'
+	doneButtonLabel: 'Done',
+	onboardingComplete: false
 }

--- a/packages/react-sprucebot/src/skillskit/next/Page.js
+++ b/packages/react-sprucebot/src/skillskit/next/Page.js
@@ -57,6 +57,7 @@ const Page = Wrapped => {
 			if (jwt) {
 				try {
 					await store.dispatch(actions.auth.go(jwt))
+					await store.dispatch(actions.onboarding.didOnboarding())
 
 					// only save cookie if a new one has been passed
 					if (query.jwt) {

--- a/packages/react-sprucebot/src/skillskit/store/actions/index.js
+++ b/packages/react-sprucebot/src/skillskit/store/actions/index.js
@@ -1,5 +1,7 @@
 import * as auth from './auth'
+import * as onboarding from './onboarding'
 
 module.exports = {
-	auth
+	auth,
+	onboarding
 }

--- a/packages/react-sprucebot/src/skillskit/store/actions/onboarding.js
+++ b/packages/react-sprucebot/src/skillskit/store/actions/onboarding.js
@@ -1,0 +1,33 @@
+export const DID_ONBOARDING_REQUEST = 'onboarding/DID_ONBOARDING_REQUEST'
+export const DID_ONBOARDING_SUCCESS = 'onboarding/DID_ONBOARDING_SUCCESS'
+export const DID_ONBOARDING_ERROR = 'onboarding/DID_ONBOARDING_ERROR'
+
+export const FINISH_ONBOARDING_REQUEST = 'onboarding/FINISH_ONBOARDING_REQUEST'
+export const FINISH_ONBOARDING_SUCCESS = 'onboarding/FINISH_ONBOARDING_SUCCESS'
+export const FINISH_ONBOARDING_ERROR = 'onboarding/FINISH_ONBOARDING_ERROR'
+
+export function didOnboarding() {
+	return {
+		types: [
+			DID_ONBOARDING_REQUEST,
+			DID_ONBOARDING_SUCCESS,
+			DID_ONBOARDING_ERROR
+		],
+		promise: (client, auth) => {
+			return client.get(`/api/1.0/guest/onboarding.json`)
+		}
+	}
+}
+
+export function finishOnboarding() {
+	return {
+		types: [
+			FINISH_ONBOARDING_REQUEST,
+			FINISH_ONBOARDING_SUCCESS,
+			FINISH_ONBOARDING_ERROR
+		],
+		promise: (client, auth) => {
+			return client.post(`/api/1.0/guest/onboarding.json`)
+		}
+	}
+}

--- a/packages/react-sprucebot/src/skillskit/store/reducers/index.js
+++ b/packages/react-sprucebot/src/skillskit/store/reducers/index.js
@@ -1,5 +1,6 @@
 import auth from './auth'
 import config from './config'
+import onboarding from './onboarding'
 import { reducer as form } from 'redux-form'
 
-export default { auth, config, form }
+export default { auth, config, onboarding, form }

--- a/packages/react-sprucebot/src/skillskit/store/reducers/onboarding.js
+++ b/packages/react-sprucebot/src/skillskit/store/reducers/onboarding.js
@@ -1,0 +1,59 @@
+import {
+	DID_ONBOARDING_REQUEST,
+	DID_ONBOARDING_SUCCESS,
+	DID_ONBOARDING_ERROR,
+	FINISH_ONBOARDING_REQUEST,
+	FINISH_ONBOARDING_SUCCESS,
+	FINISH_ONBOARDING_ERROR
+} from '../actions/onboarding'
+
+export default function reducer(state = null, action) {
+	switch (action.type) {
+		case DID_ONBOARDING_REQUEST:
+			return {
+				...state,
+				onboardingError: undefined,
+				onboardingLoading: true,
+				onboardingLoaded: false
+			}
+		case DID_ONBOARDING_SUCCESS:
+			return {
+				...state,
+				onboardingComplete: action.result.finishedOnboarding,
+				onboardingError: undefined,
+				onboardingLoading: false,
+				onboardingLoaded: true
+			}
+		case DID_ONBOARDING_ERROR:
+			return {
+				...state,
+				onboardingError: action.error,
+				onboardingLoading: false,
+				onboardingLoaded: false
+			}
+		case FINISH_ONBOARDING_REQUEST:
+			return {
+				...state,
+				onboardingError: undefined,
+				onboardingSaving: true,
+				onboardingSaved: false
+			}
+		case FINISH_ONBOARDING_SUCCESS:
+			return {
+				...state,
+				onboardingComplete: action.result.finishedOnboarding,
+				onboardingError: undefined,
+				onboardingSaving: false,
+				onboardingSaved: true
+			}
+		case FINISH_ONBOARDING_ERROR:
+			return {
+				...state,
+				onboardingError: action.error,
+				onboardingSaving: false,
+				onboardingSaved: false
+			}
+		default:
+			return state
+	}
+}

--- a/packages/sprucebot-skills-kit-server/controllers/onboarding.js
+++ b/packages/sprucebot-skills-kit-server/controllers/onboarding.js
@@ -1,0 +1,38 @@
+module.exports = (router, options) => {
+	router.get('/api/1.0/guest/onboarding.json', async (ctx, next) => {
+		try {
+			const finishedOnboarding = await ctx.services.onboarding.didOnboarding(
+				ctx.auth
+			)
+			ctx.body = {
+				finishedOnboarding:
+					finishedOnboarding && finishedOnboarding.onboardingComplete
+			}
+		} catch (err) {
+			console.error('loading onboarding failed')
+			console.error(err.stack || err)
+			ctx.throw('LOAD_ONBOARDING_ERROR')
+		} finally {
+		}
+	})
+
+	router.post('/api/1.0/guest/onboarding.json', async (ctx, next) => {
+		const waitKey = `onboarding-${ctx.auth.LocationId}`
+		try {
+			await ctx.sb.wait(waitKey)
+			const finishedOnboarding = await ctx.services.onboarding.finishOnboarding(
+				ctx.auth
+			)
+			ctx.body = {
+				finishedOnboarding:
+					finishedOnboarding && finishedOnboarding.onboardingComplete
+			}
+		} catch (err) {
+			console.error('saving onboarding failed')
+			console.error(err.stack || err)
+			ctx.throw('SAVE_ONBOARDING_ERROR')
+		} finally {
+			ctx.sb.go(waitKey)
+		}
+	})
+}

--- a/packages/sprucebot-skills-kit-server/services/onboarding.js
+++ b/packages/sprucebot-skills-kit-server/services/onboarding.js
@@ -1,0 +1,27 @@
+module.exports = {
+	async didOnboarding(user) {
+		const meta = await this.sb.meta('onboarding', {
+			locationId: user.LocationId,
+			userId: user.UserId
+		})
+
+		if (!meta) {
+			return false
+		}
+
+		return { ...meta.value }
+	},
+
+	async finishOnboarding(user) {
+		const meta = await this.sb.upsertMeta(
+			'onboarding',
+			{ onboardingComplete: true },
+			{
+				locationId: user.LocationId,
+				userId: user.UserId
+			}
+		)
+
+		return { ...meta.value }
+	}
+}

--- a/packages/sprucebot-skills-kit/config/errors.js
+++ b/packages/sprucebot-skills-kit/config/errors.js
@@ -35,5 +35,18 @@ module.exports = {
 		status: 'failure',
 		reason: 'Permission denied.',
 		friendlyReason: 'Permission denied.'
+	},
+	LOADING_ONBOARDING_ERROR: {
+		code: 404,
+		status: 'failure',
+		reason: 'finishedOnboarding could not be found',
+		friendlyReason: 'I could not tell if you have gone through onboarding yet.'
+	},
+	SAVE_ONBOARDING_ERROR: {
+		code: 404,
+		status: 'failure',
+		reason: 'Could not save finishedOnboarding',
+		friendlyReason:
+			'I had a problem trying to let the Bots know you had finished onboarding.  Maybe try again?'
 	}
 }

--- a/packages/sprucebot-skills-kit/interface/__mocks__/onboarding.js
+++ b/packages/sprucebot-skills-kit/interface/__mocks__/onboarding.js
@@ -1,0 +1,21 @@
+import path from 'path'
+
+import client from './client'
+
+function respondWithStub(file) {
+	const contents = require(file)
+	if (contents.default) {
+		return contents.default
+	}
+
+	return contents
+}
+
+export function didOnboarding(
+	status = 200,
+	file = path.resolve(__dirname, './stubs/onboarding.js')
+) {
+	return client()
+		.get(`/api/1.0/guest/onboarding.json`)
+		.reply(status, respondWithStub(file))
+}

--- a/packages/sprucebot-skills-kit/interface/__mocks__/stubs/onboarding.js
+++ b/packages/sprucebot-skills-kit/interface/__mocks__/stubs/onboarding.js
@@ -1,0 +1,1 @@
+export default { onboardingComplete: false }

--- a/packages/sprucebot-skills-kit/interface/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/packages/sprucebot-skills-kit/interface/__tests__/pages/__snapshots__/index.test.js.snap
@@ -2100,7 +2100,7 @@ export default reduxForm({
               class="BotText-s1aw735w-0 bot__text gicUIk"
             >
               <span>
-                It has a heading
+                It has a heading.
               </span>
             </div>
           </div>
@@ -2112,7 +2112,7 @@ export default reduxForm({
               class="BotText-s1aw735w-0 bot__text gicUIk"
             >
               <span>
-                And "guides" you through the steps like the TrainingGuide
+                And "guides" you through the steps like the TrainingGuide.
               </span>
             </div>
           </div>
@@ -2125,6 +2125,30 @@ export default reduxForm({
             >
               <span>
                 You can also change the label of the done button.
+              </span>
+            </div>
+          </div>
+          <div
+            class="training_guide__step off "
+            style="height:0"
+          >
+            <div
+              class="BotText-s1aw735w-0 bot__text gicUIk"
+            >
+              <span>
+                Additionally, you can pass a boolean prop to say if onboarding has been completed.
+              </span>
+            </div>
+          </div>
+          <div
+            class="training_guide__step off "
+            style="height:0"
+          >
+            <div
+              class="BotText-s1aw735w-0 bot__text gicUIk"
+            >
+              <span>
+                If the owner/teammate has done onboarding already, all of the messages will be displayed.
               </span>
             </div>
           </div>
@@ -2147,10 +2171,13 @@ export default reduxForm({
 		'This is an onboarding component.',
 		'It has a heading',
 		'And "guides" you through the steps like the TrainingGuide',
-		'You can also change the label of the done button.'
+		'You can also change the label of the done button.',
+		'Additionally, you can pass a boolean prop to say if onboarding has been completed.',
+		'If the owner/teammate has done onboarding already, all of the messages will be displayed.'
 	]}
-	onComplete={() =&gt; alert('Done!')}
+	onComplete={this.didCompleteOnboarding}
 	doneButtonLabel={'Finish'}
+	onboardingComplete={this.props.onboarding.onboardingComplete}	
 /&gt;
       </pre>
     </div>

--- a/packages/sprucebot-skills-kit/interface/__tests__/pages/__snapshots__/owner.test.js.snap
+++ b/packages/sprucebot-skills-kit/interface/__tests__/pages/__snapshots__/owner.test.js.snap
@@ -45,20 +45,9 @@ exports[`renders owner page snapshot 1`] = `
         <div
           class="tap__pane"
         >
-          <span
-            class="loader_wrapper"
-            style="display:block;margin:20px;text-align:center"
-          >
-            <span
-              class="loader_dot_dark"
-            />
-            <span
-              class="loader_dot_dark"
-            />
-            <span
-              class="loader_dot_dark"
-            />
-          </span>
+          <div
+            class="List-s15prkdz-0 List item__list bkLHAA"
+          />
         </div>
       </div>
     </div>

--- a/packages/sprucebot-skills-kit/interface/__tests__/pages/owner.test.js
+++ b/packages/sprucebot-skills-kit/interface/__tests__/pages/owner.test.js
@@ -4,6 +4,7 @@ import { render } from 'enzyme'
 import { testUtils } from 'react-sprucebot'
 
 import { JWT, auth, guests, teammates } from '../../__mocks__/users'
+import { didOnboarding } from '../../__mocks__/onboarding'
 
 import Owner from '../../pages/owner'
 
@@ -12,6 +13,7 @@ beforeEach(async () => {
 	auth()
 	guests()
 	teammates()
+	didOnboarding()
 	props = await Owner.getInitialProps({
 		store: testUtils.createStore({ config }),
 		pathname: '/owner',

--- a/packages/sprucebot-skills-kit/interface/pages/owner/index.js
+++ b/packages/sprucebot-skills-kit/interface/pages/owner/index.js
@@ -6,10 +6,14 @@ import TeamDashboard from '../../components/TeamDashboard'
 import * as users from '../../store/actions/users'
 
 class OwnerDashboard extends React.Component {
-	static getInitialProps({ store }) {
+	static async getInitialProps({ auth, store }) {
 		// load everything
-		store.dispatch(users.guests())
-		store.dispatch(users.teammates())
+		if (auth) {
+			await Promise.all([
+				store.dispatch(users.guests()),
+				store.dispatch(users.teammates())
+			])
+		}
 
 		return {}
 	}
@@ -29,7 +33,8 @@ class OwnerDashboard extends React.Component {
 				teammatesLoading = true,
 				teammatesError,
 				teammates
-			}
+			},
+			onboarding
 		} = this.props
 
 		const dashboardProps = {

--- a/packages/sprucebot-skills-kit/interface/pages/teammate/index.js
+++ b/packages/sprucebot-skills-kit/interface/pages/teammate/index.js
@@ -6,10 +6,14 @@ import TeamDashboard from '../../components/TeamDashboard'
 import * as users from '../../store/actions/users'
 
 class TeammateDashboard extends React.Component {
-	static getInitialProps({ store }) {
+	static async getInitialProps({ auth, store }) {
 		// load everything
-		store.dispatch(users.guests())
-		store.dispatch(users.teammates())
+		if (auth) {
+			await Promise.all([
+				store.dispatch(users.guests()),
+				store.dispatch(users.teammates())
+			])
+		}
 
 		return {}
 	}
@@ -29,7 +33,8 @@ class TeammateDashboard extends React.Component {
 				teammatesLoading = true,
 				teammatesError,
 				teammates
-			}
+			},
+			onboarding
 		} = this.props
 
 		const dashboardProps = {


### PR DESCRIPTION
if onboarding is completed, all messages for onboarding are displayed

[SB-1333](https://jira.sprucelabs.ai/jira/browse/SB-1333)

@sprucelabsai/engineers

## Description 
Onboarding is kept track of server side
Depending on whether a user has been through onboarding, all the messages for onboarding will be displayed instead of having to click through each one
Made Onboarding component backwards compatible if there isn't the prop, onboardingComplete.

## Type
- [x] Feature
- [ ] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
1. Run skillskit and add a new onboarding component
2. Make sure onboardingComplete is set to this.props.onboarding.onboardingComplete on your onboarding component
3.  The first time you go through onboarding, it will look normal where you have to go through one message at a time.
4.  After clicking finish, check and see that the backend has stored for that skill { onboardingComplete: true }
5.  Go through the onboarding again, and notice this time, all the messages will display.  It will scroll to the button automatically shortly after.  Clicking the button will go to the next page.