### PR TITLE
Delete FileItem / Fix Checkbox

### DIFF
--- a/packages/react-heartwood-components/src/components/Forms/components/Checkbox/Checkbox.js
+++ b/packages/react-heartwood-components/src/components/Forms/components/Checkbox/Checkbox.js
@@ -38,7 +38,7 @@ export default class Checkbox extends Component<Props, State> {
 		isIndeterminateState: this.props.isIndeterminate
 	}
 
-	handleChange = () => {
+	handleChange = e => {
 		const { onChange } = this.props
 		this.setState(prevState => {
 			if (prevState.isIndeterminateState) {
@@ -49,7 +49,7 @@ export default class Checkbox extends Component<Props, State> {
 		})
 
 		if (onChange) {
-			onChange()
+			onChange(e)
 		}
 	}
 

--- a/packages/spruce-skill-server/services/uploads.js
+++ b/packages/spruce-skill-server/services/uploads.js
@@ -8,6 +8,29 @@ module.exports = {
 		}
 	},
 
+	async deleteFileItems({ fileItemIds }) {
+		if (!fileItemIds) {
+			log.warn('Missing "fileItemIds"')
+			throw new Error('MISSING_PARAMETERS')
+		}
+
+		const fileItemIdsStr = fileItemIds.map(fid => `"${fid}"`)
+
+		const query = `mutation {
+			deleteFileItems (
+				input: {
+					fileItemIds: [${fileItemIdsStr.join(',')}]
+				}
+			) {
+				status
+			}
+		}`
+
+		const result = await this.sb.query(query)
+
+		return result
+	},
+
 	async uploadImages({
 		files,
 		acl,


### PR DESCRIPTION
## Description

* Service that a skill can call to delete `FileItems`

* Fix `Checkbox` component not forwarding the `event`, causing Formik to break

## Type

- [X] Feature
- [X] Bug
- [ ] Tech debt
