### PR TITLE
Skills API v1 mocks / auth support for tests

### DIFF
--- a/packages/spruce-node/mock/index.js
+++ b/packages/spruce-node/mock/index.js
@@ -33,6 +33,10 @@ module.exports = class MockHttps {
 		this.mockServer = mockServer(schema, customMocks)
 	}
 
+	async mockApiInit(mockApi) {
+		this.mockApi = mockApi
+	}
+
 	async query(query) {
 		const result = await this.mockServer.query(query)
 		return result
@@ -50,8 +54,8 @@ module.exports = class MockHttps {
 	 * @param {Object} query Vanilla object that is converted into a query string
 	 * @returns {Promise}
 	 */
-	async get(path, query) {
-		return Promise.resolve({})
+	get(path, query) {
+		return this.mockApi.get(path, query)
 	}
 
 	/**
@@ -63,8 +67,8 @@ module.exports = class MockHttps {
 	 * @param {String} method
 	 * @returns {Promise}
 	 */
-	async post(path, data, query, method = 'POST') {
-		return Promise.resolve({})
+	post(path, data, query, method = 'POST') {
+		return this.mockApi.post(path, data, query, method)
 	}
 
 	/**
@@ -75,9 +79,8 @@ module.exports = class MockHttps {
 	 * @param {Object} query
 	 * @returns {Promise}
 	 */
-	async patch(path, data, query) {
-		// return this.post(path, data, query, 'PATCH')
-		return Promise.resolve({})
+	patch(path, data, query) {
+		return this.mockApi.patch(path, data, query)
 	}
 
 	/**
@@ -87,7 +90,7 @@ module.exports = class MockHttps {
 	 * @returns {Promise}
 	 */
 	async delete(path, query) {
-		return Promise.resolve({})
+		return this.mockApi.delete(path, query)
 	}
 
 	/**

--- a/packages/spruce-skill-server/index.js
+++ b/packages/spruce-skill-server/index.js
@@ -111,6 +111,8 @@ module.exports = async ({
 			useMockApi: true
 		})
 		sprucebot.adapter.mockApiGQLServerInit({ customMocks })
+		const v1APIMocks = require('./tests/v1APIMocks')(koa.context)
+		sprucebot.adapter.mockApiInit(v1APIMocks)
 	}
 
 	let syncResponse

--- a/packages/spruce-skill-server/tests/v1APIMocks.js
+++ b/packages/spruce-skill-server/tests/v1APIMocks.js
@@ -1,0 +1,36 @@
+const config = require('config')
+
+module.exports = ctx => ({
+	async get(path, query) {
+		const matches = path.match(/\/locations\/([^/]+)\/users\/([^/]+)/)
+		if (matches && matches[1] && matches[2]) {
+			// ctx.sb.user() has been called. Fetch the data from the DB. Used for v1 authentication
+			const locationId = matches[1]
+			const userId = matches[2]
+			const userLocation = await ctx.db.models.UserLocation.findOne({
+				where: {
+					UserId: userId,
+					LocationId: locationId
+				},
+				include: [
+					ctx.db.models.User,
+					{
+						model: ctx.db.models.Location,
+						include: [ctx.db.models.Organization]
+					}
+				]
+			})
+			return userLocation
+		}
+		return Promise.resolve({})
+	},
+	async post(path, data, query, method) {
+		return Promise.resolve({})
+	},
+	async patch(path, data, query) {
+		return Promise.resolve({})
+	},
+	async delete(path, query) {
+		return Promise.resolve({})
+	}
+})

--- a/packages/spruce-skill/.vscode/launch.json
+++ b/packages/spruce-skill/.vscode/launch.json
@@ -43,7 +43,7 @@
 				"ORM_LOGGING": "true",
 				"API_ONLY": "true",
 				"TESTING": "true",
-				"DISABLE_MIGRATIONS": "true"
+				"DB_MIGRATIONS": "false"
 			}
 		}
 	]

--- a/packages/spruce-skill/package.json
+++ b/packages/spruce-skill/package.json
@@ -27,8 +27,8 @@
 		"interface": "next ./interface -p 3080",
 		"lint": "eslint --ext .js .",
 		"test": "yarn run build && jest",
-		"test:server": "rm tmp/testing.db | true && PORT=3010 BLUEBIRD_W_FORGOTTEN_RETURN=0 ALLOW_NON_SSL=true ORM_LOGGING=false TESTING=true API_ONLY=true DISABLE_MIGRATIONS=true mocha -r flow-remove-types/register --exit 'server/tests/**/*Tests.js'",
-		"test:server:single": "PORT=3010 BLUEBIRD_W_FORGOTTEN_RETURN=0 ALLOW_NON_SSL=true ORM_LOGGING=false TESTING=true API_ONLY=true DISABLE_MIGRATIONS=true mocha -r flow-remove-types/register --exit",
+		"test:server": "rm tmp/testing.db | true && PORT=3010 BLUEBIRD_W_FORGOTTEN_RETURN=0 ALLOW_NON_SSL=true ORM_LOGGING=false TESTING=true API_ONLY=true DB_MIGRATIONS=false mocha -r flow-remove-types/register --exit 'server/tests/**/*Tests.js'",
+		"test:server:single": "PORT=3010 BLUEBIRD_W_FORGOTTEN_RETURN=0 ALLOW_NON_SSL=true ORM_LOGGING=false TESTING=true API_ONLY=true DB_MIGRATIONS=false mocha -r flow-remove-types/register --exit",
 		"icon": "svgo icon/icon.svg",
 		"heroku-postbuild": "npm run build",
 		"release": "semantic-release"


### PR DESCRIPTION
## Description

* Add ability to mock / intercept v1 api calls

* Intercepts the `ctx.sb.user` event during tests and properly fetches data from the mock DB which allows us to run tests locally against `/api/1.0/<role>` endpoints and simulate v1 events

* Fixes issue where incorrect env var (should be `DB_MIGRATIONS` instead of `DISABLE_MIGRATIONS`) was being set during tests

## Type

- [X] Feature
- [X] Bug
- [ ] Tech debt
