### PR TITLE
fix(view): Remove more non-flex references

### DIFF
--- a/packages/heartwood-components/components/03-structure/page.scss
+++ b/packages/heartwood-components/components/03-structure/page.scss
@@ -9,12 +9,6 @@
 	}
 }
 
-.header-primary + .main-content {
-	.page {
-		min-height: calc(100vh - #{rem(48)});
-	}
-}
-
 .page__header {
 	padding-top: spacing('base');
 
@@ -131,9 +125,10 @@
 }
 
 .page__content-container {
+	display: flex;
+	flex-direction: column;
 	flex: 1;
-	height: calc(100vh - #{rem(48)});
-	overflow-y: scroll;
+	overflow: scroll;
 }
 
 .page__content {

--- a/packages/heartwood-components/components/99-web/header-primary.scss
+++ b/packages/heartwood-components/components/99-web/header-primary.scss
@@ -2,7 +2,6 @@
 	z-index: 2;
 	display: flex;
 	justify-content: space-between;
-	flex: 1 0 100%;
 	width: 100%;
 	height: rem(48);
 	background-color: $c-grey-09;

--- a/packages/heartwood-components/components/99-web/main-content.scss
+++ b/packages/heartwood-components/components/99-web/main-content.scss
@@ -1,17 +1,19 @@
 .main-wrapper {
 	display: flex;
 	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
 }
 
 .main-content {
 	display: flex;
 	flex: 1;
+	overflow: hidden;
 }
 
 .main-content-outer {
 	display: flex;
 	flex-direction: row;
 	flex: 1;
-	height: calc(100vh - #{rem(48)});
 	overflow: hidden;
 }

--- a/packages/heartwood-components/components/99-web/sidebar.scss
+++ b/packages/heartwood-components/components/99-web/sidebar.scss
@@ -2,7 +2,6 @@
 	z-index: 1;
 	display: flex;
 	flex-direction: column;
-	height: calc(100vh - #{rem(48)});
 	width: rem(240);
 	background-color: $c-grey-00;
 
@@ -23,6 +22,8 @@ html.skill .sidebar {
 	// NOTE: This classname may change
 	&.sidebar--is-mobile-expanded {
 		position: fixed;
+		top: rem(48);
+		bottom: 0;
 		left: 0;
 		display: flex;
 	}
@@ -44,6 +45,8 @@ html.skill .sidebar {
 	// NOTE: This classname may change
 	&.sidebar--is-mobile-expanded {
 		position: fixed;
+		top: rem(48);
+		bottom: 0;
 		right: 0;
 		display: flex;
 	}

--- a/packages/heartwood-components/components/feed/feed.scss
+++ b/packages/heartwood-components/components/feed/feed.scss
@@ -8,10 +8,6 @@
 	flex: 1;
 }
 
-.header-primary + .main-content .message-feed {
-	height: calc(100vh - #{rem(48)});
-}
-
 .message-feed__day-header {
 	width: calc(100% - #{rem(32)});
 	margin: spacing('base');


### PR DESCRIPTION
- More to do here, but this is mainly to just unblock right-rail in core 
calendar.
- Mostly I'm getting rid of anything that isn't flex (i.e. all these calcs that hard-ref the height of the header)