### PR TITLE
Add RecordTable, Update Table to support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"stop": "pm2 stop ecosystem.config.js",
 		"lint": "lerna run lint",
 		"build": "lerna run build",
-		"watch": "lerna run watch --stream",
+		"watch": "lerna run watch --no-sort --stream",
 		"start": "pm2 start ecosystem.config.js --no-daemon",
 		"test": "jest --clearCache && lerna run test --parallel --ignore sprucebot-node",
 		"test:update": "jest --clearCache && lerna run test --parallel --ignore sprucebot-node -- -u",

--- a/packages/heartwood-components/components/03-structure/table.scss
+++ b/packages/heartwood-components/components/03-structure/table.scss
@@ -128,6 +128,14 @@
 	padding-left: spacing('base');
 }
 
-.table-loader {
+.table-loader,
+.table-loader--is-visible {
 	display: none;
+}
+
+.table__no-results-message {
+	@include type-style-body-sm;
+	padding-top: spacing('base');
+	padding-right: spacing('base');
+	padding-left: spacing('base');
 }

--- a/packages/heartwood-components/package.json
+++ b/packages/heartwood-components/package.json
@@ -25,7 +25,8 @@
 	},
 	"scripts": {
 		"deploy": "gh-pages -d build",
-		"build": "gulp styles && gulp styles-minify && gulp js && gulp svg && fractal build"
+		"build": "gulp styles && gulp styles-minify && gulp js && gulp svg && fractal build",
+		"watch": "gulp watch"
 	},
 	"description": "This is a seed project, using [Fractal](https://github.com/frctl/fractal) alongside Sass and Gulp to provide editable component-based CSS",
 	"main": "heartwood-components.js",

