### PR TITLE
Fix running skills in non-local environments

### DIFF
--- a/packages/spruce-skill/config/default.js
+++ b/packages/spruce-skill/config/default.js
@@ -17,7 +17,7 @@ try {
 
 // When running locally we use 'flow-node' so it can handle flowtypes. When in a non-local environment we need to use the build/ directory where flowtypes have been stripped
 const baseDirectory =
-	process.env.NODE_ENV === 'local'
+	process.env.ENV === 'local'
 		? `${__dirname}/../server`
 		: `${__dirname}/../build`
 

--- a/packages/spruce-skill/config/default.js
+++ b/packages/spruce-skill/config/default.js
@@ -15,6 +15,12 @@ try {
 	console.error('Missing .env file for this project')
 }
 
+// When running locally we use 'flow-node' so it can handle flowtypes. When in a non-local environment we need to use the build/ directory where flowtypes have been stripped
+const baseDirectory =
+	process.env.NODE_ENV === 'local'
+		? `${__dirname}/../server`
+		: `${__dirname}/../build`
+
 module.exports = {
 	cards: cards,
 	DEV_MODE: process.env.DEV_MODE === 'true',
@@ -172,13 +178,13 @@ module.exports = {
 		}
 	},
 	gqlOptions: {
-		gqlDir: path.resolve(__dirname, '../server/gql')
+		gqlDir: `${baseDirectory}/gql`
 	},
 	sequelizeOptions: {
 		enabled: process.env.DB_ENABLED === 'true',
 		runMigrations: process.env.DB_MIGRATIONS === 'true',
-		modelsDir: path.resolve(__dirname, '../server/models'),
-		migrationsDir: path.resolve(__dirname, '../server/migrations'),
+		modelsDir: `${baseDirectory}/models`,
+		migrationsDir: `${baseDirectory}/migrations`,
 		// Additional sequelize options
 		options: {
 			logging: process.env.ORM_LOGGING === 'true' ? console.log : false


### PR DESCRIPTION
## Description

Currently deploying in non-local environments will crash skills.

This changes which directory to run from based on `process.env.ENV`. If in a non-local environment we run from the `build/` directory which has had flowtypes stripped.

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt
