### PR TITLE
Ability to test event emit callbacks

### DIFF
--- a/packages/spruce-skill-server/tests/SpruceTest.js
+++ b/packages/spruce-skill-server/tests/SpruceTest.js
@@ -1,4 +1,3 @@
-// @flow
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 const globby = require('globby')
 const supertest = require('supertest')
@@ -15,10 +14,10 @@ module.exports = basePath => {
 	return class Base {
 		constructor() {
 			this.mocks = {}
-			// eslint-disable-next-line
 			before(() => this.before())
-			// eslint-disable-next-line
 			after(() => this.after())
+			beforeEach(() => this.beforeEach())
+			afterEach(() => this.afterEach())
 			this.setup()
 		}
 
@@ -69,6 +68,13 @@ module.exports = basePath => {
 				throw e
 			}
 		}
+
+		async beforeEach() {
+			// Reset the emit response handler
+			global.testEmitResponse = {}
+		}
+
+		async afterEach() {}
 
 		async before() {
 			await this.beforeBase()

--- a/packages/spruce-skill-server/tests/lib/jwt.js
+++ b/packages/spruce-skill-server/tests/lib/jwt.js
@@ -28,6 +28,7 @@ module.exports.generateSkillJWT = function generateSkillJWT({
 
 	if (location) {
 		data.locationId = location.id
+		data.organizationId = location.OrganizationId
 	}
 
 	if (organization) {

--- a/packages/spruce-skill-server/tests/v1APIMocks.js
+++ b/packages/spruce-skill-server/tests/v1APIMocks.js
@@ -45,13 +45,25 @@ module.exports = ctx => ({
 		// `organizations/${organizationId}/emit`
 		const isEmit = /\/emit$/.test(path)
 		if (isEmit) {
-			if (!global.testEmitResponse[data.eventName]) {
-				throw new Error(
-					'You must set global.testEmitResponse[eventName] as the response data when using emits in tests. Bulk emits NOT allowed.'
-				)
-			}
+			if (global.testEmitResponse && global.testEmitResponse[data.eventName]) {
+				if (global.testEmitResponse[data.eventName].callback) {
+					await global.testEmitResponse[data.eventName].callback({
+						data,
+						query
+					})
+				}
 
-			return global.testEmitResponse[data.eventName]
+				if (global.testEmitResponse[data.eventName].data) {
+					return global.testEmitResponse[data.eventName].data
+				} else if (
+					!global.testEmitResponse[data.eventName].data &&
+					!global.testEmitResponse[data.eventName].callback
+				) {
+					return global.testEmitResponse[data.eventName]
+				}
+			} else {
+				log.warn(`EVENT EMIT NOT TESTED: ${data.eventName}`)
+			}
 		}
 
 		return response

--- a/packages/spruce-skill-server/tests/v1APIMocks.js
+++ b/packages/spruce-skill-server/tests/v1APIMocks.js
@@ -62,7 +62,7 @@ module.exports = ctx => ({
 					return global.testEmitResponse[data.eventName]
 				}
 			} else {
-				log.warn(`EVENT EMIT NOT TESTED: ${data.eventName}`)
+				log.trace(`EVENT EMIT NOT TESTED: ${data.eventName}`)
 			}
 		}
 


### PR DESCRIPTION
## What does this PR do?

* Fix `generateSkillJWT` not attaching `organizationId` on location emit (like it does in real api emits)

* Implement `beforeEach` and `afterEach` methods in base test class

* Reset `global.testEmitResponse` before each test

* Add ability to trigger a callback on events. This will let us test `did-` events.  See [emitCallback](https://github.com/sprucelabsai/workspace.sprucebot-skills-kit/compare/canary...prerelease/test-enhancements#diff-541b623d3be5671c6ed47a58295138b1R89) in this PR for an example

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt