### PR TITLE
feat(spruce-skill): Support Skill View Dialogs in Core

### DIFF
--- a/packages/heartwood-components/components/06-modal/modal.scss
+++ b/packages/heartwood-components/components/06-modal/modal.scss
@@ -90,6 +90,10 @@
 			transform: translate(-50%, 0);
 		}
 
+		&.modal-fullHeight {
+			height: 100%;
+		}
+
 		@include gt('small') {
 			top: spacing('base');
 			left: spacing('base');

--- a/packages/react-heartwood-components/src/components/Modal/Modal.js
+++ b/packages/react-heartwood-components/src/components/Modal/Modal.js
@@ -13,6 +13,9 @@ type Props = {
 	/** Set true to show the modal */
 	isOpen: boolean,
 
+	/** Should the modal stretch to its maximum height whatever the content? */
+	isFullHeight: boolean,
+
 	/** Size of the modal */
 	size: 'small' | 'medium' | 'full-width'
 }
@@ -26,10 +29,11 @@ export default class Modal extends React.PureComponent<Props, State> {
 		size: 'medium'
 	}
 	render() {
-		const { isOpen, size, ...rest } = this.props
+		const { isOpen, size, isFullHeight, ...rest } = this.props
 		const modalClassName = cx('modal', {
 			'modal-small': size === 'small',
-			'modal-medium': size === 'medium'
+			'modal-medium': size === 'medium',
+			'modal-fullHeight': isFullHeight
 		})
 		return (
 			<ReactModal

--- a/packages/spruce-skill/interface/pages/skill-views/example_skill_view_dialog.js
+++ b/packages/spruce-skill/interface/pages/skill-views/example_skill_view_dialog.js
@@ -35,21 +35,16 @@ class TestSkillView extends React.Component<Props> {
 				<PageContent>
 					<Layout>
 						<LayoutSection>
+							<div>Hooray from inside your skill!</div>
 							<Button
-								text="Open a skill view dialog!"
+								text="I'm done please close this modal!"
 								kind="primary"
 								disabled={false}
-								icon={{ name: 'new_tab' }}
+								icon={{ name: 'remove', isLineIcon: true }}
 								onClick={() => {
 									Iframes.sendMessage({
 										to: window.parent,
-										eventName: 'SkillViewDialog:Open',
-										data: {
-											title: 'A Cool Skill View Dialog',
-											src: `${window.location.protocol}//${
-												window.location.hostname
-											}/skill-views/example_skill_view_dialog`
-										}
+										eventName: 'SkillViewDialog:Close'
 									})
 								}}
 							/>

--- a/packages/spruce-utils/lib/iframes.js
+++ b/packages/spruce-utils/lib/iframes.js
@@ -30,7 +30,7 @@ export default class Iframes {
 		if (onResponse) {
 			const responseHandler = event => {
 				if (event.data.eventName === responseEventName) {
-					onResponse(event.data.dataFromUser)
+					onResponse(event.data.dataFromUser, event)
 					window.removeEventListener('message', responseHandler)
 				}
 			}
@@ -81,7 +81,7 @@ export default class Iframes {
 				const data =
 					typeof event.data === 'string' ? eventData : event.data.dataFromUser
 
-				callback(data, responder)
+				callback(data, responder, event)
 			}
 			// }
 		}


### PR DESCRIPTION
- Added the concept of a "fullHeight" modal, which stretches to fill the screen. This is needed since we don't know the height of the iframe content ahead of time, and doing a bunch of resize work would be jank. We could fix the height to a smaller static value if this seems like overkill.
- Removed the CardBuilder from example skill view, since they didn't hold any meaningful data and were broken anyway with the recent cardbuilder changes.
- in `Iframes`, added an argument to the callbacks to reveal the original event, should you need it (I need it in core to determine which iframe is sending messages when I have multiples)

![feb-08-2019 17-22-05](https://user-images.githubusercontent.com/1161192/52511880-a815d480-2bc7-11e9-9905-46b0f852f30b.gif)