### PR TITLE
Fixes styling for "Show Everyone/Show Only Working" button

### DIFF
--- a/packages/react-sprucebot/lib/components/Calendar/BigCalendar.js
+++ b/packages/react-sprucebot/lib/components/Calendar/BigCalendar.js
@@ -320,7 +320,7 @@ var BigCalendar = function (_Component) {
 					mode === 'team' && view === 'day' && teamSchedule && _react2.default.createElement(
 						_Button2.default,
 						{
-							className: 'toggle-show-working',
+							className: 'toggle-mode toggle-show-working',
 							onClick: this.handleToggleShowWorking
 						},
 						showOnlyWorking ? 'show everyone' : 'show only working'

--- a/packages/react-sprucebot/src/components/Calendar/BigCalendar.js
+++ b/packages/react-sprucebot/src/components/Calendar/BigCalendar.js
@@ -937,7 +937,7 @@ export default class BigCalendar extends Component {
 						view === 'day' &&
 						teamSchedule && (
 							<Button
-								className="toggle-show-working"
+								className="toggle-mode toggle-show-working"
 								onClick={this.handleToggleShowWorking}
 							>
 								{showOnlyWorking ? 'show everyone' : 'show only working'}


### PR DESCRIPTION
## Description 

The new "show working" button was missing a class that allows it to inherit the correct button styles. Added the `toggle-mode` class to the button that will fix the issue:

**BEFORE**

![screen shot 2018-09-14 at 3 50 30 pm](https://user-images.githubusercontent.com/755542/45576844-2b5c1580-b836-11e8-8cc2-52a682cd3b67.png)

**AFTER**

![screen shot 2018-09-14 at 3 50 56 pm](https://user-images.githubusercontent.com/755542/45576853-3747d780-b836-11e8-976b-809fdf0ffc42.png)

## Type
- [ ] Feature
- [X] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
Describe how to test the changes. 
