### PR TITLE
fix(SB-1461): classes for switches are same as core

### DIFF
--- a/packages/react-sprucebot/lib/components/Switch/Switch.js
+++ b/packages/react-sprucebot/lib/components/Switch/Switch.js
@@ -4,13 +4,7 @@ Object.defineProperty(exports, "__esModule", {
 	value: true
 });
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
-var _styledComponents = require('styled-components');
-
-var _styledComponents2 = _interopRequireDefault(_styledComponents);
 
 var _react = require('react');
 
@@ -27,32 +21,6 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-var switchContainerColorOff = '#d6d6d6';
-var switchContainerColorOn = '#00C8EB';
-var switchBtnColorOff = '#808080';
-var switchBtnColorOn = '#0094AD';
-
-var SwitchButton = _styledComponents2.default.span.attrs({
-	className: 'SwitchButton',
-	type: 'button'
-}).withConfig({
-	displayName: 'Switch__SwitchButton',
-	componentId: 'wfc8pr-0'
-})(['background:none;bottom:0;height:100%;left:0;margin:0;padding:0;position:absolute;right:0;top:0;width:100%;&:before{background-color:', ';border-radius:50%;bottom:0;content:\'\';height:1.125em;left:0.1875em;margin:auto;position:absolute;right:auto;top:0;width:1.125em;transition:transform 0.2s ease-out;', ';}'], switchBtnColorOff, function (props) {
-	return props.on ? 'transform: translate(1.4375em, 0);\n\t\t\t\tbackground-color: ' + switchBtnColorOn : 'transition: transform 0.2s ease-out;';
-});
-var SwitchComp = _styledComponents2.default.div.attrs({
-	className: function className(_ref) {
-		var _className = _ref.className;
-		return 'Switch switch ' + (_className || '');
-	}
-}).withConfig({
-	displayName: 'Switch__SwitchComp',
-	componentId: 'wfc8pr-1'
-})(['background-color:', ';border-radius:0.75em;height:1.5em;position:relative;transition:background-color 0.3s ease-out;width:3em;', ';'], switchContainerColorOff, function (props) {
-	return props.on ? 'background-color: ' + switchContainerColorOn + ';' : 'transition: transform 0.2s ease-out;';
-});
 
 var Switch = function (_Component) {
 	_inherits(Switch, _Component);
@@ -100,27 +68,20 @@ var Switch = function (_Component) {
 		value: function render() {
 			var _this3 = this;
 
-			var props = Object.assign({}, this.props);
-
-			delete props.className;
-			delete props.on;
-			delete props.onChange;
-			delete props.children;
-
 			return _react2.default.createElement(
-				SwitchComp,
-				_extends({
-					on: this.props.on
-				}, props, {
-					tabIndex: 0,
-					onClick: this.onChange,
-					onKeyDown: function onKeyDown(e) {
-						if (e.keyCode === 13) {
-							_this3.onChange(e);
-						}
-					}
-				}),
-				_react2.default.createElement(SwitchButton, { on: this.props.on })
+				'div',
+				{ className: 'switch switch' + (this.props.on ? ' on' : '') },
+				_react2.default.createElement(
+					'button',
+					{ onClick: function onClick() {
+							return _this3.onChange();
+						} },
+					_react2.default.createElement(
+						'span',
+						null,
+						this.props.on ? 'Enabled' : 'Disabled'
+					)
+				)
 			);
 		}
 	}]);

