### PR TITLE
feat(view): Switch to a flexbox-based layout

### DIFF
--- a/packages/heartwood-components/components/03-structure/page.scss
+++ b/packages/heartwood-components/components/03-structure/page.scss
@@ -1,7 +1,8 @@
 // Page
 
 .page {
-	min-height: 100vh;
+	display: flex;
+	width: 100%;
 
 	&--no-header {
 		margin-top: 4rem;
@@ -23,16 +24,6 @@
 
 	@include gt('medium') {
 		padding-top: 1.5rem;
-	}
-}
-
-.page--has-sidebar {
-	@include gt('990px') {
-		padding-right: rem(360);
-
-		&.page--sidebar-is-collapsed {
-			padding-right: rem(40);
-		}
 	}
 }
 
@@ -137,6 +128,12 @@
 	@include gt('medium') {
 		padding: 0 spacing('extra-loose');
 	}
+}
+
+.page__content-container {
+	flex: 1;
+	height: calc(100vh - #{rem(48)});
+	overflow-y: scroll;
 }
 
 .page__content {

--- a/packages/heartwood-components/components/99-web/header-primary.scss
+++ b/packages/heartwood-components/components/99-web/header-primary.scss
@@ -1,5 +1,4 @@
 .header-primary {
-	position: fixed;
 	z-index: 2;
 	display: flex;
 	justify-content: space-between;

--- a/packages/heartwood-components/components/99-web/main-content.scss
+++ b/packages/heartwood-components/components/99-web/main-content.scss
@@ -1,17 +1,17 @@
+.main-wrapper {
+	display: flex;
+	flex-direction: column;
+}
+
 .main-content {
-	padding-top: rem(48);
+	display: flex;
+	flex: 1;
+}
 
-	@include gt('medium') {
-		padding-left: rem(240);
-	}
-
-	.sidebar--is-collapsed & {
-		@include gt('medium') {
-			padding-left: rem(40);
-		}
-	}
-
-	.sidebar--is-missing & {
-		padding-left: 0;
-	}
+.main-content-outer {
+	display: flex;
+	flex-direction: row;
+	flex: 1;
+	height: calc(100vh - #{rem(48)});
+	overflow: hidden;
 }

--- a/packages/heartwood-components/components/99-web/sidebar.scss
+++ b/packages/heartwood-components/components/99-web/sidebar.scss
@@ -1,10 +1,7 @@
 .sidebar {
-	position: fixed;
-	top: rem(48);
 	z-index: 1;
-	display: inline-flex;
-	flex-flow: column;
-	flex: 0 0 auto;
+	display: flex;
+	flex-direction: column;
 	height: calc(100vh - #{rem(48)});
 	width: rem(240);
 	background-color: $c-grey-00;
@@ -20,41 +17,43 @@ html.skill .sidebar {
 }
 
 .sidebar--left {
-	transform: translate(-100%, 0);
-	left: 0;
+	display: none;
 	border-right: 1px solid $c-border-light;
 
 	// NOTE: This classname may change
 	&.sidebar--is-mobile-expanded {
-		transform: translate(0, 0);
+		position: fixed;
+		left: 0;
+		display: flex;
 	}
 
 	@include gt('medium') {
-		transform: translate(0, 0);
+		display: flex;
 
 		// NOTE: This classname may change
 		&.sidebar--is-mobile-expanded {
-			transform: translate(0, 0);
+			display: flex;
 		}
 	}
 }
 
 .sidebar--right {
-	transform: translate(100%, 0);
-	right: 0;
+	display: none;
 	border-left: 1px solid $c-border-light;
 
 	// NOTE: This classname may change
 	&.sidebar--is-mobile-expanded {
-		transform: translate(0, 0);
+		position: fixed;
+		right: 0;
+		display: flex;
 	}
 
 	@include gt('990px') {
-		transform: translate(0, 0);
+		display: flex;
 
 		// NOTE: This classname may change
 		&.sidebar--is-mobile-expanded {
-			transform: translate(0, 0);
+			display: flex;
 		}
 	}
 }
@@ -78,8 +77,9 @@ html.skill .sidebar {
 }
 
 .sidebar__inner {
-	height: calc(100% - #{rem(40)});
-	overflow: scroll;
+	flex: 1;
+	overflow-x: hidden;
+	overflow-y: scroll;
 }
 
 .sidebar__items {

--- a/packages/heartwood-components/components/feed/feed.scss
+++ b/packages/heartwood-components/components/feed/feed.scss
@@ -1,10 +1,11 @@
 .message-feed__wrapper {
 	display: flex;
+	height: 100%;
+	overflow: hidden;
 }
 
 .message-feed {
-	flex: 1 1 auto;
-	height: 100vh;
+	flex: 1;
 }
 
 .header-primary + .main-content .message-feed {

--- a/packages/react-heartwood-components/src/components/Page/Page.js
+++ b/packages/react-heartwood-components/src/components/Page/Page.js
@@ -22,9 +22,6 @@ type PageProps = {
 	/** Page header props */
 	header?: PageHeaderProps,
 
-	/** Set true if the page has a sidebar. Defaults to ''. */
-	hasSidebar?: boolean,
-
 	/** Set true if the page has a sidebar that is collapsed. Defaults to false. */
 	sidebarIsCollapsed?: boolean
 }
@@ -36,20 +33,22 @@ export const Page = (props: PageProps) => {
 		hasHeader,
 		className,
 		header,
-		hasSidebar,
-		sidebarIsCollapsed
+		sidebarIsCollapsed,
+		sidebar
 	} = props
 	return (
 		<div
 			className={cx('page', className, {
 				'page--centered': isCentered,
 				'page--no-header': !hasHeader,
-				'page--has-sidebar': hasSidebar,
 				'page--sidebar-is-collapsed': sidebarIsCollapsed
 			})}
 		>
-			{header && <PageHeader {...header} />}
-			{children}
+			<div className={'page__content-container'}>
+				{header && <PageHeader {...header} />}
+				{children}
+			</div>
+			{sidebar}
 		</div>
 	)
 }
@@ -58,7 +57,6 @@ Page.defaultProps = {
 	isCentered: false,
 	hasHeader: true,
 	header: null,
-	hasSidebar: false,
 	sidebarIsCollapsed: false
 }
 

--- a/packages/react-heartwood-components/src/components/View/View-story.js
+++ b/packages/react-heartwood-components/src/components/View/View-story.js
@@ -236,57 +236,59 @@ class SkillViewExample extends Component<SkillViewProps, SkillViewState> {
 						},
 						tabs: skillViewTabs
 					}}
-					hasSidebar="large"
 					sidebarIsCollapsed={!sidebarsExpanded.right}
-				>
-					<Sidebar
-						side="right"
-						isCollapsible={false}
-						isLarge
-						isExpanded={sidebarsExpanded.right}
-						isMobileExpanded={sidebarsMobileExpanded.right}
-						toggleExpanded={() => this.handleSidebarToggle('right')}
-						mobileHeader={{
-							title: 'Chimera Salon at the Point',
-							action: {
-								icon: { name: 'close' },
-								isSmall: true,
-								onClick: () => this.handleMobileSidebarToggle('right')
-							}
-						}}
-					>
-						<SidebarSection>
-							<Card isSmall>
-								<CardHeader
-									labelText="Location Status"
-									labelIcon={{ name: 'hide', isLineIcon: true }}
-									title="This location is hidden"
-								/>
-								<CardBody>
-									<p>
-										This location is currently hidden from guests, but is
-										visible to you and your teammates.
-									</p>
-								</CardBody>
-								<CardFooter>
-									<ButtonGroup
-										actions={[
-											{
-												text: 'Preview as guest',
-												kind: 'simple',
-												isSmall: true
-											},
-											{
-												text: 'Make location live',
-												kind: 'primary',
-												isSmall: true
-											}
-										]}
+					sidebar={
+						<Sidebar
+							side="right"
+							isCollapsible={false}
+							isLarge
+							isExpanded={sidebarsExpanded.right}
+							isMobileExpanded={sidebarsMobileExpanded.right}
+							toggleExpanded={() => this.handleSidebarToggle('right')}
+							mobileHeader={{
+								title: 'Chimera Salon at the Point',
+								action: {
+									icon: { name: 'close' },
+									isSmall: true,
+									onClick: () => this.handleMobileSidebarToggle('right')
+								}
+							}}
+						>
+							<SidebarSection>
+								<Card isSmall>
+									<CardHeader
+										labelText="Location Status"
+										labelIcon={{ name: 'hide', isLineIcon: true }}
+										title="This location is hidden"
 									/>
-								</CardFooter>
-							</Card>
-						</SidebarSection>
-					</Sidebar>
+									<CardBody>
+										<p>
+											This location is currently hidden from guests, but is
+											visible to you and your teammates.
+										</p>
+									</CardBody>
+									<CardFooter>
+										<ButtonGroup
+											actions={[
+												{
+													text: 'Preview as guest',
+													kind: 'simple',
+													isSmall: true
+												},
+												{
+													text: 'Make location live',
+													kind: 'primary',
+													isSmall: true
+												}
+											]}
+										/>
+									</CardFooter>
+								</Card>
+							</SidebarSection>
+						</Sidebar>
+					}
+				>
+					<div style={{ flex: 1 }}>hey</div>
 				</Page>
 			</View>
 		)
@@ -336,59 +338,62 @@ stories
 				business={organization}
 				isSidebarExpanded
 			>
-				<Page hasSidebar>
+				<Page
+					sidebar={
+						<Sidebar isLarge isCollapsible={false} side="right">
+							<SidebarSection
+								isCentered
+								verticalSpacing="loose"
+								horizontalSpacing="loose"
+							>
+								<Avatar
+									isLarge
+									isCentered
+									image="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=200&h=200&q=80"
+								/>
+								<Heading>
+									<TextStyle type="strong">Dorian Feeney</TextStyle>
+								</Heading>
+							</SidebarSection>
+							<SidebarSection horizontalSpacing="loose" className="u-flex-row">
+								<Button
+									isSmall
+									kind="secondary"
+									className="u-flex-child-grow"
+									text="Call Dorian"
+									icon={{
+										name: 'phone',
+										isLineIcon: true
+									}}
+								/>
+								<ContextMenu
+									isSmall
+									className="u-ml-tight"
+									actions={[
+										{
+											text: 'One action'
+										},
+										{
+											text: 'two action'
+										},
+										{
+											text: 'red action'
+										},
+										{
+											text: 'blue action'
+										}
+									]}
+									isSimple
+								/>
+							</SidebarSection>
+						</Sidebar>
+					}
+				>
 					<FeedBuilder
 						messages={messages}
 						messageCount={50}
 						onRowsRequested={() => null}
 					/>
-					<Sidebar isLarge isCollapsible={false} side="right">
-						<SidebarSection
-							isCentered
-							verticalSpacing="loose"
-							horizontalSpacing="loose"
-						>
-							<Avatar
-								isLarge
-								isCentered
-								image="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=200&h=200&q=80"
-							/>
-							<Heading>
-								<TextStyle type="strong">Dorian Feeney</TextStyle>
-							</Heading>
-						</SidebarSection>
-						<SidebarSection horizontalSpacing="loose" className="u-flex-row">
-							<Button
-								isSmall
-								kind="secondary"
-								className="u-flex-child-grow"
-								text="Call Dorian"
-								icon={{
-									name: 'phone',
-									isLineIcon: true
-								}}
-							/>
-							<ContextMenu
-								isSmall
-								className="u-ml-tight"
-								actions={[
-									{
-										text: 'One action'
-									},
-									{
-										text: 'two action'
-									},
-									{
-										text: 'red action'
-									},
-									{
-										text: 'blue action'
-									}
-								]}
-								isSimple
-							/>
-						</SidebarSection>
-					</Sidebar>
 				</Page>
 			</View>
 		)

--- a/packages/react-heartwood-components/src/components/View/View.js
+++ b/packages/react-heartwood-components/src/components/View/View.js
@@ -48,19 +48,6 @@ const View = (props: Props) => {
 				'sidebar--is-missing': !sidebarItems || sidebarItems.length === 0
 			})}
 		>
-			{sidebarItems && sidebarItems.length > 0 && (
-				<Sidebar
-					items={sidebarItems}
-					backLink={sidebarBackLink}
-					footer={<SidebarFooter />}
-					isSidebarVisible={isSidebarVisible}
-					isExpanded={isSidebarExpanded}
-					isMobileExpanded={isSidebarMobileExpanded}
-					toggleExpanded={toggleSidebarExpanded}
-					forceCloseSidebar={forceCloseSidebar}
-					side="left"
-				/>
-			)}
 			<HeaderPrimary
 				user={user}
 				organization={organization}
@@ -74,7 +61,23 @@ const View = (props: Props) => {
 				onClickSearch={onClickSearch}
 			/>
 
-			<main className="main-content">{children}</main>
+			<div className="main-content-outer">
+				{sidebarItems && sidebarItems.length > 0 && (
+					<Sidebar
+						items={sidebarItems}
+						backLink={sidebarBackLink}
+						footer={<SidebarFooter />}
+						isSidebarVisible={isSidebarVisible}
+						isExpanded={isSidebarExpanded}
+						isMobileExpanded={isSidebarMobileExpanded}
+						toggleExpanded={toggleSidebarExpanded}
+						forceCloseSidebar={forceCloseSidebar}
+						side="left"
+					/>
+				)}
+
+				<main className="main-content">{children}</main>
+			</div>
 		</div>
 	)
 }


### PR DESCRIPTION
- The old layout used a fixed-position layout w/ large paddings to 
account for sidebars
- Switching to flexbox so that the containers have appropriate natural 
widths, which is necessary for making components that "fit within their 
bounds" (such as calendar in core)
- Also fix some overflow bar issues for mouse users ([SBL-2240]) but not 
all.
- Update all examples in storybook
- One major change to `Page`: in order to get a proper container 
heirarchy, I've added a `sidebar` prop, which can be used to inject a 
sidebar element. This deprecates `hasSidebar`, since the layout no 
longer cares whether or not a sidebar is to the right of the content 
(flexbox distributes space instead)

## Type

- [x] Feature
- [ ] Bug
- [x] Tech debt
