### PR TITLE
Generate skill jwt w/ data for testing events

### DIFF
--- a/packages/spruce-skill/server/tests/ExampleEventTests.js
+++ b/packages/spruce-skill/server/tests/ExampleEventTests.js
@@ -1,0 +1,53 @@
+// @flow
+const { assert } = require('chai')
+const Base = require('./Base')
+const { generateSkillJWT } = require('./lib/jwt')
+
+class ExampleEventTests extends Base {
+	organization: any
+	location: any
+	skill: any
+
+	setup() {
+		it('Can respond to "get-views" event', () => this.getViews())
+	}
+
+	async before() {
+		await this.beforeBase()
+		this.organization = this.mocks.sandbox.organization
+		const locationId = Object.keys(this.mocks.sandbox.locations)[0]
+		this.location = this.mocks.sandbox.locations[locationId]
+		this.skill = this.mocks.sandbox.skill
+	}
+
+	async getViews() {
+		const eventType = `get-views`
+		const token = generateSkillJWT({
+			skill: this.skill,
+			location: this.location,
+			organization: this.organization,
+			user: this.location.owner[0],
+			payload: {
+				page: 'dashboard_location',
+				locationId: this.location.id,
+				organizationId: this.organization.id
+			},
+			eventType
+		})
+
+		const result = await this.request
+			.post('/hook.json')
+			.send({ data: token, event: eventType })
+		const { body } = result
+		assert.isArray(body)
+		assert.equal(body.length, 1)
+		assert.equal(body[0].id, 'uniqueId4')
+		assert.equal(body[0].title, 'Example Location Dashboard')
+		assert.equal(body[0].path, '/skill-views/dashboard_location')
+	}
+}
+
+describe('ExampleEventTests', function Tests() {
+	this.timeout(30000)
+	new ExampleEventTests() // eslint-disable-line
+})

--- a/packages/spruce-skill/server/tests/lib/jwt.js
+++ b/packages/spruce-skill/server/tests/lib/jwt.js
@@ -6,7 +6,9 @@ module.exports.generateSkillJWT = function generateSkillJWT({
 	user,
 	location,
 	organization,
-	expiresIn
+	expiresIn,
+	payload,
+	eventType
 }) {
 	let exp = 86400
 	if (expiresIn && parseInt(expiresIn, 10) > 0) {
@@ -14,7 +16,14 @@ module.exports.generateSkillJWT = function generateSkillJWT({
 	}
 
 	const data = {
-		userId: user.id
+		firstSentAt: new Date(),
+		deliveryTry: 1,
+		eventType,
+		payload
+	}
+
+	if (user) {
+		data.userId = user.id
 	}
 
 	if (location) {


### PR DESCRIPTION
## Description

Ability to sign a custom `payload` when generating skill JWTs in tests. This gives us the ability to simulate and test event handlers in our server side tests.

* Fix issue where mock adapter was initialized after skill settings sync

* Update `generateSkillJWT` to accept payload

* Update `generateSkillJWT` to not require a user

* Implement example test for `get-views` event

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt
