### PR TITLE
fix: Don't show the disabled error message

### DIFF
--- a/packages/spruce-utils/lib/graphql.js
+++ b/packages/spruce-utils/lib/graphql.js
@@ -110,10 +110,6 @@ export class GraphQLClient {
 				wsLink,
 				addExtensionsLink.concat(httpLink)
 			)
-		} else {
-			log.debug('GraphQL Subscriptions disabled.', {
-				wsUri: wsUri || '<NOT SET>'
-			})
 		}
 
 		this.client = new ApolloClient({


### PR DESCRIPTION
The other errors are fine, since they're predicated on wsUri being set. But this one logs every time a new client is created / there's no `window`, which happens a lot in dev on NextJS SSR.

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt
