### PR TITLE
fix: run migrations before sequelize.sync()

### DIFF
--- a/packages/sprucebot-skills-kit-server/factories/sequelize.js
+++ b/packages/sprucebot-skills-kit-server/factories/sequelize.js
@@ -66,8 +66,6 @@ module.exports = (
 			}
 		})
 
-		await sequelize.sync()
-
 		// Run migrations if enabled
 		if (runMigrations && fs.existsSync(migrationsDir)) {
 			debug('Running sequelize migrations')
@@ -93,6 +91,8 @@ module.exports = (
 				migrationsDir
 			)
 		}
+
+		await sequelize.sync()
 	}
 
 	ctx[key] = { models, sequelize, sync }


### PR DESCRIPTION
## Description 

* Fixes bug where if an index is defined before migrations run the skill will error and fail to boot.  Also hotfixed in v6.18.1

## Type
- [ ] Feature
- [X] Bug
- [ ] Tech debt