### PR TITLE
Toast

### DIFF
--- a/packages/heartwood-components/components/05-feedback/toast.scss
+++ b/packages/heartwood-components/components/05-feedback/toast.scss
@@ -22,7 +22,6 @@
 		width: auto;
 		padding-left: 0;
 		height: rem(32);
-		color: $c-primary;
 
 		.btn__inner {
 			align-items: flex-end;

--- a/packages/heartwood-components/components/05-feedback/toast.scss
+++ b/packages/heartwood-components/components/05-feedback/toast.scss
@@ -62,6 +62,7 @@
 	position: fixed;
 	bottom: 0;
 	left: 0;
+	z-index: 9;
 
 	@include gt('small') {
 		bottom: spacing('base');

--- a/packages/heartwood-components/components/05-feedback/toast.scss
+++ b/packages/heartwood-components/components/05-feedback/toast.scss
@@ -2,8 +2,8 @@
 	@include type-style-body-sm;
 	display: inline-block;
 	min-width: rem(288);
+	max-width: rem(400);
 	padding: spacing('tight');
-	// border: 1px solid $c-border;
 	border-radius: 2px;
 	background-color: $c-text;
 	color: $c-white;
@@ -11,12 +11,10 @@
 
 	&.toast-negative {
 		background-color: $c-ui-critical-dark;
-		// border-color: $c-ui-critical;
 	}
 
 	&.toast-positive {
 		background-color: $c-ui-online-dark;
-		// border-color: $c-ui-online;
 	}
 
 	.btn {
@@ -29,6 +27,10 @@
 		.btn__inner {
 			align-items: flex-end;
 		}
+	}
+
+	@include gt('small') {
+		margin-right: spacing('tight');
 	}
 }
 
@@ -43,7 +45,6 @@
 		padding: 0;
 		min-width: 0;
 		height: rem(20);
-		color: $c-primary;
 
 		.btn__inner {
 			align-items: flex-start;
@@ -58,9 +59,14 @@
 }
 
 .toasts-wrapper {
-	position: absolute;
-	bottom: spacing('base');
-	left: spacing('base');
+	position: fixed;
+	bottom: 0;
+	left: 0;
+
+	@include gt('small') {
+		bottom: spacing('base');
+		left: spacing('base');
+	}
 }
 
 .toast-wrapper + .toast-wrapper {

--- a/packages/heartwood-components/components/05-feedback/toast.scss
+++ b/packages/heartwood-components/components/05-feedback/toast.scss
@@ -3,19 +3,20 @@
 	display: inline-block;
 	min-width: rem(288);
 	padding: spacing('tight');
-	border: 1px solid $c-border;
+	// border: 1px solid $c-border;
 	border-radius: 2px;
-	background-color: $c-white;
+	background-color: $c-text;
+	color: $c-white;
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 
 	&.toast-negative {
-		background-color: $c-ui-critical-light;
-		border-color: $c-ui-critical;
+		background-color: $c-ui-critical-dark;
+		// border-color: $c-ui-critical;
 	}
 
 	&.toast-positive {
-		background-color: $c-ui-online-lighter;
-		border-color: $c-ui-online;
+		background-color: $c-ui-online-dark;
+		// border-color: $c-ui-online;
 	}
 
 	.btn {
@@ -47,6 +48,12 @@
 		.btn__inner {
 			align-items: flex-start;
 		}
+	}
+
+	.btn__icon {
+		width: rem(16);
+		height: rem(16);
+		fill: rgba($c-white, 0.8);
 	}
 }
 

--- a/packages/heartwood-components/stylesheets/core/_colors.scss
+++ b/packages/heartwood-components/stylesheets/core/_colors.scss
@@ -55,6 +55,7 @@ UI Colors
 */
 $c-ui-input-autofill: #e0edf8 !default;
 $c-ui-online: #00b2a4 !default;
+$c-ui-online-dark: #0d7171 !default;
 $c-ui-online-lighter: #defffd !default;
 $c-ui-offline: $c-grey-03 !default;
 $c-ui-success: $c-primary !default;

--- a/packages/react-heartwood-components/src/components/Toast/Toast-story.js
+++ b/packages/react-heartwood-components/src/components/Toast/Toast-story.js
@@ -43,8 +43,8 @@ class ToastExample extends Component<Props, State> {
 			negative: 'Run away! This is awful.'
 		}
 		const timeouts = {
-			neutral: false,
-			positive: 1000,
+			neutral: 'never',
+			positive: 10000,
 			negative: 4000
 		}
 		this.setState(prevState => {

--- a/packages/react-heartwood-components/src/components/Toast/Toast-story.js
+++ b/packages/react-heartwood-components/src/components/Toast/Toast-story.js
@@ -45,7 +45,7 @@ class ToastExample extends Component<Props, State> {
 		const timeouts = {
 			neutral: 'never',
 			positive: 10000,
-			negative: 4000
+			negative: 3000
 		}
 		this.setState(prevState => {
 			const newToasts = [...prevState.toasts]

--- a/packages/react-heartwood-components/src/components/Toast/Toast-story.js
+++ b/packages/react-heartwood-components/src/components/Toast/Toast-story.js
@@ -86,7 +86,10 @@ stories.addDecorator(withKnobs)
 stories.add('Toast', () => (
 	<ToastExample
 		headline={text('headline', 'Neat')}
-		text={text('text', 'Something just happened and it was fine')}
+		text={text(
+			'text',
+			'Something just happened and it was fine. Something just happened and it was fine. Something just happened and it was fine. Something just happened and it was fine'
+		)}
 		showUndo={boolean('showUndo', false)}
 	/>
 ))

--- a/packages/react-heartwood-components/src/components/Toast/Toast-story.js
+++ b/packages/react-heartwood-components/src/components/Toast/Toast-story.js
@@ -42,6 +42,11 @@ class ToastExample extends Component<Props, State> {
 			positive: 'You did something amazing. Congrats!',
 			negative: 'Run away! This is awful.'
 		}
+		const timeouts = {
+			neutral: false,
+			positive: 1000,
+			negative: 4000
+		}
 		this.setState(prevState => {
 			const newToasts = [...prevState.toasts]
 			newToasts.push({
@@ -49,7 +54,8 @@ class ToastExample extends Component<Props, State> {
 				text: texts[kind],
 				kind,
 				id: ids[kind],
-				onUndo: showUndo ? () => console.log('Undo') : null
+				onUndo: showUndo ? () => console.log('Undo') : null,
+				timeout: timeouts[kind]
 			})
 			return {
 				toasts: newToasts

--- a/packages/react-heartwood-components/src/components/Toast/Toast-story.js
+++ b/packages/react-heartwood-components/src/components/Toast/Toast-story.js
@@ -11,7 +11,7 @@ const stories = storiesOf('Toast', module)
 
 type Props = {
 	children: Node,
-	showUndo: boolean,
+	showFollowup: boolean,
 	headline: string,
 	text: string
 }
@@ -26,7 +26,7 @@ class ToastExample extends Component<Props, State> {
 	}
 
 	addToast = (kind: 'neutral' | 'positive' | 'negative') => {
-		const { showUndo, text, headline } = this.props
+		const { showFollowup, text, headline } = this.props
 		const ids = {
 			neutral: '1',
 			positive: '2',
@@ -54,7 +54,7 @@ class ToastExample extends Component<Props, State> {
 				text: texts[kind],
 				kind,
 				id: ids[kind],
-				onUndo: showUndo ? () => console.log('Undo') : null,
+				followupAction: showFollowup ? () => console.log('Undo') : null,
 				timeout: timeouts[kind]
 			})
 			return {
@@ -110,6 +110,6 @@ stories.add('Toast', () => (
 	<ToastExample
 		headline={text('headline', 'Neat')}
 		text={text('text', 'Something just happened and it was fine.')}
-		showUndo={boolean('showUndo', false)}
+		showFollowup={boolean('showFollowup', false)}
 	/>
 ))

--- a/packages/react-heartwood-components/src/components/Toast/Toast-story.js
+++ b/packages/react-heartwood-components/src/components/Toast/Toast-story.js
@@ -27,12 +27,28 @@ class ToastExample extends Component<Props, State> {
 
 	addToast = (kind: 'neutral' | 'positive' | 'negative') => {
 		const { showUndo, text, headline } = this.props
+		const ids = {
+			neutral: '1',
+			positive: '2',
+			negative: '3'
+		}
+		const headlines = {
+			neutral: 'Neat',
+			positive: 'Great!',
+			negative: 'Oh No!'
+		}
+		const texts = {
+			neutral: 'Something just happened and it was fine.',
+			positive: 'You did something amazing. Congrats!',
+			negative: 'Run away! This is awful.'
+		}
 		this.setState(prevState => {
 			const newToasts = [...prevState.toasts]
 			newToasts.push({
-				headline,
-				text,
+				headline: headlines[kind],
+				text: texts[kind],
 				kind,
+				id: ids[kind],
 				onUndo: showUndo ? () => console.log('Undo') : null
 			})
 			return {
@@ -41,9 +57,10 @@ class ToastExample extends Component<Props, State> {
 		})
 	}
 
-	removeToast = (idx: number) => {
+	removeToast = (id: string) => {
 		this.setState(prevState => {
 			const toasts = [...prevState.toasts]
+			const idx = toasts.findIndex(toast => toast.id === id)
 			const removedToast = toasts.splice(idx, 1)
 			return {
 				toasts
@@ -86,10 +103,7 @@ stories.addDecorator(withKnobs)
 stories.add('Toast', () => (
 	<ToastExample
 		headline={text('headline', 'Neat')}
-		text={text(
-			'text',
-			'Something just happened and it was fine. Something just happened and it was fine. Something just happened and it was fine. Something just happened and it was fine'
-		)}
+		text={text('text', 'Something just happened and it was fine.')}
 		showUndo={boolean('showUndo', false)}
 	/>
 ))

--- a/packages/react-heartwood-components/src/components/Toast/Toast.js
+++ b/packages/react-heartwood-components/src/components/Toast/Toast.js
@@ -36,11 +36,14 @@ export type Props = {
 	kind?: 'neutral' | 'positive' | 'negative',
 
 	/** Handle a followup action */
-	followupAction?: Function
+	followupAction?: Function,
+
+	/** Text for the followup action */
+	followupText?: string
 }
 
 const Toast = (props: Props) => {
-	const { headline, kind, text, followupAction, onRemove } = props
+	const { headline, kind, text, followupAction, followupText, onRemove } = props
 	const toastClass = cx('toast', {
 		'toast-positive': kind === 'positive',
 		'toast-negative': kind === 'negative'
@@ -51,14 +54,17 @@ const Toast = (props: Props) => {
 			<div className="toast__body">
 				<p>{text}</p>
 			</div>
-			{followupAction && <Button text="Undo" onClick={followupAction} />}
+			{followupAction && (
+				<Button text={followupText} onClick={followupAction} />
+			)}
 		</div>
 	)
 }
 
 Toast.defaultProps = {
 	kind: 'neutral',
-	onUndo: null
+	followupAction: null,
+	followupText: 'Undo'
 }
 
 export default Toast

--- a/packages/react-heartwood-components/src/components/Toast/Toast.js
+++ b/packages/react-heartwood-components/src/components/Toast/Toast.js
@@ -35,12 +35,12 @@ export type Props = {
 	/** Sets the variation of toast */
 	kind?: 'neutral' | 'positive' | 'negative',
 
-	/** Handle undoing the action that triggered the toast */
-	onUndo?: Function
+	/** Handle a followup action */
+	followupAction?: Function
 }
 
 const Toast = (props: Props) => {
-	const { headline, kind, text, onUndo, onRemove } = props
+	const { headline, kind, text, followupAction, onRemove } = props
 	const toastClass = cx('toast', {
 		'toast-positive': kind === 'positive',
 		'toast-negative': kind === 'negative'
@@ -51,7 +51,7 @@ const Toast = (props: Props) => {
 			<div className="toast__body">
 				<p>{text}</p>
 			</div>
-			{onUndo && <Button text="Undo" onClick={onUndo} />}
+			{followupAction && <Button text="Undo" onClick={followupAction} />}
 		</div>
 	)
 }

--- a/packages/react-heartwood-components/src/components/Toast/components/ToastWrapper/ToastWrapper.js
+++ b/packages/react-heartwood-components/src/components/Toast/components/ToastWrapper/ToastWrapper.js
@@ -52,7 +52,7 @@ export default class ToastWrapper extends Component<Props, State> {
 	}
 
 	render() {
-		const { toasts } = this.props
+		const { toasts } = this.state
 
 		return (
 			<div className="toasts-wrapper">

--- a/packages/react-heartwood-components/src/components/Toast/components/ToastWrapper/ToastWrapper.js
+++ b/packages/react-heartwood-components/src/components/Toast/components/ToastWrapper/ToastWrapper.js
@@ -19,11 +19,14 @@ const ToastWrapper = (props: Props) => {
 		<div className="toasts-wrapper">
 			<VelocityTransitionGroup
 				enter={{ animation: { opacity: 1, translateX: 0 }, duration: 300 }}
-				leave={{ animation: { opacity: 0, translateX: '-4px' }, duration: 0 }}
+				leave={{
+					animation: { opacity: 0, translateX: '-4px' },
+					duration: 0
+				}}
 			>
-				{toasts.map((toast, idx) => (
-					<div key={idx} className="toast-wrapper">
-						<Toast onRemove={() => handleRemove(idx)} {...toast} />
+				{toasts.map(toast => (
+					<div key={toast.id} className="toast-wrapper">
+						<Toast onRemove={() => handleRemove(toast.id)} {...toast} />
 					</div>
 				))}
 			</VelocityTransitionGroup>

--- a/packages/react-heartwood-components/src/components/Toast/components/ToastWrapper/ToastWrapper.js
+++ b/packages/react-heartwood-components/src/components/Toast/components/ToastWrapper/ToastWrapper.js
@@ -12,26 +12,28 @@ type Props = {
 	handleRemove: Function
 }
 
-const ToastWrapper = (props: Props) => {
-	const { toasts, handleRemove } = props
+type State = {}
 
-	return (
-		<div className="toasts-wrapper">
-			<VelocityTransitionGroup
-				enter={{ animation: { opacity: 1, translateX: 0 }, duration: 300 }}
-				leave={{
-					animation: { opacity: 0, translateX: '-4px' },
-					duration: 0
-				}}
-			>
-				{toasts.map(toast => (
-					<div key={toast.id} className="toast-wrapper">
-						<Toast onRemove={() => handleRemove(toast.id)} {...toast} />
-					</div>
-				))}
-			</VelocityTransitionGroup>
-		</div>
-	)
+export default class ToastWrapper extends Component<Props, State> {
+	render() {
+		const { toasts, handleRemove } = this.props
+
+		return (
+			<div className="toasts-wrapper">
+				<VelocityTransitionGroup
+					enter={{ animation: { opacity: 1, translateX: 0 }, duration: 300 }}
+					leave={{
+						animation: { opacity: 0, translateX: '-4px' },
+						duration: 0
+					}}
+				>
+					{toasts.map(toast => (
+						<div key={toast.id} className="toast-wrapper">
+							<Toast onRemove={() => handleRemove(toast.id)} {...toast} />
+						</div>
+					))}
+				</VelocityTransitionGroup>
+			</div>
+		)
+	}
 }
-
-export default ToastWrapper

--- a/packages/react-heartwood-components/src/components/Toast/components/ToastWrapper/ToastWrapper.js
+++ b/packages/react-heartwood-components/src/components/Toast/components/ToastWrapper/ToastWrapper.js
@@ -30,7 +30,7 @@ export default class ToastWrapper extends Component<Props, State> {
 		const uniqToasts = uniqBy(props.toasts, 'id')
 		let timeouts = { ...state.timeouts }
 		uniqToasts.forEach(toast => {
-			if (toast.timeout !== 'never' && !state.timeouts[toast.id]) {
+			if (toast.timeout !== 'never') {
 				timeouts[toast.id] = setTimeout(
 					() => {
 						props.handleRemove(toast.id)
@@ -42,8 +42,17 @@ export default class ToastWrapper extends Component<Props, State> {
 		return { toasts: uniqToasts, timeouts }
 	}
 
+	onRemoveClick = (id: string) => {
+		const { timeouts } = this.state
+		const { handleRemove } = this.props
+		if (timeouts[id]) {
+			clearTimeout(timeouts[id])
+		}
+		handleRemove(id)
+	}
+
 	render() {
-		const { toasts, handleRemove } = this.props
+		const { toasts } = this.props
 
 		return (
 			<div className="toasts-wrapper">
@@ -56,7 +65,7 @@ export default class ToastWrapper extends Component<Props, State> {
 				>
 					{toasts.map(toast => (
 						<div key={toast.id} className="toast-wrapper">
-							<Toast onRemove={() => handleRemove(toast.id)} {...toast} />
+							<Toast onRemove={() => this.onRemoveClick(toast.id)} {...toast} />
 						</div>
 					))}
 				</VelocityTransitionGroup>


### PR DESCRIPTION
[SBL-1866](https://sprucelabsai.atlassian.net/browse/SBL-1866)

## Description

Fixes for the `Toast` and `ToastWrapper` components:
- Updates styles to match latest from Heartwood
- Gives the `ToastWrapper` a fixed position so that it stays put on scroll
- Adds a `z-index` of 9 to keep Toasts above the UI
- Adds a default timeout of 3 seconds, with the option to override or remove timeout entirely
- Adds `id`s to Toasts in the ToastWrapper — this achieves timeout management and makes the animations smoother because we no longer rely on `idx` for updates
- Adds a `max-width` to avoid UI blocking

## Type

- [ ] Feature
- [ ] Bug
- [ *] Tech debt
