### PR TITLE
feature(tabs): Defer rendering of anchors to downstream code

### DIFF
--- a/packages/react-heartwood-components/src/components/Button/Button.js
+++ b/packages/react-heartwood-components/src/components/Button/Button.js
@@ -1,15 +1,12 @@
 // @flow
-// TODO: Incorporate Next.js router link
 import React from 'react'
 import cx from 'classnames'
 import is from 'is_js'
-import SingletonRouter from 'next/router'
-import Link from 'next/link'
 import Loader from '../Loader/Loader'
 import Icon from '../Icon/Icon'
+import BasicAnchor from '../_utilities/Anchor'
 
 import type { Node, Element } from 'react'
-import type { Props as LinkProps } from 'next/link'
 import type { Props as IconProps } from '../Icon/Icon'
 
 export type Props = {
@@ -46,11 +43,11 @@ export type Props = {
 	/** Click handler. */
 	onClick?: Function,
 
-	/** Props for Next router link: https://nextjs.org/docs/#routing. */
-	linkProps?: LinkProps,
-
 	/** Will be passed back with the on click. */
-	payload?: Object
+	payload?: Object,
+
+	/** Component used to render anchor */
+	AnchorComponent?: Node
 }
 
 const Button = (props: Props) => {
@@ -66,8 +63,8 @@ const Button = (props: Props) => {
 		icon,
 		type,
 		onClick,
-		linkProps,
 		payload,
+		AnchorComponent = BasicAnchor,
 		...rest
 	} = props
 	const btnClass = cx(className, {
@@ -84,12 +81,6 @@ const Button = (props: Props) => {
 	const textClass = cx('btn__text', {
 		'visually-hidden': isIconOnly
 	})
-
-	// Check if the link is relative (client-side) or absolute
-	let linkIsRelative = true
-	if (href && is.url(href)) {
-		linkIsRelative = false
-	}
 
 	const handleClick = (e: any) => {
 		e.currentTarget.blur()
@@ -127,17 +118,10 @@ const Button = (props: Props) => {
 		</button>
 	)
 
-	// Only return a Next link if the href is relative
-	const anchor = linkIsRelative ? (
-		<Link href={href} {...linkProps}>
-			<a className={btnClass} {...rest}>
-				<Inner />
-			</a>
-		</Link>
-	) : (
-		<a href={href} className={btnClass} {...rest}>
+	const anchor = (
+		<AnchorComponent href={href} className={btnClass} {...rest}>
 			<Inner />
-		</a>
+		</AnchorComponent>
 	)
 
 	if (!text && !icon) {

--- a/packages/react-heartwood-components/src/components/Tabs/components/Tab/Tab.js
+++ b/packages/react-heartwood-components/src/components/Tabs/components/Tab/Tab.js
@@ -7,6 +7,12 @@ export type Props = {
 	/** Tab text */
 	text: string,
 
+	/** Should tab be displayed as an anchor, rather than a button? */
+	isAnchor?: boolean,
+
+	/** Method used to render anchor, if isAnchor is true */
+	anchorRenderer?: Function,
+
 	/** Set true if this is the current tab */
 	isCurrent?: boolean,
 
@@ -17,17 +23,29 @@ export type Props = {
 	className?: string
 }
 
-const Tab = (props: Props) => {
-	const { text, isCurrent, className, ...rest } = props
+const Tab = ({
+	isAnchor,
+	anchorRenderer = ({ tabClassNames, isCurrent, text, rest }) => (
+		<a className={tabClassNames} {...rest}>
+			{text}
+		</a>
+	),
+	text,
+	isCurrent,
+	className,
+	...rest
+}: Props) => {
+	const tabClassNames = cx('tab__inner', {
+		'tab--is-current': isCurrent
+	})
+
 	return (
 		<li className={cx('tab', className)}>
-			<Button
-				className={cx('tab__inner', {
-					'tab--is-current': props.isCurrent
-				})}
-				text={props.text}
-				{...rest}
-			/>
+			{isAnchor ? (
+				anchorRenderer({ tabClassNames, isCurrent, text, rest })
+			) : (
+				<Button className={tabClassNames} text={text} {...rest} />
+			)}
 		</li>
 	)
 }

--- a/packages/react-heartwood-components/src/components/Tabs/components/Tab/Tab.js
+++ b/packages/react-heartwood-components/src/components/Tabs/components/Tab/Tab.js
@@ -7,11 +7,8 @@ export type Props = {
 	/** Tab text */
 	text: string,
 
-	/** Should tab be displayed as an anchor, rather than a button? */
-	isAnchor?: boolean,
-
 	/** Method used to render anchor, if isAnchor is true */
-	AnchorComponent?: Function,
+	AnchorComponent?: Node,
 
 	/** Set true if this is the current tab */
 	isCurrent?: boolean,
@@ -23,35 +20,23 @@ export type Props = {
 	className?: string
 }
 
-const DefaultAnchor = ({ className, text, href, target }) => (
-	<a className={className} href={href} target={target}>
-		{text}
-	</a>
-)
-
 const Tab = ({
-	isAnchor,
-	AnchorComponent = DefaultAnchor,
+	AnchorComponent,
 	text,
 	isCurrent,
 	className,
 	...rest
 }: Props) => {
-	const tabActionElementClassNames = cx('tab__inner', {
-		'tab--is-current': isCurrent
-	})
-
 	return (
 		<li className={cx('tab', className)}>
-			{isAnchor ? (
-				<AnchorComponent
-					className={tabActionElementClassNames}
-					text={text}
-					{...rest}
-				/>
-			) : (
-				<Button className={tabActionElementClassNames} text={text} {...rest} />
-			)}
+			<Button
+				AnchorComponent={AnchorComponent}
+				className={cx('tab__inner', {
+					'tab--is-current': isCurrent
+				})}
+				text={text}
+				{...rest}
+			/>
 		</li>
 	)
 }

--- a/packages/react-heartwood-components/src/components/Tabs/components/Tab/Tab.js
+++ b/packages/react-heartwood-components/src/components/Tabs/components/Tab/Tab.js
@@ -11,7 +11,7 @@ export type Props = {
 	isAnchor?: boolean,
 
 	/** Method used to render anchor, if isAnchor is true */
-	anchorRenderer?: Function,
+	AnchorComponent?: Function,
 
 	/** Set true if this is the current tab */
 	isCurrent?: boolean,
@@ -23,28 +23,34 @@ export type Props = {
 	className?: string
 }
 
+const DefaultAnchor = ({ className, text, href, target }) => (
+	<a className={className} href={href} target={target}>
+		{text}
+	</a>
+)
+
 const Tab = ({
 	isAnchor,
-	anchorRenderer = ({ tabClassNames, isCurrent, text, rest }) => (
-		<a className={tabClassNames} {...rest}>
-			{text}
-		</a>
-	),
+	AnchorComponent = DefaultAnchor,
 	text,
 	isCurrent,
 	className,
 	...rest
 }: Props) => {
-	const tabClassNames = cx('tab__inner', {
+	const tabClickElementClassNames = cx('tab__inner', {
 		'tab--is-current': isCurrent
 	})
 
 	return (
 		<li className={cx('tab', className)}>
 			{isAnchor ? (
-				anchorRenderer({ tabClassNames, isCurrent, text, rest })
+				<AnchorComponent
+					className={tabClickElementClassNames}
+					text={text}
+					{...rest}
+				/>
 			) : (
-				<Button className={tabClassNames} text={text} {...rest} />
+				<Button className={tabClickElementClassNames} text={text} {...rest} />
 			)}
 		</li>
 	)

--- a/packages/react-heartwood-components/src/components/Tabs/components/Tab/Tab.js
+++ b/packages/react-heartwood-components/src/components/Tabs/components/Tab/Tab.js
@@ -37,7 +37,7 @@ const Tab = ({
 	className,
 	...rest
 }: Props) => {
-	const tabClickElementClassNames = cx('tab__inner', {
+	const tabActionElementClassNames = cx('tab__inner', {
 		'tab--is-current': isCurrent
 	})
 
@@ -45,12 +45,12 @@ const Tab = ({
 		<li className={cx('tab', className)}>
 			{isAnchor ? (
 				<AnchorComponent
-					className={tabClickElementClassNames}
+					className={tabActionElementClassNames}
 					text={text}
 					{...rest}
 				/>
 			) : (
-				<Button className={tabClickElementClassNames} text={text} {...rest} />
+				<Button className={tabActionElementClassNames} text={text} {...rest} />
 			)}
 		</li>
 	)

--- a/packages/react-heartwood-components/src/components/_utilities/Anchor.js
+++ b/packages/react-heartwood-components/src/components/_utilities/Anchor.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const BasicAnchor = ({ className, children, href, target }) => (
+	<a className={className} href={href} target={target}>
+		{children}
+	</a>
+)
+
+export default BasicAnchor


### PR DESCRIPTION
- This is a bit of a proto for how I want to handle anchor rendering 
generally in react-heartwood; I often want to control anchor rendering 
so that I can instrument client side routing with `next/link`, etc.

- [x] Feature
- [ ] Bug
- [ ] Tech debt
