### PR TITLE
style(SB-1466): tabs match classes of core

### DIFF
--- a/packages/react-sprucebot/lib/components/Tabs/Tabs.js
+++ b/packages/react-sprucebot/lib/components/Tabs/Tabs.js
@@ -155,10 +155,10 @@ var Tabs = exports.Tabs = function (_Component) {
 
 			return _react2.default.createElement(
 				'div',
-				_extends({ className: 'tabs__container ' }, props),
+				null,
 				_react2.default.createElement(
 					'div',
-					{ className: 'tabs' },
+					_extends({ className: 'toggle__wrapper' }, props),
 					tabs
 				),
 				_react2.default.createElement(

--- a/packages/react-sprucebot/src/components/Tabs/Tabs.js
+++ b/packages/react-sprucebot/src/components/Tabs/Tabs.js
@@ -104,8 +104,10 @@ export class Tabs extends Component {
 		})
 
 		return (
-			<div className={`tabs__container `} {...props}>
-				<div className="tabs">{tabs}</div>
+			<div>
+				<div className={`toggle__wrapper`} {...props}>
+					{tabs}
+				</div>
 				<div className="tab__panes">{tabPanes}</div>
 			</div>
 		)

--- a/packages/react-sprucebot/src/components/Tabs/__snapshots__/Tabs.test.js.snap
+++ b/packages/react-sprucebot/src/components/Tabs/__snapshots__/Tabs.test.js.snap
@@ -7,11 +7,9 @@ exports[`TabPane renders 1`] = `
 `;
 
 exports[`Tabs renders 1`] = `
-<div
-  className="tabs__container "
->
+<div>
   <div
-    className="tabs"
+    className="toggle__wrapper"
   />
   <div
     className="tab__panes"

--- a/packages/sprucebot-skills-kit/interface/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/packages/sprucebot-skills-kit/interface/__tests__/pages/__snapshots__/index.test.js.snap
@@ -1031,11 +1031,9 @@ export default reduxForm({
     <div
       class="Container-md3jvi-0 container cqhPkv"
     >
-      <div
-        class="tabs__container "
-      >
+      <div>
         <div
-          class="tabs"
+          class="toggle__wrapper"
         >
           <button
             class="btn__toggle toggle__left"

--- a/packages/sprucebot-skills-kit/interface/__tests__/pages/__snapshots__/owner.test.js.snap
+++ b/packages/sprucebot-skills-kit/interface/__tests__/pages/__snapshots__/owner.test.js.snap
@@ -20,11 +20,9 @@ exports[`renders owner page snapshot 1`] = `
     >
       Who's Online
     </h2>
-    <div
-      class="tabs__container "
-    >
+    <div>
       <div
-        class="tabs"
+        class="toggle__wrapper"
       >
         <button
           class="btn__toggle toggle__left btn__toggle__active"


### PR DESCRIPTION
[SB-1466](https://jira.sprucelabs.ai/jira/browse/SB-1466)

@sprucelabsai/engineers

## Description 
tabs now match classes in core.
Still have to leave the class of tab_panes because of the way the content being displayed underneath is slightly different than in web.

## Type
- [ ] Feature
- [ ] Bug
- [x] Tech debt

## Steps to Test or Reproduce
1. Go to a skill that has tabs, such as scratch and win.
2. Go to the inspector and notice the classes.
3. The div that holds both tabs is now called "toggle__wrapper" instead of "tabs"
4. Everything else should be the same, including "toggle__left", "toggle__right", and "btn__toggle__active".
