### PR TITLE
feat(SB-1448): adds /public route and page to skills kit

### DIFF
--- a/packages/react-sprucebot/lib/components/DevControls/DevControls.js
+++ b/packages/react-sprucebot/lib/components/DevControls/DevControls.js
@@ -24,6 +24,8 @@ var _Select2 = _interopRequireDefault(_Select);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -47,7 +49,11 @@ var DevControls = function (_Component) {
 	_createClass(DevControls, [{
 		key: 'onChangeRole',
 		value: function onChangeRole(role) {
-			window.location.href = '/dev/' + role + '/redirect';
+			var href = '/dev/' + role + '/redirect';
+			if (role === 'public') {
+				href = '/public';
+			}
+			window.location.href = href;
 		}
 	}, {
 		key: 'componentDidMount',
@@ -64,14 +70,13 @@ var DevControls = function (_Component) {
 				return null;
 			}
 
-			var props = Object.assign({}, this.props);
-			var auth = props.auth;
-
-			// cleanup props
-
-			delete props.auth;
+			var _props = this.props,
+			    auth = _props.auth,
+			    props = _objectWithoutProperties(_props, ['auth']);
 
 			//easy bail if not auth'ed
+
+
 			if (!auth || auth.error || !auth.role) {
 				return _react2.default.createElement(
 					'div',
@@ -110,6 +115,11 @@ var DevControls = function (_Component) {
 						'option',
 						{ value: 'guest' },
 						'Guest'
+					),
+					_react2.default.createElement(
+						'option',
+						{ value: 'public' },
+						'Public'
 					)
 				)
 			);

--- a/packages/react-sprucebot/lib/skillskit/next/Page.js
+++ b/packages/react-sprucebot/lib/skillskit/next/Page.js
@@ -274,7 +274,7 @@ var Page = function Page(Wrapped) {
 
 										if (props.pathname === '/') {
 											redirect = '/' + role + '?' + queryString;
-										} else if (role !== firstPart) {
+										} else if (role !== firstPart && !state.config.DEV_MODE) {
 											redirect = '/unauthorized';
 										}
 									}

--- a/packages/react-sprucebot/src/components/DevControls/DevControls.js
+++ b/packages/react-sprucebot/src/components/DevControls/DevControls.js
@@ -11,7 +11,11 @@ class DevControls extends Component {
 		}
 	}
 	onChangeRole(role) {
-		window.location.href = `/dev/${role}/redirect`
+		let href = `/dev/${role}/redirect`
+		if (role === 'public') {
+			href = `/public`
+		}
+		window.location.href = href
 	}
 	componentDidMount() {
 		this.setState({
@@ -24,11 +28,7 @@ class DevControls extends Component {
 			return null
 		}
 
-		const props = Object.assign({}, this.props)
-		let { auth } = props
-
-		// cleanup props
-		delete props.auth
+		let { auth, ...props } = this.props
 
 		//easy bail if not auth'ed
 		if (!auth || auth.error || !auth.role) {
@@ -49,6 +49,7 @@ class DevControls extends Component {
 					<option value="owner">Owner</option>
 					<option value="teammate">Teammate</option>
 					<option value="guest">Guest</option>
+					<option value="public">Public</option>
 				</Select>
 			</div>
 		)

--- a/packages/react-sprucebot/src/skillskit/next/Page.js
+++ b/packages/react-sprucebot/src/skillskit/next/Page.js
@@ -112,7 +112,7 @@ const Page = Wrapped => {
 				// we are at '/' then redirect to the corresponding role's path
 				if (props.pathname === '/') {
 					redirect = `/${role}?${queryString}`
-				} else if (role !== firstPart) {
+				} else if (role !== firstPart && !state.config.DEV_MODE) {
 					redirect = `/unauthorized`
 				}
 			}

--- a/packages/sprucebot-node/index.js
+++ b/packages/sprucebot-node/index.js
@@ -32,6 +32,7 @@ class Sprucebot {
 		this.icon = svgIcon || required('svgIcon')
 		this.webhookUrl = (serverUrl || required('serverUrl')) + '/hook.json'
 		this.iframeUrl = interfaceUrl || required('interfaceUrl')
+		this.publicUrl = (interfaceUrl || required('interfaceUrl')) + '/public'
 		this.marketingUrl =
 			(interfaceUrl || required('interfaceUrl')) + '/marketing'
 
@@ -50,8 +51,9 @@ class Sprucebot {
 		})
 
 		console.log(
-			`🌲 Sprucebot🌲 Skills Kit API ${this
-				.version}\n\nhost : ${cleanedHost} \nid : ${id} \napiKey : ${apiKey.replace(
+			`🌲 Sprucebot🌲 Skills Kit API ${
+				this.version
+			}\n\nhost : ${cleanedHost} \nid : ${id} \napiKey : ${apiKey.replace(
 				/./g,
 				'*'
 			)} \nname : ${name}\n---------------------------------`
@@ -68,7 +70,8 @@ class Sprucebot {
 			icon: this.icon,
 			webhookUrl: this.webhookUrl,
 			iframeUrl: this.iframeUrl,
-			marketingUrl: this.marketingUrl
+			marketingUrl: this.marketingUrl,
+			publicUrl: this.publicUrl
 		}
 		const results = await this.https.patch('/', data)
 		let database = null
@@ -97,8 +100,8 @@ class Sprucebot {
 
 	/**
 	 * Get a user without a location. GLOBAL SKILLS ONLY
-	 * 
-	 * @param {String} userId 
+	 *
+	 * @param {String} userId
 	 * @param {Object} Optional query string to be added to the request
 	 */
 	async globalUser(userId, query) {
@@ -107,7 +110,7 @@ class Sprucebot {
 
 	/**
 	 * Get all locations. GLOBAL SKILLS ONLY
-	 * 
+	 *
 	 * @param {Object} Optional query string to be added to the request
 	 */
 	async globalLocations(query) {
@@ -115,23 +118,23 @@ class Sprucebot {
 	}
 
 	/**
-     * Create a user
-     *
-     * @param {Object} values
-     * @returns {Promise}
-     */
+	 * Create a user
+	 *
+	 * @param {Object} values
+	 * @returns {Promise}
+	 */
 	async createUser(values) {
 		return this.https.post('/ge/users', values)
 	}
 
 	/**
-     * Update a users role
-     *
-     * @param {String} locationId
-     * @param {String} userId
-     * @param {String} role
-     * @returns {Promise}
-     */
+	 * Update a users role
+	 *
+	 * @param {String} locationId
+	 * @param {String} userId
+	 * @param {String} role
+	 * @returns {Promise}
+	 */
 	async updateRole(locationId, userId, role) {
 		return this.https.patch(
 			`/ge/locations/${locationId}/users/${userId}/${role}`
@@ -208,12 +211,12 @@ class Sprucebot {
 	}
 
 	/**
-	 * ONLY APPLIES TO SKILLS THAT ARE GLOBAL (are not attached to a location).  
-	 * This allows Sprucebot to communicate to business owners without them 
-	 * actually needing any skills enabled. Core usage only. 
-	 * 
-	 * @param {String} userId 
-	 * @param {String} message 
+	 * ONLY APPLIES TO SKILLS THAT ARE GLOBAL (are not attached to a location).
+	 * This allows Sprucebot to communicate to business owners without them
+	 * actually needing any skills enabled. Core usage only.
+	 *
+	 * @param {String} userId
+	 * @param {String} message
 	 */
 	async globalMessage(userId, message) {
 		return this.https.post('/messages', { userId, message })
@@ -281,8 +284,8 @@ class Sprucebot {
 
 	/**
 	 * Get skill meta data by id
-	 * 
-	 * @param {String} id 
+	 *
+	 * @param {String} id
 	 */
 	async metaById(id, { locationId, userId } = {}) {
 		return this.https.get(`/data/${id}`, Array.from(arguments)[1])

--- a/packages/sprucebot-skills-kit/interface/next.config.js
+++ b/packages/sprucebot-skills-kit/interface/next.config.js
@@ -13,14 +13,6 @@ function client(webpack, options) {
 	const clientConfig = config.sanitizeClientConfig({ ...config })
 	// Export our whitelisted config for the client bundle
 	fs.writeFileSync(jsonPath, JSON.stringify(clientConfig))
-	webpack.plugins = webpack.plugins.filter(plugin => {
-		// DEV_MODE=true configures the the nextjs `dev` value
-		if (config.dev && plugin.constructor.name === 'UglifyJsPlugin') {
-			return false
-		} else {
-			return true
-		}
-	})
 
 	webpack.resolve = {
 		alias: {

--- a/packages/sprucebot-skills-kit/interface/pages/public.js
+++ b/packages/sprucebot-skills-kit/interface/pages/public.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import Page from '../containers/Page'
+import { Container, H1, BotText } from 'react-sprucebot'
+import ReactDOM from 'react-dom'
+
+class PublicPage extends React.Component {
+	static getInitialProps() {
+		return {
+			public: true
+		}
+	}
+	componentDidMount() {
+		this.props.skill.ready() // Show the skill
+	}
+
+	render() {
+		return (
+			<Container className="public">
+				<H1>{this.props.config.NAME}</H1>
+				<BotText>
+					Hey Dev! This is your publicly facing page. You might not have user
+					auth, but this is a great landing page into your skill!
+				</BotText>
+			</Container>
+		)
+	}
+}
+
+export default Page(PublicPage)


### PR DESCRIPTION
[SB-1448](https://jira.sprucelabs.ai/jira/browse/SB-1448)

@sprucelabsai/engineers

## Description 
Enables the skill to declare a publicUrl which acts as a landing page for unauthorized users.
Adds a PUT object publicUrl when running `sprucebot.sync()`

## Type
- [x] Feature
- [ ] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
After the skill runs, notice the Skill DB entry for `publicUrl`
Visit `/public` and notice the page renders without errors.
When in `DEV_MODE`, notice a new route added to the navigation Select menu
