### PR TITLE
fix: Implement NextJS _app.js, remove title from _document.js

### DIFF
--- a/packages/react-sprucebot/lib/Sprucebot.js
+++ b/packages/react-sprucebot/lib/Sprucebot.js
@@ -80,6 +80,8 @@ var Tabs = _interopRequireWildcard(require("./components/Tabs/Tabs"));
 
 var _skillskit = _interopRequireDefault(require("./skillskit"));
 
+var _app2 = _interopRequireDefault(require("./skillskit/next/_app"));
+
 var _document2 = _interopRequireDefault(require("./skillskit/next/_document"));
 
 var _Page = _interopRequireDefault(require("./skillskit/next/Page"));
@@ -113,6 +115,7 @@ var Sprucebot = (0, _objectSpread2.default)({
   },
   lang: _lang.default,
   skill: _skillskit.default,
+  _app: _app2.default,
   _document: _document2.default,
   Page: _Page.default,
   withStore: _withStore.default,

--- a/packages/react-sprucebot/lib/skillskit/next/_app.js
+++ b/packages/react-sprucebot/lib/skillskit/next/_app.js
@@ -1,0 +1,97 @@
+"use strict";
+
+var _interopRequireWildcard = require("@babel/runtime/helpers/interopRequireWildcard");
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _regenerator = _interopRequireDefault(require("@babel/runtime/regenerator"));
+
+var _asyncToGenerator2 = _interopRequireDefault(require("@babel/runtime/helpers/asyncToGenerator"));
+
+var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
+
+var _createClass2 = _interopRequireDefault(require("@babel/runtime/helpers/createClass"));
+
+var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
+
+var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
+
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
+
+var _app = _interopRequireWildcard(require("next/app"));
+
+var _head = _interopRequireDefault(require("next/head"));
+
+var _react = _interopRequireDefault(require("react"));
+
+var MyApp =
+/*#__PURE__*/
+function (_App) {
+  (0, _inherits2.default)(MyApp, _App);
+
+  function MyApp() {
+    (0, _classCallCheck2.default)(this, MyApp);
+    return (0, _possibleConstructorReturn2.default)(this, (0, _getPrototypeOf2.default)(MyApp).apply(this, arguments));
+  }
+
+  (0, _createClass2.default)(MyApp, [{
+    key: "render",
+    value: function render() {
+      var _this$props = this.props,
+          Component = _this$props.Component,
+          pageProps = _this$props.pageProps;
+      var name = pageProps.name;
+      return _react.default.createElement(_app.Container, null, _react.default.createElement(_head.default, null, _react.default.createElement("title", null, name)), _react.default.createElement(Component, pageProps));
+    }
+  }], [{
+    key: "getInitialProps",
+    value: function () {
+      var _getInitialProps = (0, _asyncToGenerator2.default)(
+      /*#__PURE__*/
+      _regenerator.default.mark(function _callee(_ref) {
+        var Component, router, ctx, pageProps;
+        return _regenerator.default.wrap(function _callee$(_context) {
+          while (1) {
+            switch (_context.prev = _context.next) {
+              case 0:
+                Component = _ref.Component, router = _ref.router, ctx = _ref.ctx;
+                pageProps = {};
+
+                if (!Component.getInitialProps) {
+                  _context.next = 6;
+                  break;
+                }
+
+                _context.next = 5;
+                return Component.getInitialProps(ctx);
+
+              case 5:
+                pageProps = _context.sent;
+
+              case 6:
+                return _context.abrupt("return", {
+                  pageProps: pageProps
+                });
+
+              case 7:
+              case "end":
+                return _context.stop();
+            }
+          }
+        }, _callee, this);
+      }));
+
+      return function getInitialProps(_x) {
+        return _getInitialProps.apply(this, arguments);
+      };
+    }()
+  }]);
+  return MyApp;
+}(_app.default);
+
+exports.default = MyApp;

--- a/packages/react-sprucebot/lib/skillskit/next/_document.js
+++ b/packages/react-sprucebot/lib/skillskit/next/_document.js
@@ -47,7 +47,7 @@ function (_Document) {
       var bodyClassName = this.props.config && this.props.config.SLUG ? " skill-".concat(this.props.config.SLUG) : '';
       return _react.default.createElement("html", {
         className: "skill".concat(bodyClassName)
-      }, _react.default.createElement(_document.Head, null, _react.default.createElement("title", null, this.props.name), _react.default.createElement("meta", {
+      }, _react.default.createElement(_document.Head, null, _react.default.createElement("meta", {
         name: "viewport",
         content: "width=device-width, initial-scale=1"
       }), _react.default.createElement("link", {

--- a/packages/react-sprucebot/src/Sprucebot.js
+++ b/packages/react-sprucebot/src/Sprucebot.js
@@ -36,6 +36,7 @@ import * as Typography from './components/Typography/Typography'
 import * as List from './components/List/List'
 import * as Tabs from './components/Tabs/Tabs'
 import skill from './skillskit'
+import _app from './skillskit/next/_app'
 import _document from './skillskit/next/_document'
 import Page from './skillskit/next/Page'
 import withStore, { createStore } from './skillskit/store/withStore'
@@ -62,6 +63,7 @@ const Sprucebot = {
 	},
 	lang,
 	skill,
+	_app,
 	_document,
 	Page,
 	withStore,

--- a/packages/react-sprucebot/src/skillskit/next/_app.js
+++ b/packages/react-sprucebot/src/skillskit/next/_app.js
@@ -1,0 +1,29 @@
+import App, { Container } from 'next/app'
+import Head from 'next/head'
+import React from 'react'
+
+export default class MyApp extends App {
+	static async getInitialProps({ Component, router, ctx }) {
+		let pageProps = {}
+
+		if (Component.getInitialProps) {
+			pageProps = await Component.getInitialProps(ctx)
+		}
+
+		return { pageProps }
+	}
+
+	render() {
+		const { Component, pageProps } = this.props
+		const { name } = pageProps
+
+		return (
+			<Container>
+				<Head>
+					<title>{name}</title>
+				</Head>
+				<Component {...pageProps} />
+			</Container>
+		)
+	}
+}

--- a/packages/react-sprucebot/src/skillskit/next/_document.js
+++ b/packages/react-sprucebot/src/skillskit/next/_document.js
@@ -41,7 +41,6 @@ export default class MyDocument extends Document {
 		return (
 			<html className={`skill${bodyClassName}`}>
 				<Head>
-					<title>{this.props.name}</title>
 					<meta name="viewport" content="width=device-width, initial-scale=1" />
 					<link
 						href={


### PR DESCRIPTION
## Description

NextJS introduced `_app.js` for persistent layout that modifies with the page, and as a part of that started erroring if you included <title> tags in _document.js.

```
Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title
Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title
Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title
Warning: <title> should not be used in _document.js's <Head>. https://err.sh/next.js/no-document-title
```

This is a noop for skills since they all run in iframes, but fixes the error and opens the door for us to use _app.js in the future.

## Type

- [x] Feature
- [x] Bug
- [ ] Tech debt
