### PR TITLE
fix(icons): Don't die if the icon can't be found

### DIFF
--- a/packages/react-heartwood-components/src/components/Icon/Icon.js
+++ b/packages/react-heartwood-components/src/components/Icon/Icon.js
@@ -22,7 +22,8 @@ const Icon = (props: Props) => {
 	const { icon, customIcon, isLineIcon, className, ...rest } = props
 
 	if (!customIcon && (!icon || !icons[icon.toLowerCase()])) {
-		throw new Error(`<Icon /> could not find an icon with key ${icon}`)
+		console.warn(`<Icon /> could not find an icon with key ${icon}.`)
+		return null
 	}
 	const Handler = customIcon || icons[icon.toLowerCase()]
 


### PR DESCRIPTION
- Just don't render it, and console warn.
- I was initially okay with throwing, but a user might get an icon from 
the API and not be the responsible party for it not being in the icon 
list.
- In that case, we should just render nothing.
- We might want to have an error handling hook so the user can determine 
what to do if no icon is found, something to consider for later.