### PR TITLE
fix: Add _app.js, nix title in _document bug from Next7 migration

### DIFF
--- a/packages/spruce-next-helpers/src/skillskit/next/_app.js
+++ b/packages/spruce-next-helpers/src/skillskit/next/_app.js
@@ -1,0 +1,29 @@
+import App, { Container } from 'next/app'
+import Head from 'next/head'
+import React from 'react'
+
+export default class MyApp extends App {
+	static async getInitialProps({ Component, router, ctx }) {
+		let pageProps = {}
+
+		if (Component.getInitialProps) {
+			pageProps = await Component.getInitialProps(ctx)
+		}
+
+		return { pageProps }
+	}
+
+	render() {
+		const { Component, pageProps } = this.props
+		const { name } = pageProps
+
+		return (
+			<Container>
+				<Head>
+					<title>{name}</title>
+				</Head>
+				<Component {...pageProps} />
+			</Container>
+		)
+	}
+}

--- a/packages/spruce-next-helpers/src/skillskit/next/_document.js
+++ b/packages/spruce-next-helpers/src/skillskit/next/_document.js
@@ -41,7 +41,6 @@ export default class MyDocument extends Document {
 		return (
 			<html className={`skill${bodyClassName}`}>
 				<Head>
-					<title>{this.props.name}</title>
 					<meta name="viewport" content="width=device-width, initial-scale=1" />
 					<link
 						href={


### PR DESCRIPTION
This was accidentally merged into dev, redoing it for the folder rename hoola.

## Type

- [x] Feature
- [x] Bug
- [ ] Tech debt
