### PR TITLE
Pass core SandboxMock to custom mocks

### DIFF
--- a/packages/spruce-skill-server/tests/SpruceTest.js
+++ b/packages/spruce-skill-server/tests/SpruceTest.js
@@ -45,9 +45,13 @@ module.exports = basePath => {
 					`${__dirname}/mocks/**/*Mock.js`,
 					`${basePath}/server/tests/mocks/**/*Mock.js`
 				])
+				let sandbox
 				for (let i = 0; i < mocks.length; i += 1) {
 					const Mock = require(mocks[i])
 					const mock = new Mock(this.koa)
+					if (mock.key === 'sandbox') {
+						sandbox = mock
+					}
 					if (this.mocks[mock.key]) {
 						throw new Error(
 							`A mock with the key "${
@@ -56,7 +60,10 @@ module.exports = basePath => {
 						)
 					}
 					this.mocks[mock.key] = mock
-					await mock.setup(options)
+					await mock.setup({
+						options,
+						sandbox
+					})
 				}
 			} catch (e) {
 				throw e

--- a/packages/spruce-skill-server/tests/SpruceTest.js
+++ b/packages/spruce-skill-server/tests/SpruceTest.js
@@ -61,7 +61,7 @@ module.exports = basePath => {
 					}
 					this.mocks[mock.key] = mock
 					await mock.setup({
-						options,
+						...options,
 						sandbox
 					})
 				}

--- a/packages/spruce-skill/server/tests/ExampleTests.js
+++ b/packages/spruce-skill/server/tests/ExampleTests.js
@@ -10,6 +10,7 @@ class ExampleTests extends SpruceTest(`${__dirname}/../../`) {
 	setup() {
 		it('Can do a trivial assert', () => this.trivialAssert())
 		it('Can get users', () => this.getUsers())
+		it('Can use custom mock data', () => this.customMock())
 	}
 
 	async before() {
@@ -45,6 +46,16 @@ class ExampleTests extends SpruceTest(`${__dirname}/../../`) {
 
 		log.debug(body)
 		assert.isNotNull(body.data.Users)
+	}
+
+	async customMock() {
+		// Verify "someData" is set properly by mocks/ExampleMock.js
+		assert.equal(
+			this.mocks.example.someData,
+			`Example Mock Test org/location: ${this.organization.id} / ${
+				this.location.id
+			}`
+		)
 	}
 }
 

--- a/packages/spruce-skill/server/tests/mocks/ExampleMock.js
+++ b/packages/spruce-skill/server/tests/mocks/ExampleMock.js
@@ -1,0 +1,25 @@
+module.exports = class SandboxMock {
+	constructor(app) {
+		// Every Mock must have a unique key. It is available in your tests as this.mocks[<key>]
+		this.key = 'example'
+		this.ctx = app.context
+		this.app = app
+	}
+
+	async setup(options) {
+		// Sandbox is created beforehand and contains mock data for organization, locations, and users
+		const sandbox = options.sandbox
+
+		const organization = sandbox.organization
+		const location = sandbox.locations[Object.keys(sandbox.locations)[0]]
+
+		this.someData = `Example Mock Test org/location: ${organization.id} / ${
+			location.id
+		}`
+		log.debug('Example mock created')
+	}
+
+	async teardown() {
+		return
+	}
+}


### PR DESCRIPTION
## What does this PR do?

* Passes the `SandboxMock` data into a skill's custom mocks so they can build data off the generated location, org, users, etc.

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt
