### PR TITLE
Fix link styling

### DIFF
--- a/packages/heartwood-components/components/03-structure/card.scss
+++ b/packages/heartwood-components/components/03-structure/card.scss
@@ -85,7 +85,7 @@
 }
 
 .card__body {
-	.text {
+	.text:not(a) {
 		color: $c-text-light;
 		line-height: $line-height-loose;
 	}


### PR DESCRIPTION
## Description

Fix styling for links that appear in cards (cases of `<Text element="a">`)

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt
