### PR TITLE
fix(SB-1463): onboarding no longer scrolls up

### DIFF
--- a/packages/react-sprucebot/lib/components/TrainingGuide/TrainingGuide.js
+++ b/packages/react-sprucebot/lib/components/TrainingGuide/TrainingGuide.js
@@ -100,7 +100,7 @@ var TrainingGuide = function (_Component) {
 				this.setState({ transitioning: true });
 
 				setTimeout(function () {
-					_index2.default.scrollTo(_reactDom2.default.findDOMNode(_this2.button).offsetTop - window.screen.height * 0.5);
+					_index2.default.scrollTo(_reactDom2.default.findDOMNode(_this2.button).offsetTop - window.outerHeight * 0.5);
 					_this2.setState({ transitioning: false });
 				}, 1500);
 			}

--- a/packages/react-sprucebot/src/components/TrainingGuide/TrainingGuide.js
+++ b/packages/react-sprucebot/src/components/TrainingGuide/TrainingGuide.js
@@ -71,8 +71,7 @@ export default class TrainingGuide extends Component {
 
 			setTimeout(() => {
 				skill.scrollTo(
-					ReactDOM.findDOMNode(this.button).offsetTop -
-						window.screen.height * 0.5
+					ReactDOM.findDOMNode(this.button).offsetTop - window.outerHeight * 0.5
 				)
 				this.setState({ transitioning: false })
 			}, 1500)


### PR DESCRIPTION
onboarding no longer scrolls up on a small desktop window

[SB-1463](https://jira.sprucelabs.ai/jira/browse/SB-1463)

@sprucelabsai/engineers

## Description 
There was an issue on desktop where if you shrunk the screen super small, it would scroll up because it wasn't recognizing the window height.  (it only recognized screen height).
This fixes that situation.
This has been tested on Chrome and Safari.

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
NOTE: When this gets merged, all skills will need a bump for react-sprucebot.

1. Test any skill by yarn linking react-sprucebot to it.
2.  Shrink your window super small with a height of 500px and go through the onboarding of any skill.
3. It should no longer scroll up.  It will scroll along with the next button.
4. Test all other scenarios on mobile devices/etc. to make sure scroll still works the same as before.
