### PR TITLE
[SBL-1982] Empty State React Component

### DIFF
--- a/packages/heartwood-components/components/__partials/icon.hbs
+++ b/packages/heartwood-components/components/__partials/icon.hbs
@@ -1,8 +1,10 @@
 {{!-- TODO: Make it possible to style line icons different from fill icons --}}
 <?xml version="1.0" encoding="utf-8"?>
-<svg class="{{ class }}" version=" 1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
- x="0px" y="0px" width="{{#if width}}{{width}}{{else}}24{{/if}}px" height="{{#if height}}{{height}}{{else}}24{{/if}}px"
- viewBox="0 0 {{#if width}}{{width}}{{else}}24{{/if}} {{#if height}}{{height}}{{else}}24{{/if}}" enable-background="new 0 0 {{#if width}}{{width}}{{else}}24{{/if}} {{#if height}}{{height}}{{else}}24{{/if}}"
- xml:space="preserve">
+<svg class="icon {{ class }}" version=" 1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg"
+	xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="{{#if width}}{{width}}{{else}}24{{/if}}px"
+	height="{{#if height}}{{height}}{{else}}24{{/if}}px"
+	viewBox="0 0 {{#if width}}{{width}}{{else}}24{{/if}} {{#if height}}{{height}}{{else}}24{{/if}}"
+	enable-background="new 0 0 {{#if width}}{{width}}{{else}}24{{/if}} {{#if height}}{{height}}{{else}}24{{/if}}"
+	xml:space="preserve">
 	{{{icon}}}
 </svg>

