### PR TITLE
Remove alias for react from next.config.js

### DIFF
--- a/packages/sprucebot-skills-kit/interface/next.config.js
+++ b/packages/sprucebot-skills-kit/interface/next.config.js
@@ -25,8 +25,7 @@ function client(webpack, options) {
 	webpack.resolve = {
 		alias: {
 			config: jsonPath,
-			'styled-components': require.resolve('styled-components'),
-			'react': path.resolve(__dirname, '../../../node_modules', 'react')
+			'styled-components': require.resolve('styled-components')
 		}
 	}
 	return webpack


### PR DESCRIPTION
## Description 

* Setting alias for react was causing errors resolving the path and causing builds to fail

## Type
- [ ] Feature
- [X] Bug
- [ ] Tech debt
