### PR TITLE
feat(eslint): Add spruce eslint plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"name": "workspace.sprucebot-skills-kit",
 	"workspaces": [
+		"packages/eslint-plugin-spruce",
 		"packages/heartwood-components",
 		"packages/react-heartwood-components",
 		"packages/spruce-next-helpers",

--- a/packages/eslint-plugin-spruce/index.js
+++ b/packages/eslint-plugin-spruce/index.js
@@ -1,0 +1,84 @@
+const rules = [
+	{ method: 'query', option: 'query', suffix: 'QueryString' },
+	{ method: 'mutate', option: 'mutation', suffix: 'MutationString' }
+]
+
+module.exports = {
+	rules: {
+		'utils-graphql': {
+			create: function(context) {
+				return {
+					CallExpression(node) {
+						rules.forEach(rule => {
+							if (node.callee.name === rule.method) {
+								const QueryOption = node.arguments[0].properties.find(
+									o => o.key.name === rule.option
+								)
+
+								const QueryOptionType = QueryOption.value.type
+
+								if (QueryOptionType === 'TemplateLiteral') {
+									context.report(
+										node,
+										'Tag template literal with `gql` from `graphql-tag`.'
+									)
+								} else if (QueryOptionType !== 'TaggedTemplateExpression') {
+									if (QueryOptionType === 'Identifier') {
+										if (
+											!QueryOption.value.name.match(
+												new RegExp(`.*${rule.suffix}`, 'gi')
+											)
+										) {
+											context.report(
+												node,
+												`Indentifiers passed to the ${
+													rule.option
+												} option should end with \`${
+													rule.suffix
+												}\` (i.e. \`location${rule.suffix}\`)`
+											)
+										}
+									} else {
+										context.report(
+											node,
+											`Value of option \`${
+												rule.option
+											}\` should be a template literal tagged with \`gql\` from \`graphql-tag\`.`
+										)
+									}
+								}
+							}
+						})
+					},
+					Identifier(node) {
+						rules.forEach(rule => {
+							if (node.name.match(new RegExp(`.*${rule.suffix}`, 'gi'))) {
+								const source = context.getSourceCode()
+								const tokens = source.getTokensAfter(node, { count: 3 })
+
+								if (
+									tokens[0].value === '=' &&
+									tokens[1].value === 'gql' &&
+									tokens[2].type === 'Template' &&
+									tokens[2].value.match(/{([^}]+|)\${/gi)
+								) {
+									context.report(
+										node,
+										'No nested interpolation in GraphQL documents.'
+									)
+								}
+
+								if (tokens[0].value === '=' && tokens[1].type === 'Template') {
+									context.report(
+										node,
+										'Tag template literal with `gql` from `graphql-tag`.'
+									)
+								}
+							}
+						})
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/eslint-plugin-spruce/index.js
+++ b/packages/eslint-plugin-spruce/index.js
@@ -59,13 +59,24 @@ module.exports = {
 								if (
 									tokens[0].value === '=' &&
 									tokens[1].value === 'gql' &&
-									tokens[2].type === 'Template' &&
-									tokens[2].value.match(/{([^}]+|)\${/gi)
+									tokens[2].type === 'Template'
 								) {
-									context.report(
-										node,
-										'No nested interpolation in GraphQL documents.'
-									)
+									// `value` will return up until the `${` (if one exists).
+									// Bad: { ${
+									// Good: { {} } ${
+									// Good: { {} }
+									const openBrackets = tokens[2].value.match(/{/gi)
+									const closeBrackets = tokens[2].value.match(/}/gi)
+
+									if (
+										(openBrackets && openBrackets.length - 1) >
+										(closeBrackets && closeBrackets.length)
+									) {
+										context.report(
+											node,
+											'No nested interpolation in GraphQL documents.'
+										)
+									}
 								}
 
 								if (tokens[0].value === '=' && tokens[1].type === 'Template') {

--- a/packages/eslint-plugin-spruce/package.json
+++ b/packages/eslint-plugin-spruce/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "@sprucelabs/eslint-plugin-spruce",
+	"publishConfig": {
+		"access": "public"
+	},
+	"version": "8.10.0",
+	"description": "ESLint plugin for Spruce Javascript projects",
+	"author": "George Pantazis <gcpantazis@gmail.com>",
+	"homepage": "https://github.com/sprucelabsai/workspace.sprucebot-skills-kit#readme",
+	"license": "MIT",
+	"main": "index.js",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/sprucelabsai/workspace.sprucebot-skills-kit.git"
+	},
+	"scripts": {},
+	"bugs": {
+		"url": "https://github.com/sprucelabsai/workspace.sprucebot-skills-kit/issues"
+	},
+	"dependencies": {},
+	"devDependencies": {}
+}


### PR DESCRIPTION
- Adding this to aid in GQL rules enforcement; easier to apply a rule and get all the errors in the project than manually looking around for them. Plus it future-proofs the code.
- Going forward I'd much prefer to set a standard, write a linter rule to enforce it, then hand-off to one/many engineers to implement.
- This is a medium issue right now where we have several branches with mixed standards in ai-spruce-web; It's hard to refactor when new code might come in and break the new rules. Having a linter makes  this easy, I just tell everyone to merge up dev and they'll have the new parameters flagged in their IDEs (or otherwise they'll see them on CircleCI when they open a PR).
- I can move it somewhere else if we don't want it in workspace, but I dig the deploy process here and all 🤷‍♂️ LMK what you think on that.