### PR TITLE
Switch most instances of icon injection to configuration pattern

### DIFF
--- a/packages/react-heartwood-components/.storybook/data/actions.js
+++ b/packages/react-heartwood-components/.storybook/data/actions.js
@@ -4,7 +4,10 @@ import EditIcon from '../../static/assets/icons/Interface-Essential/Edit/pencil-
 
 export const singleAction = [
 	{
-		icon: <Icon icon="edit" isLineIcon className="btn__line-icon" />,
+		icon: {
+			name: 'edit',
+			isLineIcon: true
+		},
 		kind: 'simple'
 	}
 ]

--- a/packages/react-heartwood-components/src/components/BigCalendar/EventDetails-story.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/EventDetails-story.js
@@ -7,7 +7,6 @@ import EventDetails, {
 	EventDetailsHeader,
 	EventDetailsFooter
 } from './components/EventDetails'
-import Icon from '../Icon/Icon'
 import NoteIcon from '../../../static/assets/icons/Interface-Essential/Form-Edition/paper-write.svg'
 import ServiceIcon from '../../../static/assets/icons/Interface-Essential/Lists/list-bullets-1.svg'
 import StatusIcon from '../../../static/assets/icons/Interface-Essential/Time/stopwatch.svg'
@@ -47,44 +46,44 @@ stories.add('Event Details', () => (
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: 'Mon, Oct 27, 2018',
 						subtitle: '9–10:30am'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle:
 							'<p>Beard Tinting</p><p>Head Shave</p><p>$42 | 1hr 30min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Not checked in',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'

--- a/packages/react-heartwood-components/src/components/BigCalendar/components/EventBlock/EventBlock.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/components/EventBlock/EventBlock.js
@@ -28,8 +28,8 @@ const EventBlock = (props: Props) => {
 		>
 			{block.leftIcons && block.leftIcons.length > 0 && (
 				<div className="left-icons">
-					{block.leftIcons.map(icon => (
-						<span title={icon.title}>
+					{block.leftIcons.map((icon, idx) => (
+						<span title={icon.title} key={`${icon.title}-idx`}>
 							<Icon {...icon} />
 						</span>
 					))}
@@ -55,8 +55,8 @@ const EventBlock = (props: Props) => {
 			)}
 			{block.rightIcons && block.rightIcons.length > 0 && (
 				<div className="right-icons">
-					{block.rightIcons.map(icon => (
-						<span title={icon.title}>
+					{block.rightIcons.map((icon, idx) => (
+						<span title={icon.title} key={`${icon.title}-idx`}>
 							<Icon {...icon} />
 						</span>
 					))}

--- a/packages/react-heartwood-components/src/components/BigCalendar/components/EventDetails/components/EventDetailsHeader/EventDetailsHeader.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/components/EventDetails/components/EventDetailsHeader/EventDetailsHeader.js
@@ -26,7 +26,9 @@ const EventDetailsHeader = (props: Props) => {
 					onClick={onClickBack}
 					isSmall
 					className="event-details-header__button"
-					icon={<BackIcon />}
+					icon={{
+						customIcon: BackIcon
+					}}
 				/>
 			)}
 			<div className="event-details-header__text-wrapper">
@@ -39,7 +41,9 @@ const EventDetailsHeader = (props: Props) => {
 					onClick={onClickClose}
 					isSmall
 					className="event-details-header__button"
-					icon={<Icon icon="close" />}
+					icon={{
+						customIcon: BackIcon
+					}}
 				/>
 			</div>
 		</div>

--- a/packages/react-heartwood-components/src/components/BigCalendar/storyEvents.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/storyEvents.js
@@ -1,6 +1,5 @@
 import moment from 'moment'
 
-import Icon from '../Icon/Icon'
 import NoteIcon from '../../../static/assets/icons/Interface-Essential/Form-Edition/paper-write.svg'
 import ServiceIcon from '../../../static/assets/icons/Interface-Essential/Lists/list-bullets-1.svg'
 import StatusIcon from '../../../static/assets/icons/Interface-Essential/Time/stopwatch.svg'
@@ -33,43 +32,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '1-3pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Hair Tinting</p><p>$70 | 2hrs</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Confirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -146,43 +145,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '8:45-9:30am'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>The Ultimate</p><p>$70 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Services Complete',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -241,43 +240,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '9:15-10:45am'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Spruced Up Shave</p><p>$40 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Paid',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -349,43 +348,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '4:30-6:30pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Wax</p><p>$70 | 2hr</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Confirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Mark as late'
@@ -459,43 +458,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '1-1:45pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>The Ultimate</p><p>$70 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Confirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -554,43 +553,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '10:30-11:15am'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Nose Wax</p><p>$7 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Checked In',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -649,43 +648,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '11:30am-12:45pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>24k Gold Facial</p><p>$100 | 1hr 15min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Late',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -759,43 +758,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '2:15-3pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Brow Wax</p><p>$10 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Confirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -854,43 +853,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '1-3pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Hair Tinting</p><p>$70 | 2hrs</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Confirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -967,43 +966,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '8:45-9:30am'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>The Ultimate</p><p>$70 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Late',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -1059,43 +1058,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '2:15-3pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Head Shave</p><p>$30 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Confirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -1154,43 +1153,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '3:15-4pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Young Spruce</p><p>$23 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Confirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -1249,43 +1248,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '10:15-11am'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Beard Trim</p><p>$12 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Unpaid',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -1344,43 +1343,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '12:15-2pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>The Ultimate</p><p>$70 | 1hr 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Confirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -1457,43 +1456,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '11:30am-12:45pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Signature</p><p>$40 | 1hr 15min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Checked In',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -1570,43 +1569,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '2-2:45pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Head Shave</p><p>$70 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Confirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -1665,43 +1664,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '3-3:45pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Signature Follow-up</p><p>Free | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Unconfirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Confirm appointment'
@@ -1760,43 +1759,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '9:45-10:15am'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Beard Tinting</p><p>$70 | 1hr 30min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Checked In',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -1873,43 +1872,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '12-12:45pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Brow Wax</p><p>$20 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Confirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -1968,43 +1967,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '2-2:45pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Nose Wax</p><p>$15 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Confirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -2063,43 +2062,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '10:30-11:45am'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>24k Gold Facial</p><p>$100 | 1hr 15min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Checked In',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Check guest in'
@@ -2173,43 +2172,43 @@ export default [
 						}
 					},
 					{
-						icon: <NoteIcon isLineIcon />,
+						icon: { customIcon: NoteIcon, isLineIcon: true },
 						title: 'Prefers products that aren’t tested on animals.',
 						subtitle: 'Caleigh Jerde, 4 months ago',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <Icon icon="date" isLineIcon />,
+						icon: { name: 'date', isLineIcon: true },
 						title: `${today.format('ddd, MMM D, YYYY')}`,
 						subtitle: '1:30-2:15pm'
 					},
 					{
-						icon: <ServiceIcon isLineIcon />,
+						icon: { customIcon: ServiceIcon, isLineIcon: true },
 						title: 'Services',
 						subtitle: '<p>Clothing Consult</p><p>$70 | 45min</p>',
 						actions: [
 							{
 								kind: 'simple',
-								icon: <Icon icon="add" />
+								icon: { name: 'add' }
 							},
 							{
 								kind: 'simple',
-								icon: <Icon icon="edit" className="btn__line-icon" />
+								icon: { name: 'edit', isLineIcon: true }
 							}
 						]
 					},
 					{
-						icon: <StatusIcon isLineIcon />,
+						icon: { customIcon: StatusIcon, isLineIcon: true },
 						title: 'Status',
 						subtitle: 'Unconfirmed',
 						contextMenu: {
 							isSimple: true,
-							icon: <Icon icon="edit" className="btn__line-icon" />,
+							icon: { name: 'edit', isLineIcon: true },
 							actions: [
 								{
 									text: 'Confirm appointment'

--- a/packages/react-heartwood-components/src/components/Button/Button-story.js
+++ b/packages/react-heartwood-components/src/components/Button/Button-story.js
@@ -41,14 +41,10 @@ stories
 			disabled={boolean('disabled', false)}
 			isLoading={boolean('isLoading', false)}
 			isSmall={boolean('isSmall', false)}
-			icon={
-				icon ? (
-					<Icon
-						icon={text('icon', '')}
-						className={text('iconClassName', 'btn__line-icon')}
-					/>
-				) : null
-			}
+			icon={{
+				name: text('icon', ''),
+				className: text('iconClassName', 'btn__line-icon')
+			}}
 			href={text('href', '')}
 			target={text('target', '')}
 			onClick={text('onClick', '() => console.log("you clicked")')}
@@ -65,14 +61,10 @@ stories
 			disabled={boolean('disabled', false)}
 			isLoading={boolean('isLoading', false)}
 			isSmall={boolean('isSmall', false)}
-			icon={
-				icon ? (
-					<Icon
-						icon={text('icon', '')}
-						className={text('iconClassName', 'btn__line-icon')}
-					/>
-				) : null
-			}
+			icon={{
+				name: text('icon', ''),
+				className: text('iconClassName', 'btn__line-icon')
+			}}
 			href={text('href', '')}
 			target={text('target', '')}
 			onClick={text('onClick', '() => console.log("you clicked")')}
@@ -89,14 +81,10 @@ stories
 			disabled={boolean('disabled', false)}
 			isLoading={boolean('isLoading', false)}
 			isSmall={boolean('isSmall', false)}
-			icon={
-				icon ? (
-					<Icon
-						icon={text('icon', '')}
-						className={text('iconClassName', 'btn__line-icon')}
-					/>
-				) : null
-			}
+			icon={{
+				name: text('icon', ''),
+				className: text('iconClassName', 'btn__line-icon')
+			}}
 			href={text('href', '')}
 			target={text('target', '')}
 			onClick={text('onClick', '() => console.log("you clicked")')}
@@ -113,14 +101,10 @@ stories
 			disabled={boolean('disabled', false)}
 			isLoading={boolean('isLoading', false)}
 			isSmall={boolean('isSmall', false)}
-			icon={
-				icon ? (
-					<Icon
-						icon={text('icon', '')}
-						className={text('iconClassName', 'btn__line-icon')}
-					/>
-				) : null
-			}
+			icon={{
+				name: text('icon', ''),
+				className: text('iconClassName', 'btn__line-icon')
+			}}
 			href={text('href', '')}
 			target={text('target', '')}
 			onClick={text('onClick', '() => console.log("you clicked")')}

--- a/packages/react-heartwood-components/src/components/Button/Button.js
+++ b/packages/react-heartwood-components/src/components/Button/Button.js
@@ -8,6 +8,7 @@ import SingletonRouter from 'next/router'
 import Link from 'next/link'
 import type { Props as LinkProps } from 'next/link'
 import Loader from '../Loader/Loader'
+import Icon from '../Icon/Icon'
 
 export type Props = {
 	/** Optional class to add to the button. */
@@ -88,9 +89,18 @@ const Button = (props: Props) => {
 		<span className="btn__inner">
 			{icon && (
 				<span className="btn__icon-wrapper">
-					{React.cloneElement(icon, {
-						className: cx('btn__icon', icon.props.className)
-					})}
+					<Icon
+						customIcon={icon.customIcon}
+						icon={icon.name}
+						isLineIcon={icon.isLineIcon}
+						className={cx(
+							{
+								btn__icon: true,
+								'btn__line-icon': icon.isLineIcon
+							},
+							icon.className
+						)}
+					/>
 				</span>
 			)}
 			{text && <span className="btn__text">{text}</span>}

--- a/packages/react-heartwood-components/src/components/Card/Card-story.js
+++ b/packages/react-heartwood-components/src/components/Card/Card-story.js
@@ -78,7 +78,7 @@ stories
 				<CardHeader
 					title={text('title', 'Please update your credit card')}
 					labelText={text('labelText', 'Billing failure')}
-					labelIcon={<AlertIcon3 />}
+					labelIcon={{ customIcon: AlertIcon3 }}
 				/>
 				<CardBody>
 					<Text className="u-lh-loose u-color-body-light">
@@ -217,9 +217,10 @@ stories
 				<CardHeader
 					labelText={text('Label Text', '')}
 					labelIcon={
-						boolean('Label Icon', false) && (
-							<LockIcon2 className="u-icon__no-fill u-icon__stroke" />
-						)
+						boolean('Label Icon', false) && {
+							customIcon: LockIcon2,
+							isLineIcon: true
+						}
 					}
 					title={text('Title', 'Get the most out of Spruce')}
 					actions={

--- a/packages/react-heartwood-components/src/components/Card/components/CardHeader.js
+++ b/packages/react-heartwood-components/src/components/Card/components/CardHeader.js
@@ -4,6 +4,7 @@ import React, { Fragment } from 'react'
 import type { Element, Node } from 'react'
 import cx from 'classnames'
 import Button from '../../Button/Button'
+import Icon from '../../Icon/Icon'
 import type { Props as ButtonProps } from '../../Button/Button'
 import type { Props as ContextMenuProps } from '../../ContextMenu/ContextMenu'
 
@@ -33,13 +34,14 @@ const CardHeader = (props: CardHeaderProps) => {
 				<div className="card-header__text">
 					{(labelText || labelIcon) && (
 						<div className="card-header__label">
-							{labelIcon &&
-								React.cloneElement(labelIcon, {
-									className: cx(
-										'card-header__label-icon',
-										labelIcon.props.className
-									)
-								})}
+							{labelIcon && (
+								<Icon
+									customIcon={labelIcon.customIcon}
+									icon={labelIcon.name}
+									isLineIcon={labelIcon.isLineIcon}
+									className={cx('card-header__label-icon', labelIcon.className)}
+								/>
+							)}
 							{labelText && (
 								<span className="card-header__label-text">{labelText}</span>
 							)}

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.js
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.js
@@ -5,7 +5,9 @@ import { VelocityTransitionGroup } from 'velocity-react'
 import Button from '../Button/Button'
 import type { Props as ButtonProps } from '../Button/Button'
 import ButtonGroup from '../ButtonGroup/ButtonGroup'
-import Icon from '../../../static/assets/icons/Interface-Essential/Menu/navigation-menu-horizontal.svg'
+
+import Icon from '../Icon/Icon'
+import MoreIcon from '../../../static/assets/icons/Interface-Essential/Menu/navigation-menu-horizontal.svg'
 
 export type Props = {
 	/** The actions to be shown on tap/click */
@@ -97,15 +99,7 @@ export default class ContextMenu extends Component<Props, State> {
 					kind={isSimple ? 'simple' : ''}
 					className="context-menu__button"
 					onClick={this.handleToggle}
-					icon={
-						icon ? (
-							React.cloneElement(icon, {
-								className: 'btn__line-icon'
-							})
-						) : (
-							<Icon className="btn__line-icon" />
-						)
-					}
+					icon={icon || { customIcon: MoreIcon, isLineIcon: true }}
 				/>
 				<VelocityTransitionGroup
 					enter={{

--- a/packages/react-heartwood-components/src/components/Core/components/HeaderPrimary/components/UserMenu/UserMenu.js
+++ b/packages/react-heartwood-components/src/components/Core/components/HeaderPrimary/components/UserMenu/UserMenu.js
@@ -51,7 +51,10 @@ const UserMenu = (props: Props) => {
 							<Button
 								kind="simple"
 								text="Switch Accounts"
-								icon={<SwitchIcon className="btn__line-icon" />}
+								icon={{
+									customIcon: SwitchIcon,
+									isLineIcon: true
+								}}
 								isFullWidth
 							/>
 						</li>
@@ -59,7 +62,10 @@ const UserMenu = (props: Props) => {
 							<Button
 								kind="simple"
 								text="Log Out"
-								icon={<LogoutIcon className="btn__line-icon" />}
+								icon={{
+									customIcon: LogoutIcon,
+									isLineIcon: true
+								}}
 								isFullWidth
 							/>
 						</li>

--- a/packages/react-heartwood-components/src/components/Core/components/Sidebar/components/SidebarExpander/SidebarExpander.js
+++ b/packages/react-heartwood-components/src/components/Core/components/Sidebar/components/SidebarExpander/SidebarExpander.js
@@ -20,7 +20,9 @@ const SidebarExpander = (props: Props) => {
 	return (
 		<div className="sidebar-collapse">
 			<Button
-				icon={isExpanded ? <CollapseIcon2 /> : <ExpandIcon2 />}
+				icon={{
+					customIcon: isExpanded ? CollapseIcon2 : ExpandIcon2
+				}}
 				onClick={() => {
 					toggleExpanded()
 					forceCloseSidebar()

--- a/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.js
+++ b/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.js
@@ -141,7 +141,9 @@ export default class Autosuggest extends Component<Props, State> {
 						<Button
 							isSmall
 							className="text-input__clear-btn"
-							icon={<ClearIcon />}
+							icon={{
+								customIcon: ClearIcon
+							}}
 							onClick={this.handleClearInput}
 						/>
 					)}

--- a/packages/react-heartwood-components/src/components/Forms/components/Tag/Tag.js
+++ b/packages/react-heartwood-components/src/components/Forms/components/Tag/Tag.js
@@ -28,7 +28,12 @@ const Tag = (props: Props) => {
 	return (
 		<div className={parentClass}>
 			<span className="tag__text">{text}</span>
-			<Button className="tag__btn" icon={<CloseIcon />} />
+			<Button
+				className="tag__btn"
+				icon={{
+					customIcon: CloseIcon
+				}}
+			/>
 		</div>
 	)
 }

--- a/packages/react-heartwood-components/src/components/Icon/Icon.js
+++ b/packages/react-heartwood-components/src/components/Icon/Icon.js
@@ -27,18 +27,18 @@ const key = {
 }
 
 const Icon = (props: Props) => {
-	const { icon, isLineIcon, ...rest } = props
+	const { icon, customIcon, isLineIcon, className, ...rest } = props
 
-	if (!icon || !key[icon.toLowerCase()]) {
+	if (!customIcon && (!icon || !key[icon.toLowerCase()])) {
 		// TODO: handle logging
 		// console.error(`<Icon /> could not find an icon with key ${icon}`)
 		return null
 	}
-	const Handler = key[icon.toLowerCase()]
+	const Handler = customIcon || key[icon.toLowerCase()]
 
 	return (
 		<Handler
-			className={cx({
+			className={cx(className, {
 				'u-icon__no-fill': isLineIcon,
 				'u-icon__stroke': isLineIcon
 			})}

--- a/packages/react-heartwood-components/src/components/ImageCropper/ImageCropper.js
+++ b/packages/react-heartwood-components/src/components/ImageCropper/ImageCropper.js
@@ -88,7 +88,10 @@ export default class ImageCropper extends Component<Props, State> {
 						kind="secondary"
 						className="image-cropper__rotate-btn"
 						text="Rotate Left"
-						icon={<RotateLeftIcon className="btn__line-icon" />}
+						icon={{
+							customIcon: RotateLeftIcon,
+							isLineIcon: true
+						}}
 						disabled={!image}
 						onClick={() => this.handleRotate('left')}
 					/>
@@ -96,7 +99,10 @@ export default class ImageCropper extends Component<Props, State> {
 						kind="secondary"
 						className="image-cropper__rotate-btn"
 						text="Rotate Right"
-						icon={<RotateRightIcon className="btn__line-icon" />}
+						icon={{
+							customIcon: RotateRightIcon,
+							isLineIcon: true
+						}}
 						disabled={!image}
 						onClick={() => this.handleRotate('right')}
 					/>

--- a/packages/react-heartwood-components/src/components/List/List-story.js
+++ b/packages/react-heartwood-components/src/components/List/List-story.js
@@ -146,7 +146,10 @@ stories
 						title: 'Clean Up',
 						subtitle: '$20 | 15min',
 						contextMenu: {
-							icon: <EditIcon />,
+							icon: {
+								name: 'edit',
+								isLineIcon: true
+							},
 							size: 'large',
 							isSimple: true,
 							actions: threeTextActions
@@ -156,7 +159,10 @@ stories
 						title: 'Shampoo',
 						subtitle: '$7 | 45min',
 						contextMenu: {
-							icon: <Icon icon="edit" isLineIcon />,
+							icon: {
+								name: 'edit',
+								isLineIcon: true
+							},
 							size: 'large',
 							isSimple: true,
 							actions: threeTextActions
@@ -166,7 +172,10 @@ stories
 						title: 'Young Spruce',
 						subtitle: '$23 | 50min',
 						contextMenu: {
-							icon: <Icon icon="edit" isLineIcon />,
+							icon: {
+								name: 'edit',
+								isLineIcon: true
+							},
 							size: 'large',
 							isSimple: true,
 							actions: threeTextActions
@@ -179,17 +188,26 @@ stories
 				isSmall={boolean('isSmall', false)}
 				items={object('items: dates list', [
 					{
-						icon: <DateIcon className="u-icon__no-fill u-icon__stroke" />,
+						icon: {
+							customIcon: DateIcon,
+							isLineIcon: true
+						},
 						title: 'Wed, Nov 28, 2018',
 						subtitle: 'Closed'
 					},
 					{
-						icon: <DateIcon className="u-icon__no-fill u-icon__stroke" />,
+						icon: {
+							customIcon: DateIcon,
+							isLineIcon: true
+						},
 						title: 'Thu, Nov 29, 2018',
 						subtitle: 'Closed'
 					},
 					{
-						icon: <DateIcon className="u-icon__no-fill u-icon__stroke" />,
+						icon: {
+							customIcon: DateIcon,
+							isLineIcon: true
+						},
 						title: 'Wed, Dec 25, 2018',
 						subtitle: 'Closed'
 					}
@@ -249,15 +267,22 @@ stories
 							kind: 'simple'
 						},
 						{
-							icon: <CalendarIcon className="btn__line-icon" />,
+							icon: {
+								customIcon: CalendarIcon,
+								isLineIcon: true
+							},
 							kind: 'simple'
 						},
 						{
-							icon: <ArrowBack />,
+							icon: {
+								customIcon: ArrowBack
+							},
 							kind: 'simple'
 						},
 						{
-							icon: <ArrowForward />,
+							icon: {
+								customIcon: ArrowForward
+							},
 							kind: 'simple'
 						}
 					]

--- a/packages/react-heartwood-components/src/components/List/components/ListItem/ListItem.js
+++ b/packages/react-heartwood-components/src/components/List/components/ListItem/ListItem.js
@@ -4,6 +4,7 @@ import type { Node } from 'react'
 import cx from 'classnames'
 import Avatar from '../../../Avatar/Avatar'
 import Button from '../../../Button/Button'
+import Icon from '../../../Icon/Icon'
 import type { Props as ButtonProps } from '../../../Button/Button'
 import ContextMenu from '../../../ContextMenu/ContextMenu'
 import type { Props as ContextMenuProps } from '../../../ContextMenu/ContextMenu'
@@ -24,7 +25,7 @@ export type Props = {
 	image?: string,
 
 	/** Inline svg icon */
-	icon?: Node,
+	icon?: object,
 
 	/** Set true when the list can be reordered */
 	isDraggable?: boolean,
@@ -51,6 +52,7 @@ const ListItem = (props: Props) => {
 		actions,
 		contextMenu
 	} = props
+
 	const parentClass = cx('list-item', {
 		'list-item-title-only': !subtitle,
 		'list-item--is-draggable': isDraggable
@@ -60,17 +62,14 @@ const ListItem = (props: Props) => {
 		<li className={parentClass}>
 			{(image || icon || avatar) && !isDraggable && (
 				<div className="list-item__image-wrapper">
-					{icon &&
-						React.cloneElement(icon, {
-							className: cx(
-								'list-item__icon',
-								icon.props && icon.props.className,
-								{
-									'u-icon__no-fill': icon.props && icon.props.isLineIcon,
-									'u-icon__stroke': icon.props && icon.props.isLineIcon
-								}
-							)
-						})}
+					{icon && (
+						<Icon
+							customIcon={icon.customIcon}
+							icon={icon.name}
+							isLineIcon={icon.isLineIcon}
+							className={cx('list-item__icon', icon.className, {})}
+						/>
+					)}
 					{image && (
 						<img
 							src={image}

--- a/packages/react-heartwood-components/src/components/Modal/components/ModalHeader/ModalHeader.js
+++ b/packages/react-heartwood-components/src/components/Modal/components/ModalHeader/ModalHeader.js
@@ -20,10 +20,14 @@ const ModalHeader = (props: Props) => {
 	return (
 		<div className="modal-header">
 			<div className="modal-header__title-wrapper">
-				{handleGoBack && <Button isSmall icon={<ArrowBack />} />}
+				{handleGoBack && <Button isSmall icon={{ customIcon: ArrowBack }} />}
 				<h2 className="modal-header__title">{title}</h2>
 			</div>
-			<Button isSmall icon={<CloseIcon />} onClick={onRequestClose} />
+			<Button
+				isSmall
+				icon={{ customIcon: CloseIcon }}
+				onClick={onRequestClose}
+			/>
 		</div>
 	)
 }

--- a/packages/react-heartwood-components/src/components/Pagination/Pagination.js
+++ b/packages/react-heartwood-components/src/components/Pagination/Pagination.js
@@ -91,7 +91,7 @@ const Pagination = (props: Props) => {
 				onClick={onClickBack}
 				isSmall
 				className="pagination__btn"
-				icon={<ArrowBack />}
+				icon={{ customIcon: ArrowBack }}
 				disabled={currentPage === 0}
 			/>
 			{showPages &&
@@ -120,7 +120,7 @@ const Pagination = (props: Props) => {
 				onClick={onClickNext}
 				isSmall
 				className="pagination__btn"
-				icon={<ArrowNext />}
+				icon={{ customIcon: ArrowNext }}
 				disabled={currentPage >= totalPages - 1}
 			/>
 			{showJump && onJump && (

--- a/packages/react-heartwood-components/src/components/Toast/Toast.js
+++ b/packages/react-heartwood-components/src/components/Toast/Toast.js
@@ -17,7 +17,7 @@ const ToastHeader = (props: HeaderProps) => {
 	return (
 		<div className="toast__header">
 			<p>{headline}</p>
-			<Button icon={<CloseIcon />} onClick={onRemove} />
+			<Button icon={{ customIcon: CloseIcon }} onClick={onRemove} />
 		</div>
 	)
 }


### PR DESCRIPTION
[SBL-1139](https://sprucelabsai.atlassian.net/browse/SBL-1139)

## Description

This is a request from @liquidg3 to switch Heartwood to specifying icons by configuration, rather than injecting custom `Icon` components or specifying custom icons w/ heartwood classes.

Most instances of Icons are still "custom," as you can see below, but the SVG imported is passed as a reference instead of as a component (see `customIcon` references below).

This is obviously a large change since `Button` and `List` are widely used, and both passthrough to `Icon`. Please advise if you have any concerns with external projects that have imported any affected component.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt
