### PR TITLE
fix(graphql): Include websocket dependency

### DIFF
--- a/packages/spruce-utils/package.json
+++ b/packages/spruce-utils/package.json
@@ -45,7 +45,8 @@
 		"graphql": "^14.0.2",
 		"graphql-tag": "^2.10.0",
 		"handlebars": "^4.0.12",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.11",
+		"subscriptions-transport-ws": "^0.9.15"
 	},
 	"devDependencies": {
 		"babel-eslint": "^10.0.1",


### PR DESCRIPTION
This missing peer dep breaks downstream projects; I shouldn't have to install it in ai-spruce-web so installing it as a dep of spruce-utils.

```
warning "@sprucelabs/spruce-utils > apollo-link-ws@1.0.12" has unmet peer dependency "subscriptions-transport-ws@^0.9.0".
```
```
 ERROR  Failed to compile with 1 errors                                     12:53:19 PM

This dependency was not found:

* subscriptions-transport-ws in ./node_modules/apollo-link-ws/lib/webSocketLink.js

To install it, you can run: npm install --save subscriptions-transport-ws
```