### PR TITLE
Allow View and HeaderPrimary to set necessary search props

### DIFF
--- a/packages/react-heartwood-components/src/components/Core/components/HeaderPrimary/HeaderPrimary.js
+++ b/packages/react-heartwood-components/src/components/Core/components/HeaderPrimary/HeaderPrimary.js
@@ -23,7 +23,13 @@ type Props = {
 	toggleSidebarVisibility: Function,
 
 	/** Set true to show the sidebar (small screens only) */
-	sidebarIsVisible: boolean
+	sidebarIsVisible: boolean,
+
+	/** Passthrough function to show search suggestion value */
+	getSearchSuggestionValue?: Function,
+
+	/** Passthrough function to render search suggestions */
+	renderSearchSuggestion?: Function
 }
 
 export default class HeaderPrimary extends Component<Props, State> {
@@ -72,7 +78,9 @@ export default class HeaderPrimary extends Component<Props, State> {
 			user,
 			business,
 			toggleSidebarVisibility,
-			sidebarIsVisible
+			sidebarIsVisible,
+			getSearchSuggestionValue,
+			renderSearchSuggestion
 		} = this.props
 		return (
 			<header className="header-primary" ref={ref => (this.ref = ref)}>
@@ -97,12 +105,16 @@ export default class HeaderPrimary extends Component<Props, State> {
 				<div className="header-primary__right">
 					{user ? (
 						<Fragment>
-							<Autosuggest
-								className="text-input-small"
-								placeholder="Search anything…"
-								isSmall
-								wrapperClassName="header-primary__autosuggest"
-							/>
+							{getSearchSuggestionValue && renderSearchSuggestion && (
+								<Autosuggest
+									className="text-input-small"
+									placeholder="Search anything…"
+									isSmall
+									wrapperClassName="header-primary__autosuggest"
+									getSuggestionValue={getSearchSuggestionValue}
+									renderSuggestion={renderSearchSuggestion}
+								/>
+							)}
 							<UserMenu
 								menuIsVisible={isUserMenuVisible}
 								toggleMenu={this.toggleUserMenuVisibility}

--- a/packages/react-heartwood-components/src/components/View/View.js
+++ b/packages/react-heartwood-components/src/components/View/View.js
@@ -9,6 +9,8 @@ type Props = {
 	sidebarItems: Array<Object>,
 	user: Object,
 	business: Object,
+	getSearchSuggestionValue?: Function,
+	renderSearchSuggestion?: Function,
 	children: Node
 }
 type State = {
@@ -43,7 +45,14 @@ export default class View extends Component<Props, State> {
 
 	render() {
 		const { sidebarIsVisible, sidebarIsExpanded } = this.state
-		const { sidebarItems, user, business, children } = this.props
+		const {
+			sidebarItems,
+			user,
+			business,
+			getSearchSuggestionValue,
+			renderSearchSuggestion,
+			children
+		} = this.props
 		return (
 			<div
 				className={cx('main-wrapper', {
@@ -63,6 +72,8 @@ export default class View extends Component<Props, State> {
 					business={business}
 					toggleSidebarVisibility={this.toggleSidebarVisibility}
 					sidebarIsVisible={sidebarIsVisible}
+					getSearchSuggestionValue={getSearchSuggestionValue}
+					renderSearchSuggestion={renderSearchSuggestion}
 				/>
 				<main className="main-content">{children}</main>
 			</div>


### PR DESCRIPTION
## Description

When implementing `View` this started throwing warnings, since the required props weren't being passed through.

I'm additionally removing the search-bar if those props aren't provided; I'd imagine we might want to use this view in a logged-in context without search.

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt
