### PR TITLE
Empty State defaults for RecordTable [SBL-1996]

### DIFF
--- a/packages/react-heartwood-components/src/components/Table/Table.js
+++ b/packages/react-heartwood-components/src/components/Table/Table.js
@@ -312,7 +312,7 @@ export default class Table extends Component<Props, State> {
 					subheadline: noDataSubheadline,
 					primaryAction: noDataPrimaryAction,
 					primaryActionButtonKind: noDataPrimaryActionButtonKind,
-					noDataPrimaryActionButtonIcon: noDataPrimaryActionButtonIcon
+					primaryActionButtonIcon: noDataPrimaryActionButtonIcon
 				})}
 				NoDataComponent={EmptyState}
 				ThComponent={tableProps => {

--- a/packages/react-heartwood-components/src/components/Table/Table.js
+++ b/packages/react-heartwood-components/src/components/Table/Table.js
@@ -6,6 +6,7 @@ import cx from 'classnames'
 import { Checkbox } from '../Forms'
 import Pagination from '../Pagination/Pagination'
 import Icon from '../Icon/Icon'
+import EmptyState from '../EmptyState/EmptyState'
 import ContextMenu from '../ContextMenu/ContextMenu'
 import type { Props as ButtonProps } from '../Button/Button'
 import type { Props as PaginationProps } from '../Pagination/Pagination'
@@ -48,7 +49,21 @@ type Props = {
 	onClickRow?: (e: MouseEvent, meta: { idx: number, item: Object }) => void,
 
 	/** Callback when selection changes */
-	onSelection?: ({ selectedIds: Array<string | number> }) => void
+	onSelection?: ({ selectedIds: Array<string | number> }) => void,
+
+	/** No data available */
+	noDataIcon?: string,
+	noDataHeadline?: string,
+	noDataSubheadline?: string,
+	noDataPrimaryAction?: PrimaryAction,
+	noDataPrimaryActionButtonKind?: string,
+	noDataPrimaryActionButtonIcon?: string
+}
+
+type PrimaryAction = {
+	text: string,
+	onClick: (e: MouseEvent) => void,
+	type: string
 }
 
 type State = {
@@ -62,7 +77,16 @@ export default class Table extends Component<Props, State> {
 	static defaultProps = {
 		className: '',
 		paginationProps: {},
-		isSelectable: false
+		isSelectable: false,
+		noDataIcon: 'caution',
+		noDataHeadline: 'Data not available',
+		noDataPrimaryAction: {
+			text: 'Try Again',
+			onClick: () => window.location.reload(),
+			type: 'submit'
+		},
+		noDataPrimaryActionButtonKind: 'simple',
+		noDataPrimaryActionButtonIcon: 'rotate_left'
 	}
 
 	constructor(props: Props) {
@@ -150,6 +174,12 @@ export default class Table extends Component<Props, State> {
 			pluralKind,
 			bulkActions,
 			sortable,
+			noDataIcon,
+			noDataHeadline,
+			noDataSubheadline,
+			noDataPrimaryAction,
+			noDataPrimaryActionButtonKind,
+			noDataPrimaryActionButtonIcon,
 			...rest
 		} = this.props
 		const { selectedIds } = this.state
@@ -276,7 +306,15 @@ export default class Table extends Component<Props, State> {
 							: 'table-loader'
 					}
 				}}
-				getNoDataProps={() => ({ className: 'table__no-results-message ' })}
+				getNoDataProps={() => ({
+					icon: noDataIcon,
+					headline: noDataHeadline,
+					subheadline: noDataSubheadline,
+					primaryAction: noDataPrimaryAction,
+					primaryActionButtonKind: noDataPrimaryActionButtonKind,
+					noDataPrimaryActionButtonIcon: noDataPrimaryActionButtonIcon
+				})}
+				NoDataComponent={EmptyState}
 				ThComponent={tableProps => {
 					const { toggleSort, className, ...rest } = tableProps
 					const isSortable =


### PR DESCRIPTION
## What does this PR do?
Injects a default, user-friendly `EmptyState` component into the core of the `RecordTable` component that replaces the "No rows found" error message. When no data is loaded from the API, the Empty State component will be rendered in place of rows of data (see screenshot).

## Type
- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

* [SBL-1996](https://sprucelabsai.atlassian.net/browse/SBL-1996)

## Where should the reviewer start?
Code review, local testing

## Any background context you want to provide?
n/a

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)
No

## Screenshots (if appropriate)
![screen shot 2019-02-18 at 9 14 09 am](https://user-images.githubusercontent.com/374170/52963671-a386b400-335d-11e9-90e5-d19246a0da31.png)

## What gif best describes this PR or how it makes you feel?
![beep-boop-beep](https://user-images.githubusercontent.com/374170/52963680-af727600-335d-11e9-947e-a6dcb813661e.gif)
