### PR TITLE
feat(sidebar): Add mobile-only prop for sidebar sections

### DIFF
--- a/packages/heartwood-components/components/03-structure/page.scss
+++ b/packages/heartwood-components/components/03-structure/page.scss
@@ -133,6 +133,7 @@
 
 .page__content {
 	padding: spacing('extra-loose') 0;
+	z-index: 1;
 
 	> .text-container {
 		padding: 0 spacing('base');
@@ -143,4 +144,9 @@
 			padding: 0;
 		}
 	}
+}
+
+.page__sidebar {
+	display: flex;
+	z-index: 2;
 }

--- a/packages/heartwood-components/components/99-web/main-content.scss
+++ b/packages/heartwood-components/components/99-web/main-content.scss
@@ -9,6 +9,7 @@
 	display: flex;
 	flex: 1;
 	overflow: hidden;
+	z-index: 1;
 }
 
 .main-content-outer {
@@ -16,4 +17,9 @@
 	flex-direction: row;
 	flex: 1;
 	overflow: hidden;
+}
+
+.main-content__sidebar {
+	display: flex;
+	z-index: 2;
 }

--- a/packages/heartwood-components/components/99-web/sidebar.scss
+++ b/packages/heartwood-components/components/99-web/sidebar.scss
@@ -304,6 +304,14 @@ html.skill .sidebar {
 .sidebar-section {
 	padding: spacing('tight') spacing('tight') 0;
 
+	&.sidebar-section--show-only-on-mobile {
+		display: block;
+
+		@include gt('medium') {
+			display: none;
+		}
+	}
+
 	&.sidebar-section--centered {
 		text-align: center;
 	}

--- a/packages/react-heartwood-components/src/components/Core/components/Sidebar/components/SidebarSection/SidebarSection.js
+++ b/packages/react-heartwood-components/src/components/Core/components/Sidebar/components/SidebarSection/SidebarSection.js
@@ -25,12 +25,14 @@ const SidebarSection = (props: Props) => {
 		children,
 		className,
 		isCentered,
+		isOnlyForMobile,
 		horizontalSpacing,
 		verticalSpacing
 	} = props
 	return (
 		<div
 			className={cx('sidebar-section', className, {
+				'sidebar-section--show-only-on-mobile': isOnlyForMobile,
 				'sidebar-section--centered': isCentered,
 				'sidebar-section--horizontal-loose': horizontalSpacing === 'loose',
 				'sidebar-section--vertical-loose': verticalSpacing === 'loose'

--- a/packages/react-heartwood-components/src/components/Page/Page.js
+++ b/packages/react-heartwood-components/src/components/Page/Page.js
@@ -48,7 +48,7 @@ export const Page = (props: PageProps) => {
 				{header && <PageHeader {...header} />}
 				{children}
 			</div>
-			{sidebar}
+			{sidebar && <div className={'page__sidebar'}>{sidebar}</div>}
 		</div>
 	)
 }

--- a/packages/react-heartwood-components/src/components/View/View.js
+++ b/packages/react-heartwood-components/src/components/View/View.js
@@ -63,7 +63,7 @@ const View = (props: Props) => {
 
 			<div className="main-content-outer">
 				{sidebarItems && sidebarItems.length > 0 && (
-					<div class="main-content__sidebar">
+					<div className="main-content__sidebar">
 						<Sidebar
 							style={{ zIndex: 1 }}
 							items={sidebarItems}

--- a/packages/react-heartwood-components/src/components/View/View.js
+++ b/packages/react-heartwood-components/src/components/View/View.js
@@ -63,17 +63,20 @@ const View = (props: Props) => {
 
 			<div className="main-content-outer">
 				{sidebarItems && sidebarItems.length > 0 && (
-					<Sidebar
-						items={sidebarItems}
-						backLink={sidebarBackLink}
-						footer={<SidebarFooter />}
-						isSidebarVisible={isSidebarVisible}
-						isExpanded={isSidebarExpanded}
-						isMobileExpanded={isSidebarMobileExpanded}
-						toggleExpanded={toggleSidebarExpanded}
-						forceCloseSidebar={forceCloseSidebar}
-						side="left"
-					/>
+					<div class="main-content__sidebar">
+						<Sidebar
+							style={{ zIndex: 1 }}
+							items={sidebarItems}
+							backLink={sidebarBackLink}
+							footer={<SidebarFooter />}
+							isSidebarVisible={isSidebarVisible}
+							isExpanded={isSidebarExpanded}
+							isMobileExpanded={isSidebarMobileExpanded}
+							toggleExpanded={toggleSidebarExpanded}
+							forceCloseSidebar={forceCloseSidebar}
+							side="left"
+						/>
+					</div>
 				)}
 
 				<main className="main-content">{children}</main>


### PR DESCRIPTION
- Also fixing zIndex for view/page so that page content can't overlap the sidebars on mobile.

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt
