### PR TITLE
task(RecordSelectionList): Finish styles with correct UI controls

### DIFF
--- a/packages/heartwood-components/components/01-button/button.scss
+++ b/packages/heartwood-components/components/01-button/button.scss
@@ -134,6 +134,7 @@ Baseline styling for all buttons
 
 	&.btn-icon-only {
 		width: $tap-height;
+		min-width: 0;
 
 		&.btn-small {
 			width: $tap-height-small;

--- a/packages/heartwood-components/components/08-lists/lists.scss
+++ b/packages/heartwood-components/components/08-lists/lists.scss
@@ -208,17 +208,25 @@
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;
-		margin: 1rem;
-
-		.btn {
-			height: auto;
-			margin: 0;
-			padding: 0;
-		}
+		padding: spacing('base') 0;
 	}
 
 	.record-selection__list-wrapper {
 		position: relative;
 		min-height: 28rem;
+	}
+
+	.record-selection__record-wrapper {
+		display: flex;
+		align-items: center;
+		border-bottom: 1px solid $c-grey-03;
+	}
+
+	.record-selection__record-select {
+		margin-right: spacing('tight');
+	}
+
+	.record-selection__record-content {
+		flex: 1;
 	}
 }

--- a/packages/react-heartwood-components/src/components/Icon/Icon.js
+++ b/packages/react-heartwood-components/src/components/Icon/Icon.js
@@ -8,7 +8,7 @@ import * as icons from '../../icons.js'
 
 export type Props = {
 	/** The name of the icon to render. If not found, this will return null. */
-	icon: string,
+	icon?: string,
 
 	/** Set true to render an icon with a stroke, but no fill */
 	isLineIcon?: boolean,

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectList-story.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectList-story.js
@@ -48,6 +48,7 @@ class BasicExample extends Component<Props, State> {
 
 		return (
 			<RecordSelectionList
+				canSearch
 				selectedIds={selectedIds}
 				loadRecords={async ({ limit, offset, search }) => {
 					// Artificial API wait time

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
@@ -40,7 +40,7 @@ type RecordSelectionListProps = {|
 	/** Can the search the records in the list? */
 	canSearch?: boolean,
 
-  /** Array of IDs that should not be selectable */
+	/** Array of IDs that should not be selectable */
 	unselectableIds?: Array<RecordId>,
 
 	/** Can the user select many or one records in this list? */

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 
 import {
 	List,
@@ -9,6 +9,8 @@ import {
 	InfiniteLoader
 } from 'react-virtualized'
 
+import { TextInput, Checkbox, Radio } from '../Forms'
+import Button from '../Button/Button'
 import TextContainer from '../TextContainer/TextContainer'
 import Text from '../Text/Text'
 
@@ -35,11 +37,17 @@ type RecordSelectionListProps = {|
 	/** Array of IDs in this collection of records that should be marked as selected */
 	selectedIds?: Array<RecordId>,
 
+	/** Can the search the records in the list? */
+	canSearch?: boolean,
+
 	/** Can the user select many or one records in this list? */
 	canSelect?: 'many' | 'one',
 
 	/** Can the user remove records from this list? */
 	canRemove?: boolean,
+
+	/** Optionally provide a placeholder to the search input */
+	searchPlaceholder?: string,
 
 	/** Callback for selection of a record */
 	onSelect?: RecordId => void,
@@ -127,6 +135,7 @@ export default class RecordSelectionList extends Component<
 		const { loadedRecords } = this.state
 
 		const record = loadedRecords[index]
+		const SelectionComponent = canSelect === 'one' ? Radio : Checkbox
 
 		return (
 			record && (
@@ -142,8 +151,8 @@ export default class RecordSelectionList extends Component<
 						style={{ ...style }}
 					>
 						{onSelect && canSelect && (
-							<input
-								type={canSelect === 'one' ? 'radio' : 'checkbox'}
+							<SelectionComponent
+								className="record-selection__record-select"
 								onChange={() => {
 									onSelect(record.id)
 								}}
@@ -151,10 +160,16 @@ export default class RecordSelectionList extends Component<
 							/>
 						)}
 
-						<Fragment key={key}>{renderRecord(record)}</Fragment>
+						<div className="record-selection__record-content" key={key}>
+							{renderRecord(record)}
+						</div>
 
 						{onRemove && canRemove && (
-							<button
+							<Button
+								kind="simple"
+								disabled={false}
+								isSmall
+								icon={{ name: 'remove_circle', className: 'btn__line-icon' }}
 								onClick={() => {
 									this.setState({
 										loadedRecords: loadedRecords.filter(
@@ -164,9 +179,7 @@ export default class RecordSelectionList extends Component<
 
 									onRemove(record.id)
 								}}
-							>
-								x
-							</button>
+							/>
 						)}
 					</div>
 				</CellMeasurer>
@@ -235,7 +248,12 @@ export default class RecordSelectionList extends Component<
 	handleRemoveSelection = () => {}
 
 	render() {
-		const { selectedIds = [], totalRecordCount } = this.props
+		const {
+			selectedIds = [],
+			totalRecordCount,
+			canSearch,
+			searchPlaceholder
+		} = this.props
 		const { loadedRecords, search } = this.state
 		const totalSelected = selectedIds.length
 		const isRowLoaded = ({ index }) => {
@@ -255,7 +273,14 @@ export default class RecordSelectionList extends Component<
 					<Text>{`${totalSelected} selected`}</Text>
 				</TextContainer>
 
-				<input type="text" value={search} onChange={this.handleSearchUpdate} />
+				{canSearch && (
+					<TextInput
+						type="text"
+						placeholder={searchPlaceholder || 'Search...'}
+						value={search}
+						onChange={this.handleSearchUpdate}
+					/>
+				)}
 
 				<div className="record-selection__list-wrapper">
 					<AutoSizer onResize={onResize}>


### PR DESCRIPTION
RecordSelectionList, with proper form controls

**Notes:**
- There is no canonical filled circle remove icon, so I'm using the lined version until one is available
- There is no "greyscale" Button with a hover/focus treatment (you can provide something busted to `kind` but that seems like a bug, and it doesn't have hover), so I'm using the default simple button.
- I chose to center align the select control / record item / remove button; the user may provide arbitrary components as the record renderer, and fixing top-alignment to be juuuuust right for `ListItem` felt like it would cause issues with non-ListItem recordRenderers. 

![feb-08-2019 10-31-24-3](https://user-images.githubusercontent.com/1161192/52491818-944d7c80-2b8d-11e9-8f22-5d2a7c049bbc.gif)
