### PR TITLE
Switch to using the latest awscli from pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,9 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - 'ec:9f:2e:aa:1f:c9:ab:49:57:8f:c0:cd:2e:5b:f3:b0'
-      - run: node -v && npm -v
       - run: pip install awscli --upgrade --user
+      - run: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
+      - run: node -v && npm -v && aws --version
       - checkout
       - run: yarn install --frozen-lockfile
       - run: yarn build
@@ -40,8 +41,9 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - 'ec:9f:2e:aa:1f:c9:ab:49:57:8f:c0:cd:2e:5b:f3:b0'
-      - run: node -v && npm -v
       - run: pip install awscli --upgrade --user
+      - run: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
+      - run: node -v && npm -v && aws --version
       - checkout
       - run: yarn install --frozen-lockfile
       - run: yarn build
@@ -62,8 +64,9 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - 'ec:9f:2e:aa:1f:c9:ab:49:57:8f:c0:cd:2e:5b:f3:b0'
-      - run: node -v && npm -v
       - run: pip install awscli --upgrade --user
+      - run: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
+      - run: node -v && npm -v && aws --version
       - checkout
       - run: yarn install --frozen-lockfile
       - run: yarn build
@@ -84,8 +87,9 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - 'ec:9f:2e:aa:1f:c9:ab:49:57:8f:c0:cd:2e:5b:f3:b0'
-      - run: node -v && npm -v
       - run: pip install awscli --upgrade --user
+      - run: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
+      - run: node -v && npm -v && aws --version
       - checkout
       - run: yarn install --frozen-lockfile
       - run: yarn build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,19 +2,20 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:10
+      - image: circleci/python:3-node
     steps:
       - add_ssh_keys:
           fingerprints:
             - 'ec:9f:2e:aa:1f:c9:ab:49:57:8f:c0:cd:2e:5b:f3:b0'
       - checkout
+      - run: node -v && npm -v
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn build
       - run: yarn test
   pre_release:
     docker:
-      - image: circleci/node:10
+      - image: circleci/python:3-node
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -33,7 +34,7 @@ jobs:
       - run: yarn s3-sync-stylesheets-pre
   canary:
     docker:
-      - image: circleci/node:10
+      - image: circleci/python:3-node
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -54,7 +55,7 @@ jobs:
       - run: yarn s3-sync-stylesheets-pre
   dev_release:
     docker:
-      - image: circleci/node:10
+      - image: circleci/python:3-node
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -75,7 +76,7 @@ jobs:
       - run: yarn s3-sync-stylesheets-latest
   prod_release:
     docker:
-      - image: circleci/node:10
+      - image: circleci/python:3-node
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,8 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - 'ec:9f:2e:aa:1f:c9:ab:49:57:8f:c0:cd:2e:5b:f3:b0'
-      - run: sudo apt-get install awscli
+      - run: node -v && npm -v
+      - run: pip install awscli --upgrade --user
       - checkout
       - run: yarn install --frozen-lockfile
       - run: yarn build
@@ -39,7 +40,8 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - 'ec:9f:2e:aa:1f:c9:ab:49:57:8f:c0:cd:2e:5b:f3:b0'
-      - run: sudo apt-get install awscli
+      - run: node -v && npm -v
+      - run: pip install awscli --upgrade --user
       - checkout
       - run: yarn install --frozen-lockfile
       - run: yarn build
@@ -60,7 +62,8 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - 'ec:9f:2e:aa:1f:c9:ab:49:57:8f:c0:cd:2e:5b:f3:b0'
-      - run: sudo apt-get install awscli
+      - run: node -v && npm -v
+      - run: pip install awscli --upgrade --user
       - checkout
       - run: yarn install --frozen-lockfile
       - run: yarn build
@@ -81,7 +84,8 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - 'ec:9f:2e:aa:1f:c9:ab:49:57:8f:c0:cd:2e:5b:f3:b0'
-      - run: sudo apt-get install awscli
+      - run: node -v && npm -v
+      - run: pip install awscli --upgrade --user
       - checkout
       - run: yarn install --frozen-lockfile
       - run: yarn build


### PR DESCRIPTION
I've mentioned this previously, but `awscli` from `apt` is an old version that in my experience hasn't been very solid. At my last job I switched to using the recommended installation method (pip) as documented here: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html#install-tool-pip

I suspect that we've hit a certain s3 sync payload-size that is crashing the older cli, similar to this issue: https://github.com/aws/aws-cli/issues/1775

From memory, I think this also triggers when you pass a certain # of files.

This has little downside other than  `python:3-node` doesn't let us specify the node version. Currently it uses v10, but they could upgrade that to v12 later on this year, etc. At that stage we should write our own dockerfile  to gain more control here: https://circleci.com/docs/2.0/custom-images/