### PR TITLE
fix(heartwood): Remove min-height from .main-content

### DIFF
--- a/packages/heartwood-components/components/99-web/main-content.scss
+++ b/packages/heartwood-components/components/99-web/main-content.scss
@@ -1,5 +1,4 @@
 .main-content {
-	min-height: 100vh;
 	padding-top: rem(48);
 
 	@include gt('medium') {


### PR DESCRIPTION
- It was set to 100vh, but that won't work correctly on mobile devices 
without JS intervention. So let's leave that off, and defer to the pages 
using that class to handle their heights if they desire.

- [x] Feature
- [ ] Bug
- [ ] Tech debt