--- a/packages/heartwood-components/components/empty-state/empty-state.config.js
+++ b/packages/heartwood-components/components/empty-state/empty-state.config.js
@@ -9,13 +9,17 @@ module.exports = {
 	context: {
 		headline: 'Headline',
 		subheadline: 'Subheadline',
-		icon:
-			'<path fill="none" fill-rule="evenodd" clip-rule="evenodd" d="M6 7C7.51878 7 8.75 5.76878 8.75 4.25C8.75 2.73122 7.51878 1.5 6 1.5C4.48122 1.5 3.25 2.73122 3.25 4.25C3.25 5.76878 4.48122 7 6 7Z" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill="none" d="M1.5 12.5001C1.50011 10.7267 2.54175 9.11875 4.16015 8.39369C5.77855 7.66863 7.67188 7.96169 8.99533 9.14212" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill="none" d="M8.5 14.5L10.5 16.5L12.5 14.5" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill="none" d="M10.5 16.5V10.5" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill="none" d="M12.5 12.5L14.5 10.5L16.5 12.5" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill="none" d="M14.5 10.5V16.5" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>',
+		icon: {
+			src:
+				'<path fill-rule="evenodd" clip-rule="evenodd" d="M12 1.70996C16.1421 1.70996 19.5 5.06783 19.5 9.20996C19.5 12.757 14 21.591 12.421 24.06C12.3291 24.2034 12.1704 24.2902 12 24.2902C11.8296 24.2902 11.6709 24.2034 11.579 24.06C10 21.592 4.5 12.757 4.5 9.20996C4.5 5.06783 7.85786 1.70996 12 1.70996Z" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill-rule="evenodd" clip-rule="evenodd" d="M12 12.21C13.6569 12.21 15 10.8668 15 9.20996C15 7.55311 13.6569 6.20996 12 6.20996C10.3431 6.20996 9 7.55311 9 9.20996C9 10.8668 10.3431 12.21 12 12.21Z" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>'
+		},
 		action: {
 			className: 'btn-simple',
 			text: 'Go back',
-			icon:
-				'<path fill-rule="evenodd" clip-rule="evenodd" d="M16.6663 9.16665H6.52467L11.183 4.50831L9.99967 3.33331L3.33301 9.99998L9.99967 16.6666L11.1747 15.4916L6.52467 10.8333H16.6663V9.16665V9.16665Z"/>'
+			icon: {
+				src:
+					'<path fill-rule="evenodd" clip-rule="evenodd" d="M16.6663 9.16665H6.52467L11.183 4.50831L9.99967 3.33331L3.33301 9.99998L9.99967 16.6666L11.1747 15.4916L6.52467 10.8333H16.6663V9.16665V9.16665Z"/>'
+			}
 		}
 	},
 	variants: [

--- a/packages/heartwood-components/components/empty-state/empty-state.config.js
+++ b/packages/heartwood-components/components/empty-state/empty-state.config.js
@@ -1,0 +1,74 @@
+module.exports = {
+	title: 'Empty State',
+	collated: true,
+	collator: function(markup, item) {
+		return `<!-- Start: @${item.handle} -->\n${markup}\n<!-- End: @${
+			item.handle
+		} -->\n`
+	},
+	context: {
+		headline: 'Headline',
+		subheadline: 'Subheadline',
+		icon:
+			'<path fill="none" fill-rule="evenodd" clip-rule="evenodd" d="M6 7C7.51878 7 8.75 5.76878 8.75 4.25C8.75 2.73122 7.51878 1.5 6 1.5C4.48122 1.5 3.25 2.73122 3.25 4.25C3.25 5.76878 4.48122 7 6 7Z" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill="none" d="M1.5 12.5001C1.50011 10.7267 2.54175 9.11875 4.16015 8.39369C5.77855 7.66863 7.67188 7.96169 8.99533 9.14212" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill="none" d="M8.5 14.5L10.5 16.5L12.5 14.5" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill="none" d="M10.5 16.5V10.5" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill="none" d="M12.5 12.5L14.5 10.5L16.5 12.5" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path fill="none" d="M14.5 10.5V16.5" stroke="#0099FF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>',
+		action: {
+			className: 'btn-simple',
+			text: 'Go back',
+			icon:
+				'<path fill-rule="evenodd" clip-rule="evenodd" d="M16.6663 9.16665H6.52467L11.183 4.50831L9.99967 3.33331L3.33301 9.99998L9.99967 16.6666L11.1747 15.4916L6.52467 10.8333H16.6663V9.16665V9.16665Z"/>'
+		}
+	},
+	variants: [
+		{
+			name: 'Without subheadline',
+			context: {
+				subheadline: null,
+				action: {
+					className: 'btn-primary',
+					text: 'Go back'
+				}
+			}
+		},
+		{
+			name: 'Without icon',
+			context: {
+				icon: null
+			}
+		},
+		{
+			name: 'Without actions',
+			context: {
+				actions: null
+			}
+		},
+		{
+			name: 'Without subheadline, icon',
+			context: {
+				subheadline: null,
+				icon: null
+			}
+		},
+		{
+			name: 'Without subheadline, actions',
+			context: {
+				subheadline: null,
+				action: null
+			}
+		},
+		{
+			name: 'Without actions, icon',
+			context: {
+				icon: null,
+				action: null
+			}
+		},
+		{
+			name: 'Without subheadline, icon, actions',
+			context: {
+				subheadline: null,
+				icon: null,
+				action: null
+			}
+		}
+	]
+}

--- a/packages/heartwood-components/components/empty-state/empty-state.hbs
+++ b/packages/heartwood-components/components/empty-state/empty-state.hbs
@@ -1,10 +1,10 @@
 <div class="empty-state">
-    {{> @icon icon=icon}}
-    <h3 class="empty-state__headline">Headline</h3>
-    {{#if subheadline}}
-    <div class="empty-state__subheadline">Subheadline</div>
-    {{/if}}
-    {{#if action}}
-    {{> @button className=action.className text=action.text icon=action.icon }}
-    {{/if}}
+	<span class="empty-state__icon">{{> @icon icon=icon.src class=icon.className}}</span>
+	<h3 class="empty-state__headline">Headline</h3>
+	{{#if subheadline}}
+	<div class="empty-state__subheadline">Subheadline</div>
+	{{/if}}
+	{{#if action}}
+	{{> @button className=action.className text=action.text icon=action.icon.src }}
+	{{/if}}
 </div>

--- a/packages/heartwood-components/components/empty-state/empty-state.hbs
+++ b/packages/heartwood-components/components/empty-state/empty-state.hbs
@@ -1,0 +1,10 @@
+<div class="empty-state">
+    {{> @icon icon=icon}}
+    <h3 class="empty-state__headline">Headline</h3>
+    {{#if subheadline}}
+    <div class="empty-state__subheadline">Subheadline</div>
+    {{/if}}
+    {{#if action}}
+    {{> @button className=action.className text=action.text icon=action.icon }}
+    {{/if}}
+</div>

--- a/packages/heartwood-components/components/empty-state/empty-state.scss
+++ b/packages/heartwood-components/components/empty-state/empty-state.scss
@@ -6,4 +6,15 @@
 	&__headline {
 		font-weight: $font-weight-bold;
 	}
+
+	&__icon {
+		display: inline-block;
+
+		.icon {
+			fill: none;
+			height: 56px;
+			stroke: $c-text-icon;
+			width: 56px;
+		}
+	}
 }

--- a/packages/heartwood-components/components/empty-state/empty-state.scss
+++ b/packages/heartwood-components/components/empty-state/empty-state.scss
@@ -1,0 +1,9 @@
+.empty-state {
+	color: $c-text-light;
+	padding: spacing('base');
+	text-align: center;
+
+	&__headline {
+		font-weight: $font-weight-bold;
+	}
+}

--- a/packages/heartwood-components/stylesheets/heartwood-components.scss
+++ b/packages/heartwood-components/stylesheets/heartwood-components.scss
@@ -59,3 +59,4 @@ $foit: true;
 @import '../components/99-web/detail-view';
 @import '../components/feed/feed';
 @import '../components/message/message';
+@import '../components/empty-state/empty-state';

--- a/packages/react-heartwood-components/src/components/EmptyState/EmptyState-story.js
+++ b/packages/react-heartwood-components/src/components/EmptyState/EmptyState-story.js
@@ -1,0 +1,60 @@
+// @flow
+import React from 'react'
+import { each, keys } from 'lodash'
+import { storiesOf } from '@storybook/react'
+import {
+	withKnobs,
+	withKnobsOptions,
+	text,
+	boolean,
+	select,
+	object
+} from '@storybook/addon-knobs/react'
+import EmptyState from './EmptyState'
+import * as icons from '../../icons.js'
+
+const options = {}
+
+each(keys(icons), icon => {
+	options[icon] = icon
+})
+
+const stories = storiesOf('EmptyState', module)
+
+stories.addDecorator(
+	withKnobsOptions({
+		escapeHTML: false
+	})
+)
+stories.addDecorator(withKnobs)
+
+stories.add('Simple', () => (
+	<EmptyState
+		headline={text('headline', 'Data not available')}
+		subheadline={text('subheadline', 'Please try again later')}
+	/>
+))
+
+stories.add('Full', () => (
+	<EmptyState
+		icon={select('icon', options, 'location')}
+		isLineIcon={boolean('isLineIcon', true)}
+		headline={text('headline', 'Data not available')}
+		subheadline={text('subheadline', 'Please try again later')}
+		primaryAction={object('primary button action', {
+			text: 'Try Again',
+			onClick: () => console.log('Next'),
+			type: 'submit'
+		})}
+		primaryActionButtonKind={select(
+			'primary button kind',
+			['primary', 'secondary', 'simple', 'caution'],
+			'simple'
+		)}
+		primaryActionButtonIcon={select(
+			'primary button icon',
+			options,
+			'rotate_left'
+		)}
+	/>
+))

--- a/packages/react-heartwood-components/src/components/EmptyState/EmptyState.js
+++ b/packages/react-heartwood-components/src/components/EmptyState/EmptyState.js
@@ -42,7 +42,7 @@ const EmptyState = (props: Props) => {
 		<div className="empty-state">
 			{icon && (
 				<span className="empty-state__icon">
-					<Icon icon={icon} isLineIcon={isLineIcon || true} />
+					<Icon icon={icon} isLineIcon={isLineIcon} />
 				</span>
 			)}
 			<h3 className="empty-state__headline">{headline}</h3>
@@ -56,7 +56,7 @@ const EmptyState = (props: Props) => {
 							? { name: primaryActionButtonIcon, className: `btn__line-icon` }
 							: null
 					}
-					kind={primaryActionButtonKind || `simple`}
+					kind={primaryActionButtonKind}
 					{...primaryAction}
 				/>
 			)}
@@ -65,7 +65,9 @@ const EmptyState = (props: Props) => {
 }
 
 EmptyState.defaultProps = {
-	headline: 'Data not available'
+	headline: `Data not available`,
+	isLineIcon: true,
+	primaryActionButtonKind: `simple`
 }
 
 export default EmptyState

--- a/packages/react-heartwood-components/src/components/EmptyState/EmptyState.js
+++ b/packages/react-heartwood-components/src/components/EmptyState/EmptyState.js
@@ -1,0 +1,71 @@
+// @flow
+import React from 'react'
+import Icon from '../Icon/Icon'
+import Button from '../Button/Button'
+import type { Props as ButtonProps } from '../Button/Button'
+
+export type Props = {
+	/** Headline text to be displayed */
+	headline: string,
+
+	/** Subheadline text to be displayed (optional) */
+	subheadline?: string,
+
+	/** Primary icon to be displayed above the headline (optional) */
+	icon?: string,
+
+	/** Primary icon as line art (optional) */
+	isLineIcon?: boolean,
+
+	/** Primary action in the footer (optional) */
+	primaryAction?: { ...ButtonProps },
+
+	/** Primary action in the footer (optional) */
+	primaryActionButtonKind?: string,
+
+	/** Primary action in the footer (optional) */
+	primaryActionButtonIcon?: string
+}
+
+const EmptyState = (props: Props) => {
+	const {
+		headline,
+		subheadline,
+		icon,
+		isLineIcon,
+		primaryAction,
+		primaryActionButtonKind,
+		primaryActionButtonIcon
+	} = props
+
+	return (
+		<div className="empty-state">
+			{icon && (
+				<span className="empty-state__icon">
+					<Icon icon={icon} isLineIcon={isLineIcon || true} />
+				</span>
+			)}
+			<h3 className="empty-state__headline">{headline}</h3>
+			{subheadline && (
+				<div className="empty-state__subheadline">{subheadline}</div>
+			)}
+			{primaryAction && (
+				<Button
+					icon={
+						primaryActionButtonIcon
+							? { name: primaryActionButtonIcon, className: `btn__line-icon` }
+							: null
+					}
+					kind={primaryActionButtonKind || `simple`}
+					{...primaryAction}
+				/>
+			)}
+		</div>
+	)
+}
+
+EmptyState.defaultProps = {
+	headline: 'Data not available'
+}
+
+export default EmptyState


### PR DESCRIPTION
## What does this PR do?
Creates a re-usable React Empty State Heartwood Component with headline, subheadline, primary icon, and button action (w/ support for button kind [primary|secondary|caution|simple]) as well as a button icon).

## Type
- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?
* [SBL-1982](https://sprucelabsai.atlassian.net/browse/SBL-1982)

## Where should the reviewer start?
Screenshot review then code review.

## Any background context you want to provide?
Dependent on PR #393 getting merged first

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)
No

## Screenshots (if appropriate)
![screen shot 2019-02-13 at 4 37 36 pm](https://user-images.githubusercontent.com/374170/52751892-34503f00-2fae-11e9-8d5f-ec995ab0c4a1.png)

## What gif best describes this PR or how it makes you feel?
![candy](https://user-images.githubusercontent.com/374170/52751903-3e723d80-2fae-11e9-991a-a41340d31f73.gif)


