### PR TITLE
fix(BigCalendar): Prep for usage in core web [SBL-2216]

### DIFF
--- a/packages/heartwood-components/components/09-bigcalendar/bigcalendar.scss
+++ b/packages/heartwood-components/components/09-bigcalendar/bigcalendar.scss
@@ -31,6 +31,10 @@ $event-indent-width: rem(50);
 }
 
 .bigcalendar {
+	height: 100%;
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
 	background-color: #fff;
 	-webkit-touch-callout: none;
 	-webkit-user-select: none; /* Disable selection/copy in UIWebView */
@@ -38,9 +42,6 @@ $event-indent-width: rem(50);
 	* {
 		box-sizing: border-box;
 	}
-}
-
-body.sb-show-main {
 }
 
 .bigcalendar__header-top {
@@ -215,7 +216,17 @@ body.sb-show-main {
 	}
 }
 
+.bigcalendar__view-wrapper {
+	flex: 1;
+	overflow: hidden;
+}
+
 .bigcalendar__view-day {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+
 	.bigcalendar__time-gutter {
 		@include type-style-label;
 		min-width: $time-gutter-width;
@@ -392,9 +403,6 @@ body.sb-show-main {
 
 	&.is-drag-source {
 		opacity: 0.5;
-	}
-
-	&.is-active-drag {
 	}
 
 	&.animate,

--- a/packages/react-heartwood-components/src/components/BigCalendar/BigCalendar-story.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/BigCalendar-story.js
@@ -165,7 +165,12 @@ class BigCalendarExample extends Component<Props, State> {
 		const { users, events, userMode, toasts } = this.state
 
 		return (
-			<div>
+			<div
+				style={{
+					width: '100vw',
+					height: '50vh'
+				}}
+			>
 				<BigCalendar
 					// users={object('users', users, CATEGORIES.data)}
 					// allEvents={object('allEvents', events, CATEGORIES.data)}

--- a/packages/react-heartwood-components/src/components/BigCalendar/BigCalendar.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/BigCalendar.js
@@ -7,8 +7,6 @@ import React, { Component } from 'react'
 // sub components
 import Header from './components/Header/Header'
 import VIEWS from './components/Views'
-import sizeUtil from './utils/size'
-
 autoPlay(true)
 
 export type User = {
@@ -54,9 +52,6 @@ type Props = {
 type State = {
 	selectedView: 'day' | 'week' | 'month',
 	startDate?: moment,
-	bodyHeight: number,
-	bodyWidth: number,
-	calendarBodyHeight: number,
 	currentHorizontalPage: number,
 	totalHorizontalPages: number
 }
@@ -83,9 +78,6 @@ class BigCalendar extends Component<Props, State> {
 
 	state = {
 		selectedView: this.props.defaultView,
-		bodyWidth: -1,
-		bodyHeight: -1,
-		calendarBodyHeight: 0,
 		startDate: null,
 		currentHorizontalPage: 0,
 		totalHorizontalPages: 0
@@ -125,17 +117,6 @@ class BigCalendar extends Component<Props, State> {
 		}
 	}
 
-	componentDidMount = () => {
-		window.addEventListener('resize', this.handleSizing)
-		this.handleSizing()
-		//TODO better way to detect everything is rendered and sized correctly
-		setTimeout(this.handleSizing, 1000)
-	}
-
-	componentWillUnmount = () => {
-		window.removeEventListener('resize', this.handleSizing)
-	}
-
 	getDefaultStartDate = (): moment => {
 		// TODO use cookies that can work both client and server side
 		return moment.tz(
@@ -157,30 +138,6 @@ class BigCalendar extends Component<Props, State> {
 				.add(duration, unit)
 				.endOf('day')
 		}
-	}
-
-	handleSizing = () => {
-		// can sometimes fire too early (before the ref is set)
-		if (!this.domNodeRef.current) {
-			return
-		}
-
-		//get node for scroll wrapper
-		const scrollNode = this.domNodeRef.current.querySelectorAll(
-			'.bigcalendar__drag-grid'
-		)[0]
-
-		// calc positions
-		const scrollTop = sizeUtil.getTop(scrollNode)
-		const width = sizeUtil.bodyWidth()
-		const height = sizeUtil.bodyHeight()
-		const calendarBodyHeight = height - scrollTop
-
-		this.setState({
-			bodyWidth: width,
-			bodyHeight: height,
-			calendarBodyHeight
-		})
 	}
 
 	handleChangeView = () => {
@@ -338,9 +295,6 @@ class BigCalendar extends Component<Props, State> {
 		const {
 			selectedView,
 			startDate,
-			bodyWidth,
-			bodyHeight,
-			calendarBodyHeight,
 			currentHorizontalPage,
 			totalHorizontalPages
 		} = this.state
@@ -352,15 +306,7 @@ class BigCalendar extends Component<Props, State> {
 		const viewProps = this.getViewProps()
 
 		return (
-			<div
-				className={parentClass}
-				ref={this.domNodeRef}
-				style={{
-					width: bodyWidth,
-					height: bodyHeight
-				}}
-				{...props}
-			>
+			<div className={parentClass} ref={this.domNodeRef} {...props}>
 				<Header
 					userModeOptions={userModeOptions}
 					onChangeUserMode={this.handleChangeUserMode}
@@ -398,7 +344,6 @@ class BigCalendar extends Component<Props, State> {
 						startDate={startDate}
 						events={allEvents}
 						slotsPerHour={slotsPerHour}
-						calendarBodyHeight={calendarBodyHeight}
 						users={users}
 						minTime={defaultMinTime}
 						maxTime={defaultMaxTime}

--- a/packages/react-heartwood-components/src/components/BigCalendar/components/Views/Day.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/components/Views/Day.js
@@ -1382,9 +1382,6 @@ class Day extends PureComponent<Props, State> {
 						dragScrollSpeed={dragScrollSpeed}
 						enableAutoScrollX={enableAutoScrollX}
 						enableAutoScrollY={enableAutoScrollY}
-						style={{
-							height: calendarBodyHeight
-						}}
 					>
 						<div className="scroll-inner" ref={this.scrollInnerRef}>
 							{users.map((user, idx) => (

--- a/packages/react-heartwood-components/src/components/BigCalendar/utils/size.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/utils/size.js
@@ -1,10 +1,4 @@
 export default {
-	bodyWidth() {
-		return document.body.clientWidth
-	},
-	bodyHeight() {
-		return document.body.clientHeight
-	},
 	getLocalTop(node) {
 		return node.offsetTop
 	},


### PR DESCRIPTION
- This removes the JS-based sizing for calendar; using flexbox instead, 
and having BigCalendar take up the available space of its parent.

[SBL-2216](https://sprucelabsai.atlassian.net/browse/SBL-2216)

## Type

- [x] Feature
- [ ] Bug
- [x] Tech debt
