### PR TITLE
refactor(Table): Sane default for the Empty State primary action butt…

### DIFF
--- a/packages/react-heartwood-components/src/components/Table/Table.js
+++ b/packages/react-heartwood-components/src/components/Table/Table.js
@@ -86,7 +86,7 @@ export default class Table extends Component<Props, State> {
 			type: 'submit'
 		},
 		noDataPrimaryActionButtonKind: 'simple',
-		noDataPrimaryActionButtonIcon: 'rotate_left'
+		noDataPrimaryActionButtonIcon: null
 	}
 
 	constructor(props: Props) {


### PR DESCRIPTION
…on icon instead of the refresh icon

## Description

Removes the `rotate_left` icon default for the Empty State primary action button. It is not safe to assume this is a sane default, and would need to be set to `null` by the dev to prevent it from rendering. Instead, the default is now null and the icon must be explicitly set to be visible.

## Type

- [ ] Feature
- [ ] Bug
- [ ] Tech debt
- [x] Refactor
