### PR TITLE
fix regression on SBL-1171 - datepicker not closing on clicking outside

### DIFF
--- a/packages/react-heartwood-components/src/components/BigCalendar/components/HeaderControls/HeaderControls.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/components/HeaderControls/HeaderControls.js
@@ -128,6 +128,10 @@ class HeaderControls extends Component<Props, State> {
 						/>
 						{isDatePickerShown && !shouldResetDatePicker && (
 							<div className="bigcalendar_date-picker">
+								<div
+									className="bigcalendar_date-picker-underlay"
+									onClick={() => this.toggleDatePicker()}
+								/>
 								<DatePicker
 									date={selectedDate}
 									onSelectDate={this.onSelectDate}


### PR DESCRIPTION
## Description

Fixes regression and allows clicking outside of datepicker to close

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt
