### PR TITLE
feat(SB-626): todayOnly query for users method

### DIFF
--- a/packages/sprucebot-node/index.js
+++ b/packages/sprucebot-node/index.js
@@ -50,11 +50,12 @@ class Sprucebot {
 		})
 
 		console.log(
-			`🌲 Sprucebot🌲 Skills Kit API ${this
-				.version}\n\nhost : ${cleanedHost} \nid : ${id} \napiKey : ${apiKey.replace(
-					/./g,
-					'*'
-				)} \nname : ${name}\n---------------------------------`
+			`🌲 Sprucebot🌲 Skills Kit API ${
+				this.version
+			}\n\nhost : ${cleanedHost} \nid : ${id} \napiKey : ${apiKey.replace(
+				/./g,
+				'*'
+			)} \nname : ${name}\n---------------------------------`
 		)
 	}
 
@@ -97,8 +98,8 @@ class Sprucebot {
 
 	/**
 	 * Get a user without a location. GLOBAL SKILLS ONLY
-	 * 
-	 * @param {String} userId 
+	 *
+	 * @param {String} userId
 	 * @param {Object} Optional query string to be added to the request
 	 */
 	async globalUser(userId, query) {
@@ -107,7 +108,7 @@ class Sprucebot {
 
 	/**
 	 * Get all locations. GLOBAL SKILLS ONLY
-	 * 
+	 *
 	 * @param {Object} Optional query string to be added to the request
 	 */
 	async globalLocations(query) {
@@ -115,23 +116,23 @@ class Sprucebot {
 	}
 
 	/**
-     * Create a user
-     *
-     * @param {Object} values
-     * @returns {Promise}
-     */
+	 * Create a user
+	 *
+	 * @param {Object} values
+	 * @returns {Promise}
+	 */
 	async createUser(values) {
 		return this.https.post('/ge/users', values)
 	}
 
 	/**
-     * Update a users role
-     *
-     * @param {String} locationId
-     * @param {String} userId
-     * @param {String} role
-     * @returns {Promise}
-     */
+	 * Update a users role
+	 *
+	 * @param {String} locationId
+	 * @param {String} userId
+	 * @param {String} role
+	 * @returns {Promise}
+	 */
 	async updateRole(locationId, userId, role) {
 		return this.https.patch(
 			`/ge/locations/${locationId}/users/${userId}/${role}`
@@ -144,7 +145,7 @@ class Sprucebot {
 	 * @param {Object} query
 	 * @returns {Promise}
 	 */
-	async users(locationId, { role, status, page, limit } = {}) {
+	async users(locationId, { role, status, page, limit, todayOnly } = {}) {
 		return this.https.get(
 			`/locations/${locationId}/users/`,
 			Array.from(arguments)[1]
@@ -208,12 +209,12 @@ class Sprucebot {
 	}
 
 	/**
-	 * ONLY APPLIES TO SKILLS THAT ARE GLOBAL (are not attached to a location).  
-	 * This allows Sprucebot to communicate to business owners without them 
-	 * actually needing any skills enabled. Core usage only. 
-	 * 
-	 * @param {String} userId 
-	 * @param {String} message 
+	 * ONLY APPLIES TO SKILLS THAT ARE GLOBAL (are not attached to a location).
+	 * This allows Sprucebot to communicate to business owners without them
+	 * actually needing any skills enabled. Core usage only.
+	 *
+	 * @param {String} userId
+	 * @param {String} message
 	 */
 	async globalMessage(userId, message) {
 		return this.https.post('/messages', { userId, message })
@@ -286,8 +287,8 @@ class Sprucebot {
 
 	/**
 	 * Get skill meta data by id
-	 * 
-	 * @param {String} id 
+	 *
+	 * @param {String} id
 	 */
 	async metaById(id, { locationId, userId } = {}) {
 		return this.https.get(`/data/${id}`, Array.from(arguments)[1])
@@ -423,7 +424,7 @@ class Sprucebot {
 		//first is always auto resolved
 		if (this._mutexes[key].count === 1) {
 			this._mutexes[key].promises.push(new Promise(resolve => resolve()))
-			this._mutexes[key].resolvers.push(() => { })
+			this._mutexes[key].resolvers.push(() => {})
 		} else {
 			let resolver = resolve => {
 				this._mutexes[key].resolvers.push(resolve)


### PR DESCRIPTION
Able to pass todayOnly query through sprucebot-node's users method

[SB-626](https://jira.sprucelabs.ai/jira/browse/SB-626)

@sprucelabsai/engineers

## Description 
Able to pass todayOnly query through sprucebot-node's users method.

## Type
- [x] Feature
- [ ] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
1. Yarn link sprucebot-node to LBB skill locally.
2. Set a debugger to the api locally with breakpoints in the getUsers method.
3. Simulate a did-leave event on LBB and it should hit the breakpoint in the API.
4.  You should see the todayOnly object passed through in the query.
