### PR TITLE
feat(RecordSelectionList): Support arbitrary data with getRecordId

### DIFF
--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectList-story.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectList-story.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react'
-import { sampleSize } from 'lodash'
+import { map, sampleSize } from 'lodash'
 import { storiesOf } from '@storybook/react'
 import { withKnobs } from '@storybook/addon-knobs/react'
 
@@ -70,7 +70,7 @@ class BasicExample extends Component<Props, State> {
 
 					if (search) {
 						const filteredLocations = locations.filter(location => {
-							return location.publicName.match(new RegExp(search, 'ig'))
+							return location.node.publicName.match(new RegExp(search, 'ig'))
 						})
 
 						results = filteredLocations.slice(offset, offset + limit)
@@ -84,15 +84,16 @@ class BasicExample extends Component<Props, State> {
 
 					return results
 				}}
+				getRecordId={record => record.node.id}
 				renderRecord={record => (
 					<RecordSelectionListItem
-						id={record.id}
-						title={record.publicName}
-						subtitle={record.address}
+						id={record.node.id}
+						title={record.node.publicName}
+						subtitle={record.node.address}
 						icon={{ name: 'location', isLineIcon: true }}
-						isDisabled={unselectableIds.indexOf(record.id) >= 0}
+						isDisabled={unselectableIds.indexOf(record.node.id) >= 0}
 						note={
-							unselectableIds.indexOf(record.id) >= 0 &&
+							unselectableIds.indexOf(record.node.id) >= 0 &&
 							'Location already in group!'
 						}
 					/>
@@ -133,7 +134,9 @@ stories.add('Default', () => (
 	<BasicExample
 		canSelect={select('Can Select', [null, 'many', 'one'], null)}
 		canRemove={select('Can Remove', [true, false], false)}
-		locations={generateLocations({ amount: 100 })}
+		locations={map(generateLocations({ amount: 100 }), o => ({
+			node: { ...o }
+		}))}
 	/>
 ))
 

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
@@ -23,6 +23,11 @@ type RecordSelectionListProps = {|
 	/** Required method to render a record into a node */
 	renderRecord: any => Node,
 
+	/** Get a unique ID for a record; given that data may be shaped in an unpredictable manner,
+	 * you must implement this at each usage.
+	 */
+	getRecordId: Record => string,
+
 	/** Load records for the offset/limit provided */
 	loadRecords: ({|
 		offset: number,
@@ -85,6 +90,12 @@ export default class RecordSelectionList extends Component<
 	constructor(props: RecordSelectionListProps) {
 		super(props)
 
+		if (!props.getRecordId) {
+			throw new Error(
+				"RecordSelectionList: `getRecordId` must be provided to determine a record's unique identifier. (record => string)"
+			)
+		}
+
 		this.state = { loadedRecords: [], isLoading: false, search: '' }
 	}
 
@@ -131,6 +142,7 @@ export default class RecordSelectionList extends Component<
 			selectedIds,
 			unselectableIds,
 			renderRecord,
+			getRecordId,
 			canSelect,
 			canRemove,
 			onSelect,
@@ -158,12 +170,15 @@ export default class RecordSelectionList extends Component<
 							<SelectionComponent
 								className="record-selection__record-select"
 								onChange={() => {
-									onSelect(record.id, record)
+									onSelect(getRecordId(record), record)
 								}}
 								disabled={
-									unselectableIds && unselectableIds.indexOf(record.id) >= 0
+									unselectableIds &&
+									unselectableIds.indexOf(getRecordId(record)) >= 0
 								}
-								checked={selectedIds && selectedIds.indexOf(record.id) >= 0}
+								checked={
+									selectedIds && selectedIds.indexOf(getRecordId(record)) >= 0
+								}
 							/>
 						)}
 
@@ -180,11 +195,12 @@ export default class RecordSelectionList extends Component<
 								onClick={() => {
 									this.setState({
 										loadedRecords: loadedRecords.filter(
-											loadedRecord => loadedRecord.id !== record.id
+											loadedRecord =>
+												getRecordId(loadedRecord) !== getRecordId(record)
 										)
 									})
 
-									onRemove(record.id, record)
+									onRemove(getRecordId(record), record)
 								}}
 							/>
 						)}


### PR DESCRIPTION
- Resulting from the relay migration
- You can use this to create UIDs on your own if your data didn't come 
with IDs!

## Type

- [x] Feature
- [X] Bug
- [ ] Tech debt