--- a/packages/react-sprucebot/src/components/Switch/Switch.js
+++ b/packages/react-sprucebot/src/components/Switch/Switch.js
@@ -1,60 +1,5 @@
-import styled from 'styled-components'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-
-const switchContainerColorOff = '#d6d6d6'
-const switchContainerColorOn = '#00C8EB'
-const switchBtnColorOff = '#808080'
-const switchBtnColorOn = '#0094AD'
-
-const SwitchButton = styled.span.attrs({
-	className: 'SwitchButton',
-	type: 'button'
-})`
-	background: none;
-	bottom: 0;
-	height: 100%;
-	left: 0;
-	margin: 0;
-	padding: 0;
-	position: absolute;
-	right: 0;
-	top: 0;
-	width: 100%;
-	&:before {
-		background-color: ${switchBtnColorOff};
-		border-radius: 50%;
-		bottom: 0;
-		content: '';
-		height: 1.125em;
-		left: 0.1875em;
-		margin: auto;
-		position: absolute;
-		right: auto;
-		top: 0;
-		width: 1.125em;
-		transition: transform 0.2s ease-out;
-		${props =>
-			props.on
-				? `transform: translate(1.4375em, 0);
-				background-color: ${switchBtnColorOn}`
-				: `transition: transform 0.2s ease-out;`};
-	}
-`
-const SwitchComp = styled.div.attrs({
-	className: ({ className }) => `Switch switch ${className || ''}`
-})`
-	background-color: ${switchContainerColorOff};
-	border-radius: 0.75em;
-	height: 1.5em;
-	position: relative;
-	transition: background-color 0.3s ease-out;
-	width: 3em;
-	${props =>
-		props.on
-			? `background-color: ${switchContainerColorOn};`
-			: `transition: transform 0.2s ease-out;`};
-`
 
 export default class Switch extends Component {
 	constructor(props) {
@@ -87,27 +32,12 @@ export default class Switch extends Component {
 	}
 
 	render() {
-		const props = Object.assign({}, this.props)
-
-		delete props.className
-		delete props.on
-		delete props.onChange
-		delete props.children
-
 		return (
-			<SwitchComp
-				on={this.props.on}
-				{...props}
-				tabIndex={0}
-				onClick={this.onChange}
-				onKeyDown={e => {
-					if (e.keyCode === 13) {
-						this.onChange(e)
-					}
-				}}
-			>
-				<SwitchButton on={this.props.on} />
-			</SwitchComp>
+			<div className={`switch switch${this.props.on ? ' on' : ''}`}>
+				<button onClick={() => this.onChange()}>
+					<span>{this.props.on ? 'Enabled' : 'Disabled'}</span>
+				</button>
+			</div>
 		)
 	}
 }

--- a/packages/react-sprucebot/src/components/Switch/__snapshots__/Switch.test.js.snap
+++ b/packages/react-sprucebot/src/components/Switch/__snapshots__/Switch.test.js.snap
@@ -1,61 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`it renders 1`] = `
-.c1 {
-  background: none;
-  bottom: 0;
-  height: 100%;
-  left: 0;
-  margin: 0;
-  padding: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: 100%;
-}
-
-.c1:before {
-  background-color: #808080;
-  border-radius: 50%;
-  bottom: 0;
-  content: '';
-  height: 1.125em;
-  left: 0.1875em;
-  margin: auto;
-  position: absolute;
-  right: auto;
-  top: 0;
-  width: 1.125em;
-  -webkit-transition: -webkit-transform 0.2s ease-out;
-  -webkit-transition: transform 0.2s ease-out;
-  transition: transform 0.2s ease-out;
-  -webkit-transition: -webkit-transform 0.2s ease-out;
-  -webkit-transition: transform 0.2s ease-out;
-  transition: transform 0.2s ease-out;
-}
-
-.c0 {
-  background-color: #d6d6d6;
-  border-radius: 0.75em;
-  height: 1.5em;
-  position: relative;
-  -webkit-transition: background-color 0.3s ease-out;
-  transition: background-color 0.3s ease-out;
-  width: 3em;
-  -webkit-transition: -webkit-transform 0.2s ease-out;
-  -webkit-transition: transform 0.2s ease-out;
-  transition: transform 0.2s ease-out;
-}
-
 <div
-  className="Switch switch  c0"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  tabIndex={0}
+  className="switch switch"
 >
-  <span
-    className="SwitchButton c1"
-    type="button"
-  />
+  <button
+    onClick={[Function]}
+  >
+    <span>
+      Disabled
+    </span>
+  </button>
 </div>
 `;

--- a/packages/sprucebot-skills-kit/interface/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/packages/sprucebot-skills-kit/interface/__tests__/pages/__snapshots__/index.test.js.snap
@@ -517,13 +517,13 @@ exports[`renders page with styleguide 1`] = `
       class="Container-md3jvi-0 container cqhPkv"
     >
       <div
-        class="Switch__SwitchComp-wfc8pr-1 Switch switch  eHWIUy"
-        tabindex="0"
+        class="switch switch"
       >
-        <span
-          class="Switch__SwitchButton-wfc8pr-0 SwitchButton kLTHFe"
-          type="button"
-        />
+        <button>
+          <span>
+            Disabled
+          </span>
+        </button>
       </div>
       <pre
         class="Pre-s1a0pq3k-0 dHESOH"
@@ -535,13 +535,13 @@ exports[`renders page with styleguide 1`] = `
 /&gt;
       </pre>
       <div
-        class="Switch__SwitchComp-wfc8pr-1 Switch switch  fzCZJB"
-        tabindex="0"
+        class="switch switch on"
       >
-        <span
-          class="Switch__SwitchButton-wfc8pr-0 SwitchButton esjjoB"
-          type="button"
-        />
+        <button>
+          <span>
+            Enabled
+          </span>
+        </button>
       </div>
       <pre
         class="Pre-s1a0pq3k-0 dHESOH"
@@ -942,13 +942,13 @@ export default reduxForm({
             class="List__ItemRightContent-s15prkdz-4 ItemRightContent content__right fgoBzY"
           >
             <div
-              class="Switch__SwitchComp-wfc8pr-1 Switch switch  eHWIUy"
-              tabindex="0"
+              class="switch switch"
             >
-              <span
-                class="Switch__SwitchButton-wfc8pr-0 SwitchButton kLTHFe"
-                type="button"
-              />
+              <button>
+                <span>
+                  Disabled
+                </span>
+              </button>
             </div>
           </div>
         </div>
@@ -1639,13 +1639,13 @@ export default reduxForm({
                 class="List__ItemRightContent-s15prkdz-4 ItemRightContent content__right fgoBzY"
               >
                 <div
-                  class="Switch__SwitchComp-wfc8pr-1 Switch switch  eHWIUy"
-                  tabindex="0"
+                  class="switch switch"
                 >
-                  <span
-                    class="Switch__SwitchButton-wfc8pr-0 SwitchButton kLTHFe"
-                    type="button"
-                  />
+                  <button>
+                    <span>
+                      Disabled
+                    </span>
+                  </button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
can now style on state of switch

[SB-1461](https://jira.sprucelabs.ai/jira/browse/SB-1461)

@sprucelabsai/engineers

## Description 
classes for switches are same as core so styles only need to be applied once

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
1. Go to Styleguide in sprucebot-skills-kit
2. Notice the classes of the off and on states of the switch
3. Off state the class should be "switch switch"
4. On state the class should be "switch switch on"
