### PR TITLE
Sidebar icons styling

### DIFF
--- a/packages/heartwood-components/components/99-web/sidebar.scss
+++ b/packages/heartwood-components/components/99-web/sidebar.scss
@@ -75,14 +75,14 @@
 	width: rem(16);
 	height: rem(16);
 	stroke: $c-text-icon;
-	fill: $c-text-icon;
 
 	.sidebar:not(.sidebar--is-collapsed) & + * {
 		margin-left: spacing('tight');
 	}
 
-	&.sidebar-item__line-icon {
-		fill: none;
+	&.sidebar-item__icon--fill {
+		stroke: none;
+		fill: $c-text-icon;
 	}
 }
 
@@ -109,6 +109,11 @@
 .sidebar-item--is-current-parent {
 	.sidebar-item__icon {
 		stroke: $c-primary;
+
+		&.sidebar-item__icon--fill {
+			stroke: none;
+			fill: $c-primary;
+		}
 	}
 }
 


### PR DESCRIPTION
[SBL-1604](https://sprucelabsai.atlassian.net/browse/SBL-1604)

## Description

Update styles so that icons are stroke-only by default. This can be overridden with the `.sidebar-item__icon--fill` class. 

## Type

- [x ] Feature
- [ ] Bug
- [ ] Tech debt