--- a/packages/react-heartwood-components/src/components/Forms/components/Checkbox/Checkbox.js
+++ b/packages/react-heartwood-components/src/components/Forms/components/Checkbox/Checkbox.js
@@ -69,6 +69,7 @@ export default class Checkbox extends Component<Props, State> {
 			<div className={parentClass}>
 				<div className="checkbox-item__inner">
 					<input
+						autoComplete={'off'}
 						className="checkbox-item__input"
 						type="checkbox"
 						id={id}

--- a/packages/react-heartwood-components/src/components/RecordTable/RecordTable-story.js
+++ b/packages/react-heartwood-components/src/components/RecordTable/RecordTable-story.js
@@ -1,0 +1,11 @@
+// @flow
+import React, { Component } from 'react'
+import { storiesOf } from '@storybook/react'
+import { withKnobs, text, boolean, number } from '@storybook/addon-knobs/react'
+import RecordTable from './RecordTable'
+
+const stories = storiesOf('RecordTable', module)
+
+stories.addDecorator(withKnobs)
+
+stories.add('RecordTable', () => <div>TODO</div>)

--- a/packages/react-heartwood-components/src/components/RecordTable/RecordTable.js
+++ b/packages/react-heartwood-components/src/components/RecordTable/RecordTable.js
@@ -1,0 +1,441 @@
+// @flow
+import React, { Component, Fragment } from 'react'
+
+import Table, { TableSearch } from '../Table'
+import Tabs from '../Tabs'
+import { TextInput } from '../Forms'
+import Button from '../Button/Button'
+
+import type { Props as TabProps } from '../Tabs/Tabs'
+
+const RECORD_TABLE_INITIAL_LIMIT = 10
+
+export type RecordTableFetchOptions = {
+	sortColumn: string,
+	sortDirection: string,
+	offset: number,
+	limit: number,
+	search?: string,
+	selectedTab?: string
+}
+
+export type RecordTableFetchResults = {|
+	visibleRows: Array<Object>,
+	totalRows: number
+|}
+
+export type Tab = {
+	...TabProps,
+	key: string,
+	payload?: Object
+}
+
+type RecordTableProps = {|
+	/** Singular noun describing the contents of this table */
+	kind?: string,
+
+	/** Plural noun describing the contents of this table */
+	pluralKind?: string,
+
+	/** for handling when a tab is selected, return false to stop tab form being set */
+	onClickTab?: (
+		e: MouseEvent,
+		{ idx: number, key: string, payload?: Object }
+	) => boolean,
+
+	/** the tabs to render, passed to Tabs component. onClick is ignored */
+	tabs?: Array<Tab>,
+
+	/** Should rows be selectable? */
+	isSelectable?: boolean,
+
+	/** which tab to select at first */
+	initialSelectedTab?: string,
+
+	/** how to sort to start */
+	initialSortColumn: string,
+
+	/** direction to start (defaults to desc) */
+	initialSortDirection?: string,
+
+	/** starting limit, defaults to RECORD_TABLE_INITIAL_LIMIT  */
+	initialLimit?: number,
+
+	/** The rows that should be visible when the table mounts */
+	initialVisibleRows: Array<Object>,
+
+	/** The total possible number of rows this table may contain */
+	totalRows: number,
+
+	/** should we enable searching? */
+	enableSearch?: boolean,
+
+	/** should we enable filtering? */
+	enableFilter?: boolean,
+
+	/** placeholder to show for search */
+	searchPlaceholder?: string,
+
+	/** props to pass through to the table search component */
+	tableSearchProps?: Object,
+
+	/** when rendering search results, this is how i'll know what to output */
+	searchSuggestionAccessor?: (suggestion: Object) => any,
+
+	/** called anytime records need to be fetched */
+	fetchRecords: (
+		options: RecordTableFetchOptions
+	) => Promise<RecordTableFetchResults>,
+
+	/** table columns to be rendered TODO(TR) import Column interfaces  */
+	columns: Array<Object>,
+
+	/** should I fetch all my data on mount? */
+	fetchOnMount?: boolean,
+
+	/** passthrough to Table component */
+	handleClickRow?: Function,
+
+	/** called when search suggestion is selected */
+	onSelection?: Function
+|}
+
+type RecordTableState = {
+	selectedTab?: string,
+	currentPage: number,
+	limit: number,
+	sortColumn: string,
+	sortDirection: string,
+	visibleRows: Array<Object>,
+	totalRows: number,
+	loading: boolean,
+	currentFilter?: string
+}
+
+class RecordTable extends Component<RecordTableProps, RecordTableState> {
+	static defaultProps = {
+		enableSearch: false,
+		enableFilter: false,
+		searchPlaceholder: 'Filter table...',
+		initialLimit: RECORD_TABLE_INITIAL_LIMIT
+	}
+
+	constructor(props: RecordTableProps) {
+		super(props)
+
+		this.state = {
+			loading: false,
+			currentPage: 0,
+			limit: props.initialLimit || RECORD_TABLE_INITIAL_LIMIT,
+			selectedTab: props.initialSelectedTab,
+			sortColumn: props.initialSortColumn,
+			sortDirection: props.initialSortDirection || 'desc',
+			visibleRows: props.initialVisibleRows,
+			totalRows: props.totalRows,
+			currentFilter: ''
+		}
+	}
+
+	handleClickTab = (e: MouseEvent, idx: number, tab: Tab) => {
+		const { onClickTab } = this.props
+		let cancel = false
+
+		if (onClickTab) {
+			cancel =
+				onClickTab(e, {
+					idx,
+					payload: tab.payload,
+					key: tab.key
+				}) === false
+		}
+
+		if (!cancel) {
+			this.setState({ selectedTab: tab.key })
+		}
+	}
+
+	refresh = async () => {
+		this.setState({ loading: true })
+		const { visibleRows, totalRows } = await this.fetchRecords({
+			page: this.state.currentPage
+		})
+		this.setState({ loading: false, visibleRows, totalRows })
+	}
+
+	navigateToPage = async ({
+		search,
+		page
+	}: { search?: string, page: number } = {}) => {
+		try {
+			const { visibleRows, totalRows } = await this.fetchRecords({
+				search,
+				page
+			})
+
+			this.setState({
+				currentPage: page,
+				visibleRows,
+				totalRows
+			})
+		} catch (e) {
+			// Nothing
+		}
+	}
+
+	fetchRecords = async ({
+		search,
+		page
+	}: {|
+		search?: string,
+		page: number
+	|}) => {
+		const {
+			sortDirection,
+			sortColumn,
+			limit,
+			selectedTab,
+			currentFilter
+		} = this.state
+
+		const offset = limit * page
+
+		const data = await this.props.fetchRecords({
+			sortColumn,
+			sortDirection,
+			limit,
+			offset,
+			selectedTab,
+			search: search || currentFilter
+		})
+
+		return data
+	}
+
+	handleSortChanged = (sorted: Array<{ id: string, desc: boolean }>) => {
+		const sort = {
+			sortColumn: sorted[0].id,
+			sortDirection: sorted[0].desc ? 'desc' : 'asc'
+		}
+
+		this.setState(sort, this.refresh)
+	}
+
+	handleClickTab = (e: MouseEvent, tab: Tab) => {
+		this.setState({ currentPage: 0, selectedTab: tab.key }, this.refresh)
+	}
+
+	handleSearchSuggestions = async (value: string) => {
+		const { currentPage } = this.state
+		const { visibleRows } = await this.fetchRecords({
+			page: currentPage,
+			search: value
+		})
+
+		const suggestions =
+			visibleRows.length > 0
+				? visibleRows.map<Object>((record: Object) => {
+						return {
+							text: record.name,
+							record
+						}
+				  })
+				: [
+						{
+							text: 'NO RESULTS',
+							isEmptyMessage: true,
+							value
+						}
+				  ]
+
+		return suggestions
+	}
+
+	renderSuggestion = (suggestion: any) => {
+		const {
+			// eslint-disable-next-line no-unused-vars
+			searchSuggestionAccessor = record => (
+				<Button
+					isSmall
+					className="autosuggest__list-item-inner"
+					text={suggestion.text}
+				/>
+			)
+		} = this.props
+
+		if (suggestion.isEmptyMessage && suggestion.value) {
+			return (
+				<div className="autosuggest__no-results">
+					<p className="autosuggest__no-results-title">No matches found.</p>
+					<p className="autosuggest__no-results-subtitle">
+						Please adjust your search and try again.
+					</p>
+				</div>
+			)
+		}
+
+		if (suggestion.isEmptyMessage && !suggestion.value) {
+			return (
+				<div className="autosuggest__no-results">
+					<p className="autosuggest__no-results-title">Type to search.</p>
+					<p className="autosuggest__no-results-subtitle">
+						{`I'll find whataver I can as fast as I can.`}
+					</p>
+				</div>
+			)
+		}
+
+		return searchSuggestionAccessor(suggestion.record)
+	}
+
+	componentDidMount = () => {
+		if (this.props.fetchOnMount) {
+			this.refresh()
+		}
+	}
+
+	handleSuggestionSelected = async (e: MouseEvent, suggestion: any) => {
+		this.props.onSelection && this.props.onSelection(e, suggestion)
+	}
+
+	render() {
+		const {
+			// eslint-disable-next-line no-unused-vars
+			onClickTab,
+			tabs,
+			columns,
+			isSelectable,
+			handleClickRow,
+			enableSearch,
+			enableFilter,
+			searchPlaceholder,
+			tableSearchProps = {},
+			...props
+		} = this.props
+		const {
+			currentPage,
+			sortColumn,
+			loading,
+			limit,
+			selectedTab,
+			visibleRows,
+			totalRows,
+			currentFilter
+		} = this.state
+
+		// setup default props types
+		tableSearchProps.getSuggestionValue =
+			tableSearchProps.getSuggestionValue ||
+			function(value) {
+				return value.text
+			}
+
+		tableSearchProps.getSuggestions =
+			tableSearchProps.getSuggestions || this.handleSearchSuggestions
+
+		tableSearchProps.renderSuggestion =
+			tableSearchProps.renderSuggestion || this.renderSuggestion
+
+		return (
+			<Fragment>
+				{tabs && (
+					<Tabs
+						tabs={tabs.map(tab => {
+							return {
+								...tab,
+								isCurrent: selectedTab === tab.key,
+								onClick: e => {
+									this.handleClickTab(e, tab)
+								}
+							}
+						})}
+						isPadded
+					/>
+				)}
+				{enableSearch && (
+					<TableSearch
+						placeholder={searchPlaceholder}
+						onSuggestionSelected={this.handleSuggestionSelected}
+						{...tableSearchProps}
+					/>
+				)}
+
+				{enableFilter && (
+					<div className="table-search__wrapper">
+						<div className="autosuggest__wrapper">
+							<TextInput
+								value={currentFilter}
+								placeholder={searchPlaceholder}
+								onChange={e => {
+									this.setState(
+										{
+											currentPage: 0,
+											currentFilter: e.target.value
+										},
+										() => {
+											this.refresh()
+										}
+									)
+								}}
+								isSmall
+							/>
+							<Button
+								isSmall
+								className="text-input__clear-btn"
+								icon={{
+									name: 'close'
+								}}
+								onClick={() => {
+									this.setState(
+										{
+											currentPage: 0,
+											currentFilter: ''
+										},
+										() => {
+											this.refresh()
+										}
+									)
+								}}
+							/>
+						</div>
+					</div>
+				)}
+
+				<Table
+					className="results-table"
+					isSelectable={isSelectable}
+					columns={columns}
+					defaultSorted={[
+						{
+							id: sortColumn,
+							desc: false
+						}
+					]}
+					pageSize={Math.min(visibleRows.length, limit)}
+					paginationProps={{
+						currentPage,
+						showPages: Math.ceil(totalRows / limit) > 1,
+						onClickNext: () => {
+							this.navigateToPage({ page: currentPage + 1 })
+						},
+						onClickBack: () => {
+							this.navigateToPage({ page: currentPage - 1 })
+						},
+						onPageButtonClick: (pageIdx: number) => {
+							this.navigateToPage({ page: pageIdx })
+						},
+						totalPages: Math.ceil(totalRows / limit)
+					}}
+					manual
+					loading={loading}
+					data={visibleRows || []}
+					onSortedChange={this.handleSortChanged}
+					onClickRow={handleClickRow}
+					key="id"
+					{...props}
+				/>
+			</Fragment>
+		)
+	}
+}
+
+export default RecordTable

--- a/packages/react-heartwood-components/src/components/Table/Table.js
+++ b/packages/react-heartwood-components/src/components/Table/Table.js
@@ -276,6 +276,7 @@ export default class Table extends Component<Props, State> {
 							: 'table-loader'
 					}
 				}}
+				getNoDataProps={() => ({ className: 'table__no-results-message ' })}
 				ThComponent={tableProps => {
 					const { toggleSort, className, ...rest } = tableProps
 					const isSortable =


### PR DESCRIPTION
- Moving RecordTable to react-heartwood (stubbed storybook page so this doesn't get forgotten)
- Update Table mostly to support totalRows but also to tweak varnames
- Fix some of the react-table injected UI classnames (temporary in some cases, as we've got designs for no-matches, etc)
- Update lerna watch command to work for react-heartwood
- Disable autocomplete on checkboxes so that they don't get "randomly" (not really randomly but not correctly in this implementation) re-checked when going backwards in history

Follow-ups:
- The flowtypes are pretty important to getting the implementation right, so I'm working on a `with-flow` export for react-heartwood. This is non-trivial since we're using a bunch of babel plugins that make the code incompatible with our next projects, so I need to make a pass across the codebase for that.