### PR TITLE
Tabs — Ability to Truncate

### DIFF
--- a/packages/heartwood-components/components/07-navigation/01-tabs/tabs.config.js
+++ b/packages/heartwood-components/components/07-navigation/01-tabs/tabs.config.js
@@ -1,8 +1,8 @@
 module.exports = {
 	title: 'Tabs',
 	collated: true,
-	collator: function(markup, item) {
-        return `<!-- Start: @${item.handle} -->\n<span style="display: inline-block; margin: 0 1rem 1rem 0;">${markup}</span>\n<!-- End: @${item.handle} -->\n`
+	collator: function (markup, item) {
+		return `<!-- Start: @${item.handle} -->\n<div margin: 0 1rem 1rem 0;">${markup}</div>\n<!-- End: @${item.handle} -->\n`
 	},
 	context: {
 		tabs: [

--- a/packages/heartwood-components/components/07-navigation/01-tabs/tabs.hbs
+++ b/packages/heartwood-components/components/07-navigation/01-tabs/tabs.hbs
@@ -1,12 +1,25 @@
-<ul class="tab-group">
+<ul class="tab-group{{#if overflow}} tab-group--spacing-even{{/if}}">
 	{{#each tabs}}
 	{{> @tab text=text isCurrent=isCurrent href=href}}
 	{{/each}}
-	{{#if overflow}}
+	<li class="tab disclosure-tab{{#if overflow}} disclosure-tab--is-visible{{/if}}">{{> @button className="btn-small
+		btn-simple" icon='
+		<path fill-rule="evenodd" fill="none" clip-rule="evenodd" d="M3.375 14.648C4.82475 14.648 6 13.4727 6 12.023C6 10.5732 4.82475 9.39799 3.375 9.39799C1.92525 9.39799 0.75 10.5732 0.75 12.023C0.75 13.4727 1.92525 14.648 3.375 14.648Z"
+		 stroke="#737780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+		<path fill-rule="evenodd" fill="none" clip-rule="evenodd" d="M20.625 14.648C22.0747 14.648 23.25 13.4727 23.25 12.023C23.25 10.5732 22.0747 9.39799 20.625 9.39799C19.1753 9.39799 18 10.5732 18 12.023C18 13.4727 19.1753 14.648 20.625 14.648Z"
+		 stroke="#737780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+		<path fill-rule="evenodd" fill="none" clip-rule="evenodd" d="M12 14.648C13.4497 14.648 14.625 13.4727 14.625 12.023C14.625 10.5732 13.4497 9.39799 12 9.39799C10.5503 9.39799 9.375 10.5732 9.375 12.023C9.375 13.4727 10.5503 14.648 12 14.648Z"
+		 stroke="#737780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />'}}
+	</li>
+	{{!-- {{#if overflow}}
 	<li class="tab">
-	{{> @button className="btn-small btn-simple" icon='<path fill-rule="evenodd" fill="none" clip-rule="evenodd" d="M3.375 14.648C4.82475 14.648 6 13.4727 6 12.023C6 10.5732 4.82475 9.39799 3.375 9.39799C1.92525 9.39799 0.75 10.5732 0.75 12.023C0.75 13.4727 1.92525 14.648 3.375 14.648Z" stroke="#737780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-	<path fill-rule="evenodd" fill="none" clip-rule="evenodd" d="M20.625 14.648C22.0747 14.648 23.25 13.4727 23.25 12.023C23.25 10.5732 22.0747 9.39799 20.625 9.39799C19.1753 9.39799 18 10.5732 18 12.023C18 13.4727 19.1753 14.648 20.625 14.648Z" stroke="#737780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-	<path fill-rule="evenodd" fill="none" clip-rule="evenodd" d="M12 14.648C13.4497 14.648 14.625 13.4727 14.625 12.023C14.625 10.5732 13.4497 9.39799 12 9.39799C10.5503 9.39799 9.375 10.5732 9.375 12.023C9.375 13.4727 10.5503 14.648 12 14.648Z" stroke="#737780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>'}}
-	{{/if}}
+		{{> @button className="btn-small btn-simple" icon='
+		<path fill-rule="evenodd" fill="none" clip-rule="evenodd" d="M3.375 14.648C4.82475 14.648 6 13.4727 6 12.023C6 10.5732 4.82475 9.39799 3.375 9.39799C1.92525 9.39799 0.75 10.5732 0.75 12.023C0.75 13.4727 1.92525 14.648 3.375 14.648Z"
+		 stroke="#737780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+		<path fill-rule="evenodd" fill="none" clip-rule="evenodd" d="M20.625 14.648C22.0747 14.648 23.25 13.4727 23.25 12.023C23.25 10.5732 22.0747 9.39799 20.625 9.39799C19.1753 9.39799 18 10.5732 18 12.023C18 13.4727 19.1753 14.648 20.625 14.648Z"
+		 stroke="#737780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+		<path fill-rule="evenodd" fill="none" clip-rule="evenodd" d="M12 14.648C13.4497 14.648 14.625 13.4727 14.625 12.023C14.625 10.5732 13.4497 9.39799 12 9.39799C10.5503 9.39799 9.375 10.5732 9.375 12.023C9.375 13.4727 10.5503 14.648 12 14.648Z"
+		 stroke="#737780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />'}}
+		{{/if}} --}}
 	</li>
 </ul>

--- a/packages/heartwood-components/components/07-navigation/01-tabs/tabs.hbs
+++ b/packages/heartwood-components/components/07-navigation/01-tabs/tabs.hbs
@@ -2,7 +2,7 @@
 	{{#each tabs}}
 	{{> @tab text=text isCurrent=isCurrent href=href}}
 	{{/each}}
-	<li class="tab disclosure-tab{{#if overflow}} disclosure-tab--is-visible{{/if}}">{{> @button className="btn-small
+	<li class="tab context-tab{{#if overflow}} context-tab--is-visible{{/if}}">{{> @button className="btn-small
 		btn-simple" icon='
 		<path fill-rule="evenodd" fill="none" clip-rule="evenodd" d="M3.375 14.648C4.82475 14.648 6 13.4727 6 12.023C6 10.5732 4.82475 9.39799 3.375 9.39799C1.92525 9.39799 0.75 10.5732 0.75 12.023C0.75 13.4727 1.92525 14.648 3.375 14.648Z"
 		 stroke="#737780" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />

--- a/packages/heartwood-components/components/07-navigation/tabs.scss
+++ b/packages/heartwood-components/components/07-navigation/tabs.scss
@@ -44,13 +44,12 @@
 .tab-group {
 	display: flex;
 	width: 100%;
-	overflow: hidden;
 	border-bottom: 1px solid $c-border;
 
 	&.tab-group--spacing-even {
-
 		.tab {
 			flex: 1 1 auto;
+			padding: 0;
 		}
 	}
 }
@@ -60,6 +59,10 @@
 
 	&.context-tab--is-visible {
 		display: inline;
+	}
+
+	.context-menu {
+		height: 100%;
 	}
 }
 

--- a/packages/heartwood-components/components/07-navigation/tabs.scss
+++ b/packages/heartwood-components/components/07-navigation/tabs.scss
@@ -36,24 +36,48 @@
 	}
 }
 
+.tab .tab__inner {
+	height: auto;
+}
+
 .tab-group {
 	display: flex;
+	width: 100%;
+	padding: 0 spacing('base');
+	overflow: hidden;
 	border-bottom: 1px solid $c-border;
 
-	> .tab > .btn {
-		@include typescale('ui');
-		height: auto;
+	&.tab-group--spacing-even {
+		justify-content: space-between;
 	}
 
-	.btn-icon-only {
-		height: rem(34);
-		width: rem(34);
-		min-width: 0;
-		border-radius: 0;
-	}
+	// > .tab > .btn {
+	// 	@include typescale('ui');
+	// 	height: auto;
+	// }
+
+	// .btn-icon-only {
+	// 	height: rem(34);
+	// 	width: rem(34);
+	// 	min-width: 0;
+	// 	border-radius: 0;
+	// }
 
 	&.tab-group--is-padded {
 		padding-left: spacing('base');
 		padding-right: spacing('base');
 	}
+}
+
+.disclosure-tab {
+	display: none;
+
+	&.disclosure-tab--is-visible {
+		display: inline;
+	}
+}
+
+.tab-group .tab.disclosure-tab .btn {
+	height: 100%;
+	border-radius: 0;
 }

--- a/packages/heartwood-components/components/07-navigation/tabs.scss
+++ b/packages/heartwood-components/components/07-navigation/tabs.scss
@@ -4,9 +4,10 @@
 	flex-flow: column;
 	align-items: center;
 	flex: 0 1 auto;
+	padding: 0 spacing('base');
 
 	+ .tab {
-		margin-left: spacing('base');
+		padding-left: 0;
 	}
 }
 
@@ -43,41 +44,26 @@
 .tab-group {
 	display: flex;
 	width: 100%;
-	padding: 0 spacing('base');
 	overflow: hidden;
 	border-bottom: 1px solid $c-border;
 
 	&.tab-group--spacing-even {
-		justify-content: space-between;
-	}
 
-	// > .tab > .btn {
-	// 	@include typescale('ui');
-	// 	height: auto;
-	// }
-
-	// .btn-icon-only {
-	// 	height: rem(34);
-	// 	width: rem(34);
-	// 	min-width: 0;
-	// 	border-radius: 0;
-	// }
-
-	&.tab-group--is-padded {
-		padding-left: spacing('base');
-		padding-right: spacing('base');
+		.tab {
+			flex: 1 1 auto;
+		}
 	}
 }
 
-.disclosure-tab {
+.context-tab {
 	display: none;
 
-	&.disclosure-tab--is-visible {
+	&.context-tab--is-visible {
 		display: inline;
 	}
 }
 
-.tab-group .tab.disclosure-tab .btn {
+.tab-group .tab.context-tab .btn {
 	height: 100%;
 	border-radius: 0;
 }

--- a/packages/heartwood-components/components/07-navigation/tabs.scss
+++ b/packages/heartwood-components/components/07-navigation/tabs.scss
@@ -4,10 +4,13 @@
 	flex-flow: column;
 	align-items: center;
 	flex: 0 1 auto;
-	padding: 0 spacing('base');
 
-	+ .tab {
-		padding-left: 0;
+	.tab-group--is-padded & {
+		padding: 0 spacing('base');
+
+		+ .tab {
+			padding-left: 0;
+		}
 	}
 }
 

--- a/packages/heartwood-components/components/07-navigation/tabs.scss
+++ b/packages/heartwood-components/components/07-navigation/tabs.scss
@@ -64,9 +64,18 @@
 	.context-menu {
 		height: 100%;
 	}
+
+	.context-menu__item-btn {
+		height: rem(34);
+		color: inherit;
+	}
 }
 
-.tab-group .tab.context-tab .btn {
-	height: 100%;
-	border-radius: 0;
+.tab-group .tab.context-tab {
+	.btn {
+		border-radius: 0;
+	}
+	.context-menu__button {
+		height: 100%;
+	}
 }

--- a/packages/react-heartwood-components/src/components/Card/components/OnboardingCard.js
+++ b/packages/react-heartwood-components/src/components/Card/components/OnboardingCard.js
@@ -76,7 +76,7 @@ export default class OnboardingCard extends Component<Props, State> {
 			<Card className="onboarding-card">
 				<div className="onboarding-card__header">
 					<p className="onboarding-card__title">{title}</p>
-					{tabs && <Tabs tabs={tabs} />}
+					{tabs && <Tabs tabs={tabs} isPadded={false} isTruncatable={false} />}
 				</div>
 				<CardHeader title={steps[currentStep].panelTitle} />
 				<CardBody isSectioned>{steps[currentStep].panelCopy}</CardBody>

--- a/packages/react-heartwood-components/src/components/Tabs/Tabs-story.js
+++ b/packages/react-heartwood-components/src/components/Tabs/Tabs-story.js
@@ -24,6 +24,20 @@ stories
 			])}
 		/>
 	))
+	.add('Many Tabs', () => (
+		<Tabs
+			tabs={object('tabs', [
+				{ text: 'Team', isCurrent: true },
+				{ text: 'Guests' },
+				{ text: 'Everyone', onClick: () => console.log('Click') },
+				{ text: 'All' },
+				{ text: 'Active' },
+				{ text: 'Hidden' },
+				{ text: 'Public' },
+				{ text: 'Private' }
+			])}
+		/>
+	))
 	.add('With Disclosure', () => (
 		<Tabs
 			tabs={object('tabs', [

--- a/packages/react-heartwood-components/src/components/Tabs/Tabs-story.js
+++ b/packages/react-heartwood-components/src/components/Tabs/Tabs-story.js
@@ -27,11 +27,11 @@ stories
 	.add('Many Tabs', () => (
 		<Tabs
 			tabs={object('tabs', [
-				{ text: 'Team', isCurrent: true },
+				{ text: 'Team' },
 				{ text: 'Guests' },
 				{ text: 'Everyone', onClick: () => console.log('Click') },
 				{ text: 'All' },
-				{ text: 'Active' },
+				{ text: 'Active', isCurrent: true },
 				{ text: 'Hidden' },
 				{ text: 'Public' },
 				{ text: 'Private' }

--- a/packages/react-heartwood-components/src/components/Tabs/Tabs.js
+++ b/packages/react-heartwood-components/src/components/Tabs/Tabs.js
@@ -13,7 +13,10 @@ type Props = {
 	tabs: Array<TabProps>,
 
 	/** Adds horizontal Padding */
-	isPadded?: boolean
+	isPadded?: boolean,
+
+	/** Set false to prevent truncation behavior */
+	isTruncatable?: boolean
 }
 
 type State = {
@@ -48,7 +51,8 @@ export default class Tabs extends Component<Props, State> {
 	}
 
 	static defaultProps = {
-		isPadded: false
+		isPadded: true,
+		isTruncatable: true
 	}
 
 	tabGroup: any
@@ -57,15 +61,23 @@ export default class Tabs extends Component<Props, State> {
 	debouncedResize = debounce(() => this.handleWindowResize(), 500)
 
 	componentDidMount() {
-		this.handleInitialMeasurement()
-		if (typeof window !== 'undefined') {
-			window.addEventListener('resize', this.debouncedResize, false)
+		const { isTruncatable } = this.props
+
+		if (isTruncatable) {
+			this.handleInitialMeasurement()
+			if (typeof window !== 'undefined') {
+				window.addEventListener('resize', this.debouncedResize, false)
+			}
 		}
 	}
 
 	componentWillUnmount() {
-		if (typeof window !== 'undefined') {
-			window.removeEventListener('resize', this.debouncedResize, false)
+		const { isTruncatable } = this.props
+
+		if (isTruncatable) {
+			if (typeof window !== 'undefined') {
+				window.removeEventListener('resize', this.debouncedResize, false)
+			}
 		}
 	}
 
@@ -127,7 +139,7 @@ export default class Tabs extends Component<Props, State> {
 	}
 
 	render() {
-		const { tabs, isPadded } = this.props
+		const { tabs, isPadded, isTruncatable } = this.props
 		const { hiddenTabIndices, isContextTabVisible, activeTabIndex } = this.state
 		const hiddenTabs = []
 		const activeTab = tabs.find(tab => tab.isCurrent)
@@ -163,14 +175,16 @@ export default class Tabs extends Component<Props, State> {
 						}
 						return <Tab key={tab.text} {...tab} />
 					})}
-					<li
-						ref={ref => (this.contextTab = ref)}
-						className={cx('tab context-tab', {
-							'context-tab--is-visible': isContextTabVisible
-						})}
-					>
-						<ContextMenu actions={hiddenTabs} closeOnSelectAction />
-					</li>
+					{isTruncatable && (
+						<li
+							ref={ref => (this.contextTab = ref)}
+							className={cx('tab context-tab', {
+								'context-tab--is-visible': isContextTabVisible
+							})}
+						>
+							<ContextMenu actions={hiddenTabs} closeOnSelectAction />
+						</li>
+					)}
 				</ul>
 				{activeTab && activeTab.panel}
 			</Fragment>

--- a/packages/react-heartwood-components/src/components/Tabs/Tabs.js
+++ b/packages/react-heartwood-components/src/components/Tabs/Tabs.js
@@ -78,12 +78,14 @@ export default class Tabs extends Component<Props, State> {
 			}
 		})
 		const totalTabsWidth = tabWidths.reduce((a, b) => a + b, 0)
-		this.setState({
-			tabWidths,
-			contextTabWidth,
-			isContextTabVisible: totalTabsWidth > wrapperWidth
-		}, () => this.handleMeasurement())
-
+		this.setState(
+			{
+				tabWidths,
+				contextTabWidth,
+				isContextTabVisible: totalTabsWidth > wrapperWidth
+			},
+			() => this.handleMeasurement()
+		)
 	}
 
 	handleMeasurement = () => {
@@ -103,7 +105,7 @@ export default class Tabs extends Component<Props, State> {
 			})
 		} else {
 			tabs.forEach((tab, idx) => {
-				if ((width + contextTabWidth) > wrapperWidth) {
+				if (width + contextTabWidth > wrapperWidth) {
 					hiddenTabIndices.push(idx)
 				}
 				width += tabWidths[idx + 1]
@@ -129,7 +131,7 @@ export default class Tabs extends Component<Props, State> {
 		return (
 			<Fragment>
 				<ul
-					ref={ref => this.tabGroup = ref}
+					ref={ref => (this.tabGroup = ref)}
 					className={cx('tab-group', {
 						'tab-group--is-padded': isPadded,
 						'tab-group--spacing-even': hiddenTabIndices.length > 0
@@ -141,9 +143,12 @@ export default class Tabs extends Component<Props, State> {
 						}
 						return <Tab key={tab.text} {...tab} />
 					})}
-					<li ref={ref => this.contextTab = ref} className={cx("tab context-tab", {
-						'context-tab--is-visible': isContextTabVisible
-					})}>
+					<li
+						ref={ref => (this.contextTab = ref)}
+						className={cx('tab context-tab', {
+							'context-tab--is-visible': isContextTabVisible
+						})}
+					>
 						<ContextMenu actions={hiddenTabs} closeOnSelectAction />
 					</li>
 				</ul>
@@ -152,4 +157,3 @@ export default class Tabs extends Component<Props, State> {
 		)
 	}
 }
-

--- a/packages/react-heartwood-components/src/components/Tabs/Tabs.js
+++ b/packages/react-heartwood-components/src/components/Tabs/Tabs.js
@@ -118,8 +118,14 @@ export default class Tabs extends Component<Props, State> {
 	render() {
 		const { tabs, isPadded } = this.props
 		const { hiddenTabIndices, isContextTabVisible } = this.state;
-		const hiddenTabs = []
-		const activeTab = tabs.find(tab => tab.isCurrent)
+		const hiddenTabs = [];
+		const activeTab = tabs.find(tab => tab.isCurrent);
+		if (hiddenTabIndices.length > 0) {
+			hiddenTabIndices.forEach(idx => {
+				hiddenTabs.push(tabs[idx])
+			})
+		}
+
 		return (
 			<Fragment>
 				<ul
@@ -138,7 +144,7 @@ export default class Tabs extends Component<Props, State> {
 					<li ref={ref => this.contextTab = ref} className={cx("tab context-tab", {
 						'context-tab--is-visible': isContextTabVisible
 					})}>
-						<Button isSmall icon={{ name: 'more', isLineIcon: true }} />
+						<ContextMenu actions={hiddenTabs} closeOnSelectAction />
 					</li>
 				</ul>
 				{activeTab && activeTab.panel}

--- a/packages/react-heartwood-components/src/components/Tabs/Tabs.js
+++ b/packages/react-heartwood-components/src/components/Tabs/Tabs.js
@@ -42,42 +42,42 @@ export default class Tabs extends Component<Props, State> {
 		isPadded: false
 	}
 
-	tabGroup: any;
-	contextTab: any;
+	tabGroup: any
+	contextTab: any
 
 	debouncedResize = debounce(() => this.handleWindowResize(), 500)
 
 	componentDidMount() {
-		this.handleInitialMeasurement();
+		this.handleInitialMeasurement()
 		if (typeof window !== 'undefined') {
-			window.addEventListener('resize', this.debouncedResize, false);
+			window.addEventListener('resize', this.debouncedResize, false)
 		}
 	}
 
 	componentWillUnmount() {
 		if (typeof window !== 'undefined') {
-			window.removeEventListener('resize', this.debouncedResize, false);
+			window.removeEventListener('resize', this.debouncedResize, false)
 		}
 	}
 
 	handleWindowResize = () => {
-		this.handleMeasurement();
+		this.handleMeasurement()
 	}
 
 	handleInitialMeasurement = () => {
 		// Purpose: get the initial measurements for child tabs
-		const wrapper = this.tabGroup;
-		const wrapperWidth = wrapper.offsetWidth;
-		const contextTabWidth = this.contextTab.offsetWidth;
-		const children = wrapper.childNodes;
-		const childrenArray = Array.prototype.slice.call(children);
-		const tabWidths = [];
+		const wrapper = this.tabGroup
+		const wrapperWidth = wrapper.offsetWidth
+		const contextTabWidth = this.contextTab.offsetWidth
+		const children = wrapper.childNodes
+		const childrenArray = Array.prototype.slice.call(children)
+		const tabWidths = []
 		childrenArray.forEach(child => {
 			if (!child.classList.contains('context-tab')) {
 				tabWidths.push(child.offsetWidth)
 			}
 		})
-		const totalTabsWidth = tabWidths.reduce((a, b) => a + b, 0);
+		const totalTabsWidth = tabWidths.reduce((a, b) => a + b, 0)
 		this.setState({
 			tabWidths,
 			contextTabWidth,
@@ -87,14 +87,14 @@ export default class Tabs extends Component<Props, State> {
 	}
 
 	handleMeasurement = () => {
-		const wrapper = this.tabGroup;
-		const wrapperWidth = wrapper.offsetWidth;
-		const contextTabWidth = this.contextTab.offsetWidth;
-		const { tabs } = this.props;
-		const { tabWidths } = this.state;
-		const totalTabsWidth = tabWidths.reduce((a, b) => a + b, 0);
-		const hiddenTabIndices = [];
-		let width = tabWidths[0];
+		const wrapper = this.tabGroup
+		const wrapperWidth = wrapper.offsetWidth
+		const contextTabWidth = this.contextTab.offsetWidth
+		const { tabs } = this.props
+		const { tabWidths } = this.state
+		const totalTabsWidth = tabWidths.reduce((a, b) => a + b, 0)
+		const hiddenTabIndices = []
+		let width = tabWidths[0]
 
 		if (wrapperWidth > totalTabsWidth) {
 			this.setState({
@@ -106,7 +106,7 @@ export default class Tabs extends Component<Props, State> {
 				if ((width + contextTabWidth) > wrapperWidth) {
 					hiddenTabIndices.push(idx)
 				}
-				width += tabWidths[idx + 1];
+				width += tabWidths[idx + 1]
 			})
 			this.setState({
 				hiddenTabIndices,
@@ -117,9 +117,9 @@ export default class Tabs extends Component<Props, State> {
 
 	render() {
 		const { tabs, isPadded } = this.props
-		const { hiddenTabIndices, isContextTabVisible } = this.state;
-		const hiddenTabs = [];
-		const activeTab = tabs.find(tab => tab.isCurrent);
+		const { hiddenTabIndices, isContextTabVisible } = this.state
+		const hiddenTabs = []
+		const activeTab = tabs.find(tab => tab.isCurrent)
 		if (hiddenTabIndices.length > 0) {
 			hiddenTabIndices.forEach(idx => {
 				hiddenTabs.push(tabs[idx])
@@ -137,7 +137,7 @@ export default class Tabs extends Component<Props, State> {
 				>
 					{tabs.map((tab, idx) => {
 						if (hiddenTabIndices.indexOf(idx) > -1) {
-							return null;
+							return null
 						}
 						return <Tab key={tab.text} {...tab} />
 					})}


### PR DESCRIPTION
[SBL-1599](https://sprucelabsai.atlassian.net/browse/SBL-1599)

## Description
![tabs](https://user-images.githubusercontent.com/13734175/50406294-f427c980-077f-11e9-93f6-be785dca2958.gif)

This makes any instance of Tabs automatically truncate itself. A couple of notes:
- To avoid this behavior (as needed for Onboarding Cards) you can pass `isTruncatable={false}`
- The window resize event is debounced by 500ms for performance. We could make this faster if it seems too slow.
- If the active tab would be hidden, it will instead be shown first, with the rest of the tabs in the order in which they were authored. The active tab will never appear in the context menu.
- The Tabs component uses state in an atypical fashion; namely that `tabWidths` and `contextTabWidth` are sort of permanent. These values are captured in the initial render so that we can easily reason about when to hide and show which tabs on window resize without having to render an ugly tab group.

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt
