### PR TITLE
React Heartwood Component Updates

### DIFF
--- a/packages/heartwood-components/components/01-button/button.scss
+++ b/packages/heartwood-components/components/01-button/button.scss
@@ -123,6 +123,7 @@ Button Variation mixins
 Baseline styling for all buttons
 */
 .btn {
+	@include btn($color: $c-text, $is-simple: true, $is-solid: false);
 	@extend %reset-button;
 	position: relative;
 	display: inline-block;

--- a/packages/heartwood-components/components/02-forms/autosuggest.scss
+++ b/packages/heartwood-components/components/02-forms/autosuggest.scss
@@ -9,6 +9,7 @@
 	top: 100%;
 	left: 0;
 	width: 100%;
+	margin-bottom: spacing('base');
 	max-height: rem(200);
 	z-index: 1;
 	overflow: scroll;

--- a/packages/heartwood-components/components/05-feedback/toast.scss
+++ b/packages/heartwood-components/components/05-feedback/toast.scss
@@ -2,6 +2,7 @@
 	@include type-style-body-sm;
 	display: inline-block;
 	min-width: rem(288);
+	min-height: rem(56);
 	max-width: rem(400);
 	padding: spacing('tight');
 	border-radius: 2px;

--- a/packages/react-heartwood-components/src/components/Button/Button-story.js
+++ b/packages/react-heartwood-components/src/components/Button/Button-story.js
@@ -77,6 +77,24 @@ stories
 			linkProps={object('linkProps', {})}
 		/>
 	))
+	.add('Default', () => (
+		<Button
+			isFullWidth={isFullWidth}
+			text={btnText}
+			kind={text('kind', '') || ''}
+			disabled={boolean('disabled', false)}
+			isLoading={boolean('isLoading', false)}
+			isSmall={boolean('isSmall', false)}
+			icon={{
+				name: text('icon', null),
+				className: text('iconClassName', 'btn__line-icon')
+			}}
+			href={text('href', '')}
+			target={text('target', '')}
+			onClick={text('onClick', '() => console.log("you clicked")')}
+			linkProps={object('linkProps', {})}
+		/>
+	))
 	.add('Caution', () => (
 		<Button
 			isFullWidth={isFullWidth}

--- a/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.js
+++ b/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.js
@@ -81,6 +81,9 @@ const theme = (props: ThemeProps) => ({
 })
 
 export default class Autosuggest extends Component<Props, State> {
+	domNodeRef = React.createRef()
+	autosuggestRef = React.createRef()
+
 	static defaultProps = {
 		defaultSuggestions: []
 	}
@@ -113,9 +116,11 @@ export default class Autosuggest extends Component<Props, State> {
 		// May be async/passed by parent
 		const { getSuggestions } = this.props
 		const suggestions = await getSuggestions(value)
-		this.setState({
+		await this.setState({
 			suggestions: suggestions || []
 		})
+
+		this.scrollParentIfNeeded()
 	}
 
 	onSuggestionsClearRequested = () => {
@@ -123,6 +128,49 @@ export default class Autosuggest extends Component<Props, State> {
 		this.setState({
 			suggestions: defaultSuggestions
 		})
+	}
+
+	scrollParentIfNeeded = () => {
+		const suggestionsContainer =
+			this.autosuggestRef &&
+			this.autosuggestRef.current &&
+			this.autosuggestRef.current.suggestionsContainer
+
+		if (suggestionsContainer && this.domNodeRef && this.domNodeRef.current) {
+			const overflowParent = this.findOverflowParent(this.domNodeRef.current)
+
+			if (overflowParent) {
+				const overflowBox = overflowParent.getBoundingClientRect()
+				const overflowBoxBottom = overflowBox.top + overflowBox.height
+				const suggestionsBox = suggestionsContainer.getBoundingClientRect()
+				const suggestionsBottom = suggestionsBox.top + suggestionsBox.height
+
+				if (suggestionsBottom > overflowBoxBottom) {
+					if (overflowParent.scrollTo) {
+						overflowParent.scrollTo({
+							top: suggestionsBox.top,
+							behavior: 'smooth'
+						})
+					} else {
+						overflowParent.scrollTop(suggestionsBox.top)
+					}
+				}
+			}
+		}
+	}
+
+	findOverflowParent = node => {
+		if (node == null || typeof node === 'undefined' || node.nodeType !== 1) {
+			return null
+		}
+
+		const computedStyle = window.getComputedStyle(node)
+
+		if (computedStyle.overflow !== 'visible') {
+			return node
+		} else {
+			return this.findOverflowParent(node.parentNode)
+		}
 	}
 
 	handleClearInput = () => {
@@ -167,10 +215,11 @@ export default class Autosuggest extends Component<Props, State> {
 		})
 
 		return (
-			<div className={parentClass}>
+			<div className={parentClass} ref={this.domNodeRef}>
 				{label && <InputPre label={label} id={id} postLabel={postLabel} />}
 				<div className={cx('autosuggest__wrapper', wrapperClassName)}>
 					<ReactAutosuggest
+						ref={this.autosuggestRef}
 						suggestions={suggestions}
 						onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
 						onSuggestionsClearRequested={this.onSuggestionsClearRequested}

--- a/packages/react-heartwood-components/src/components/Modal/Modal-story.js
+++ b/packages/react-heartwood-components/src/components/Modal/Modal-story.js
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react'
 import { withKnobs, text, boolean, object } from '@storybook/addon-knobs/react'
 import Modal from './Modal'
 import Button from '../Button/Button'
+import Autosuggest from '../Forms/components/Autosuggest/Autosuggest'
 import {
 	Checkbox,
 	TextInput,
@@ -11,6 +12,30 @@ import {
 	FormLayout,
 	FormLayoutItem
 } from '../Forms'
+
+import countries from '../../../.storybook/data/countries'
+
+const renderSuggestion = (suggestion: any) => {
+	if (suggestion.isEmptyMessage) {
+		return (
+			<div className="autosuggest__no-results">
+				<p className="autosuggest__no-results-title">
+					No matching countries found.
+				</p>
+				<p className="autosuggest__no-results-subtitle">
+					Please adjust your search and try again.
+				</p>
+			</div>
+		)
+	}
+	return (
+		<Button
+			isSmall
+			className="autosuggest__list-item-inner"
+			text={suggestion.text}
+		/>
+	)
+}
 
 type Props = {
 	title: string,
@@ -161,6 +186,34 @@ stories
 								placeholder="Optional category description…"
 								helper="Add a short teaser for your guests to see when they browse your services."
 								rows={3}
+							/>
+						</FormLayoutItem>
+						<FormLayoutItem>
+							<Autosuggest
+								label={'Country'}
+								placeholder={'Select a country...'}
+								defaultSuggestions={object('defaultSuggestions', countries)}
+								shouldRenderSuggestions={() => true}
+								renderSuggestion={renderSuggestion}
+								getSuggestionValue={value => value.text}
+								getSuggestions={value => {
+									const results = countries.filter(
+										suggestion =>
+											suggestion.text.toLowerCase().slice(0, value.length) ===
+											value.toLowerCase()
+									)
+									// Here you could add click events to buttons or whatever else they need
+									// No Results Message
+									if (results.length === 0) {
+										return [
+											{
+												text: 'NO RESULTS',
+												isEmptyMessage: true
+											}
+										]
+									}
+									return results
+								}}
 							/>
 						</FormLayoutItem>
 						<FormLayoutItem>


### PR DESCRIPTION
[SBL-2067](https://sprucelabsai.atlassian.net/browse/SBL-2067) - Buttons: If "kind" is omitted, the grey default button has no hover/focus state
[SBL-2033](https://sprucelabsai.atlassian.net/browse/SBL-2033) - Toast - formatting for headline only is off
[SBL-1927](https://sprucelabsai.atlassian.net/browse/SBL-1927) - Autosuggest does not display properly in modals

## Description

Fixes the issues above. See below for Autosuggest in modal fix:

![modal-autosuggest](https://user-images.githubusercontent.com/755542/54939398-1ef3fc00-4eee-11e9-9f2a-831f2986b2c8.gif)

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt
