### PR TITLE
fix(skill-view): Get _document config from next/config rather than props

### DIFF
--- a/packages/spruce-next-helpers/src/skillskit/next/_document.js
+++ b/packages/spruce-next-helpers/src/skillskit/next/_document.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import Document, { Head, Main, NextScript } from 'next/document'
+import getConfig from 'next/config'
+
 const debug = require('debug')('@sprucelabs/spruce-next-helpers')
+const { publicRuntimeConfig } = getConfig()
 
 export default class MyDocument extends Document {
 	static async getInitialProps({ renderPage, query, store }) {
@@ -34,17 +37,17 @@ export default class MyDocument extends Document {
 
 	render() {
 		let bodyClassName =
-			this.props.config && this.props.config.SLUG
-				? `skill-${this.props.config.SLUG}`
+			publicRuntimeConfig && publicRuntimeConfig.SLUG
+				? `skill-${publicRuntimeConfig.SLUG}`
 				: ''
 
 		return (
 			<html className={`skill ${bodyClassName}`}>
 				<Head>
 					<meta name="viewport" content="width=device-width, initial-scale=1" />
-					{this.props.config && this.props.config.SKILL_STYLESHEET && (
+					{publicRuntimeConfig && publicRuntimeConfig.SKILL_STYLESHEET && (
 						<link
-							href={this.props.config.SKILL_STYLESHEET}
+							href={publicRuntimeConfig.SKILL_STYLESHEET}
 							rel="stylesheet"
 							type="text/css"
 							charSet="UTF-8"

--- a/packages/spruce-skill/interface/next.config.js
+++ b/packages/spruce-skill/interface/next.config.js
@@ -4,6 +4,8 @@ const config = require('config')
 const withSass = require('@zeit/next-sass')
 const withCSS = require('@zeit/next-css')
 
+const clientConfig = config.sanitizeClientConfig({ ...config })
+
 function server(webpack) {
 	return webpack
 }
@@ -11,7 +13,6 @@ function server(webpack) {
 function client(webpack) {
 	const jsonPath = path.resolve(__dirname, './client.json')
 	// Remove sensitive keys
-	const clientConfig = config.sanitizeClientConfig({ ...config })
 	// Export our whitelisted config for the client bundle
 	fs.writeFileSync(jsonPath, JSON.stringify(clientConfig))
 	webpack.plugins = webpack.plugins.filter(plugin => {
@@ -57,6 +58,7 @@ module.exports = withCSS(
 			} else {
 				return client(webpack, options)
 			}
-		}
+		},
+		publicRuntimeConfig: { ...clientConfig }
 	})
 )


### PR DESCRIPTION
- Props don't get passed on to error pages (since Next caught an exception / might not have the props and has to react predictably), so the injected props from skillView HOCs aren't available. This was removing the config necessary to inject stylesheets on error pages.
- Using the NextJS standard way of injecting universal config (`next/config`)
- We need to do this more generally in skillView / as a part of removing more of the prop injection

Closes [SBL-1387](https://sprucelabsai.atlassian.net/browse/SBL-1387)

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt

### Before:
![screen shot 2019-02-14 at 1 36 17 pm](https://user-images.githubusercontent.com/1161192/52812646-91ef9480-305d-11e9-8745-c5d5ee57dfca.png)

### After: 
![screen shot 2019-02-14 at 1 35 42 pm](https://user-images.githubusercontent.com/1161192/52812650-95831b80-305d-11e9-8abf-51b799583b5c.png)
