### PR TITLE
fix(babel): utils: force auto modules

### DIFF
--- a/packages/spruce-utils/.babelrc
+++ b/packages/spruce-utils/.babelrc
@@ -6,6 +6,7 @@
 			"next/babel",
 			{
 				"preset-env": {
+					"modules": "auto",
 					"targets": {
 						"browsers": "> 1%"
 					}


### PR DESCRIPTION
See https://github.com/zeit/next.js/blob/canary/packages/next/build/babel/preset.ts#L52-L56

I need to create a default config that all babel projects can use that has next's feature-set w/o the next-only junk. This was breaking utils with NODE_ENV=production. See the highlight in the link above.

- [ ] Feature
- [x] Bug
- [ ] Tech debt
