### PR TITLE
Table fixes to support ESM Booking Tiers

### DIFF
--- a/packages/react-heartwood-components/src/components/RecordTable/RecordTable.js
+++ b/packages/react-heartwood-components/src/components/RecordTable/RecordTable.js
@@ -182,10 +182,16 @@ class RecordTable extends Component<RecordTableProps, RecordTableState> {
 		search,
 		page
 	}: { search?: string, page: number } = {}) => {
+		const { onNavigateToPage } = this.props
+
 		try {
 			const { visibleRows, totalRows } = await this.fetchRecords({
 				search,
 				page
+			})
+
+			onNavigateToPage({
+				currentPage: page
 			})
 
 			this.setState({

--- a/packages/react-heartwood-components/src/components/RecordTable/RecordTable.js
+++ b/packages/react-heartwood-components/src/components/RecordTable/RecordTable.js
@@ -385,7 +385,8 @@ class RecordTable extends Component<RecordTableProps, RecordTableState> {
 			searchPlaceholder,
 			noDataPrimaryActionButtonKind,
 			noDataPrimaryActionButtonIcon,
-			tableSearchProps = {}
+			tableSearchProps = {},
+			...rest
 		} = this.props
 
 		const {
@@ -462,6 +463,7 @@ class RecordTable extends Component<RecordTableProps, RecordTableState> {
 				)}
 
 				<Table
+					{...rest}
 					className="results-table"
 					isSelectable={isSelectable}
 					columns={columns}

--- a/packages/react-heartwood-components/src/components/RecordTable/RecordTable.js
+++ b/packages/react-heartwood-components/src/components/RecordTable/RecordTable.js
@@ -474,7 +474,6 @@ class RecordTable extends Component<RecordTableProps, RecordTableState> {
 				)}
 
 				<Table
-					{...rest}
 					className="results-table"
 					isSelectable={isSelectable}
 					columns={columns}
@@ -518,6 +517,7 @@ class RecordTable extends Component<RecordTableProps, RecordTableState> {
 					noDataPrimaryAction={this.getNoDataPrimaryAction()}
 					noDataPrimaryActionButtonKind={noDataPrimaryActionButtonKind}
 					noDataPrimaryActionButtonIcon={noDataPrimaryActionButtonIcon}
+					{...rest}
 				/>
 			</Fragment>
 		)

--- a/packages/react-heartwood-components/src/components/RecordTable/RecordTable.js
+++ b/packages/react-heartwood-components/src/components/RecordTable/RecordTable.js
@@ -166,7 +166,10 @@ class RecordTable extends Component<RecordTableProps, RecordTableState> {
 		}
 
 		if (!cancel) {
-			this.setState({ currentPage: 0, selectedTab: tab.key }, this.refresh)
+			this.setState(
+				{ currentPage: 0, selectedTab: tab.key, expandedRows: {} },
+				this.refresh
+			)
 		}
 	}
 
@@ -182,7 +185,7 @@ class RecordTable extends Component<RecordTableProps, RecordTableState> {
 		search,
 		page
 	}: { search?: string, page: number } = {}) => {
-		const { onNavigateToPage } = this.props
+		const { onNavigateToPage = () => {} } = this.props
 
 		try {
 			const { visibleRows, totalRows } = await this.fetchRecords({
@@ -197,7 +200,8 @@ class RecordTable extends Component<RecordTableProps, RecordTableState> {
 			this.setState({
 				currentPage: page,
 				visibleRows,
-				totalRows
+				totalRows,
+				expandedRows: {}
 			})
 		} catch (e) {
 			// Nothing
@@ -403,7 +407,8 @@ class RecordTable extends Component<RecordTableProps, RecordTableState> {
 			selectedTab,
 			visibleRows,
 			totalRows,
-			currentFilter
+			currentFilter,
+			expandedRows
 		} = this.state
 
 		// setup default props types
@@ -479,6 +484,12 @@ class RecordTable extends Component<RecordTableProps, RecordTableState> {
 							desc: false
 						}
 					]}
+					expanded={expandedRows}
+					onExpandedChange={newExpanded => {
+						this.setState({
+							expandedRows: newExpanded
+						})
+					}}
 					pageSize={Math.min(visibleRows.length, limit)}
 					paginationProps={{
 						currentPage,

--- a/packages/react-heartwood-components/src/components/Table/Table.js
+++ b/packages/react-heartwood-components/src/components/Table/Table.js
@@ -302,20 +302,27 @@ export default class Table extends Component<Props, State> {
 				})}
 				getTrGroupProps={(state, rowInfo) => {
 					const expanded = state.expanded[rowInfo.viewIndex]
+					const isDirty =
+						(typeof rowIsDirty === 'function' && !!rowIsDirty(rowInfo)) ||
+						rowInfo.original.isDirty
+
 					return {
 						className: cx('table-row-group', {
 							'table-row-group--expanded': expanded,
-							'table-row-group--is-dirty': rowInfo.original.isDirty
+							'table-row-group--is-dirty': isDirty
 						})
 					}
 				}}
 				getTrProps={(state, rowInfo) => {
 					const expanded = state.expanded[rowInfo.viewIndex]
-					rowIsDirty && rowIsDirty(rowInfo)
+					const isDirty =
+						(typeof rowIsDirty === 'function' && !!rowIsDirty(rowInfo)) ||
+						rowInfo.original.isDirty
+
 					return {
 						className: cx('table-row', {
 							'table-row--expanded': expanded,
-							'table-row--is-dirty': rowInfo.original.isDirty
+							'table-row--is-dirty': isDirty
 						}),
 						onClick: this.handleClickRow
 					}


### PR DESCRIPTION
- Call `rowIsDirty` method for determining row dirtiness (wasn't actually being called before)
- Also adding a callback for navigation w/ pagination, which is needed if you want to have controlled row expansion. (This may make sense at the top-level table)
- Also controlling subcomponent expansion in RecordTable, which a downstream project could decide to override if they wanted.

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt