### PR TITLE
Minor Styling Fixes

### DIFF
--- a/packages/heartwood-components/components/02-forms/select.scss
+++ b/packages/heartwood-components/components/02-forms/select.scss
@@ -35,10 +35,19 @@
 		cursor: pointer;
 
 		&[disabled] {
-			color: $c-grey-01;
-			background-color: $c-grey-02;
-			border: none;
+			color: rgba($c-primary, 0.5);
+			border-color: rgba($c-primary, 0.5);
 			cursor: not-allowed;
+
+			&[readonly] {
+				border: none;
+				background-color: $c-grey-00;
+				color: $c-text-light;
+
+				+ .select__icon {
+					display: none;
+				}
+			}
 		}
 	}
 }

--- a/packages/heartwood-components/stylesheets/core/_colors.scss
+++ b/packages/heartwood-components/stylesheets/core/_colors.scss
@@ -39,9 +39,9 @@ $c-border-light: $c-grey-01 !default;
 /**
 Primaries
 */
-$c-primary: #0076D6 !default;
-$c-primary-light: #0099FF !default;
-$c-primary-dark: #005499 !default;
+$c-primary: #1953cb !default;
+$c-primary-light: #3873d7 !default;
+$c-primary-dark: #072e99 !default;
 
 /**
 Secondaries
@@ -68,5 +68,3 @@ $c-ui-critical: #e51b3d !default;
 $c-ui-critical-light: #ffdad3 !default;
 $c-ui-critical-lighter: #ffebec !default;
 $c-ui-critical-dark: #bf060c !default;
-
-


### PR DESCRIPTION
## Description
Updates the styling of `select`s that are `disabled` or `readonly`. Also includes an update to `$c-primary` colors to match the latest Heartwood designs.

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt
