### PR TITLE
fix: Only import babel-polyfill once

### DIFF
--- a/packages/react-sprucebot/lib/Sprucebot.js
+++ b/packages/react-sprucebot/lib/Sprucebot.js
@@ -2,13 +2,7 @@
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _register = require('babel-core/register');
-
-var _register2 = _interopRequireDefault(_register);
-
-var _babelPolyfill = require('babel-polyfill');
-
-var _babelPolyfill2 = _interopRequireDefault(_babelPolyfill);
+require('./require-babel-polyfill');
 
 var _Avatar = require('./components/Avatar/Avatar');
 

--- a/packages/react-sprucebot/lib/require-babel-polyfill.js
+++ b/packages/react-sprucebot/lib/require-babel-polyfill.js
@@ -1,0 +1,12 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});
+
+exports.default = function () {
+	if (!global || !global._babelPolyfill) {
+		require('babel-core/register');
+		require('babel-polyfill');
+	}
+}();

--- a/packages/react-sprucebot/lib/skillskit/helpers/sharable.js
+++ b/packages/react-sprucebot/lib/skillskit/helpers/sharable.js
@@ -25,26 +25,21 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
 
 exports.default = function (config, Sharable) {
-
 	var actionGo = function actionGo(_ref) {
 		var actions = _ref.actions,
 		    _ref$internal = _ref.internal,
 		    internal = _ref$internal === undefined ? false : _ref$internal;
 
-
 		var newActions = false;
 
 		if (!internal && config && config.actionsToEvents) {
-
 			newActions = {};
 
 			Object.keys(config.actionsToEvents).map(function (namespace) {
-
 				//build namespace
 				newActions[namespace] = {};
 
 				Object.keys(config.actionsToEvents[namespace]).map(function (action) {
-
 					//save event
 					var event = config.actionsToEvents[namespace][action];
 

--- a/packages/react-sprucebot/src/Sprucebot.js
+++ b/packages/react-sprucebot/src/Sprucebot.js
@@ -1,5 +1,4 @@
-import register from 'babel-core/register'
-import polyfill from 'babel-polyfill'
+import './require-babel-polyfill'
 
 import Avatar from './components/Avatar/Avatar'
 import BotText from './components/BotText/BotText'

--- a/packages/react-sprucebot/src/require-babel-polyfill.js
+++ b/packages/react-sprucebot/src/require-babel-polyfill.js
@@ -1,0 +1,6 @@
+export default (() => {
+	if (!global || !global._babelPolyfill) {
+		require('babel-core/register')
+		require('babel-polyfill')
+	}
+})()


### PR DESCRIPTION
## Description 

* Fixes an issue w/ using locally linked modules that also import `react-sprucebot` where multiple imports of babel-polyfill fails (https://github.com/babel/babel-loader/issues/401)

## Type
- [ ] Feature
- [X] Bug
- [ ] Tech debt