### PR TITLE
Strict ACL checks & spruce-skill-server tests

### DIFF
--- a/packages/spruce-skill-server/.gitignore
+++ b/packages/spruce-skill-server/.gitignore
@@ -66,3 +66,5 @@ ecosystem.config.js
 # node-config
 config/local.*
 client.json
+
+tmp/

--- a/packages/spruce-skill-server/middleware/events.js
+++ b/packages/spruce-skill-server/middleware/events.js
@@ -14,6 +14,18 @@ module.exports = (router, options) => {
 		let body = ctx.request.body
 		const eventName = body && body.event
 		// setup if we are listening to this event
+		if (!config.eventContract || !config.eventContract.events) {
+			debug('No event contract found in config')
+		}
+
+		if (
+			config.eventContract &&
+			config.eventContract.events &&
+			!config.eventContract.events[eventName]
+		) {
+			debug(`No eventContract specified for: ${eventName}`)
+		}
+
 		if (
 			ctx.path === '/hook.json' &&
 			body &&

--- a/packages/spruce-skill-server/package.json
+++ b/packages/spruce-skill-server/package.json
@@ -16,7 +16,7 @@
 	],
 	"scripts": {
 		"lint": "eslint '**/**/*{.js}'",
-		"test": "jest"
+		"test": "cd ../spruce-skill/ && rm tmp/testing.db | true && mkdir -p tmp/ | true && PORT=3010 BLUEBIRD_W_FORGOTTEN_RETURN=0 ALLOW_NON_SSL=true ORM_LOGGING=false TESTING=true API_ONLY=true DB_MIGRATIONS=false mocha -r flow-remove-types/register --exit '../spruce-skill-server/tests/**/*Tests.js'"
 	},
 	"dependencies": {
 		"@koa/cors": "2",
@@ -57,24 +57,12 @@
 	"devDependencies": {
 		"add": "^2.0.6",
 		"aws-sdk": "^2.153.0",
+		"chai": "^4.2.0",
 		"eslint": "^4.10.0",
 		"eslint-config-prettier": "^2.9.0",
 		"eslint-plugin-prettier": "^2.3.1",
-		"jest": "^24.5.0",
+		"mocha": "^5.2.0",
 		"prettier": "^1.13",
 		"yarn": "^1.2.1"
-	},
-	"jest": {
-		"clearMocks": true,
-		"testPathIgnorePatterns": [
-			"/config/"
-		],
-		"collectCoverageFrom": [
-			"**/*.js",
-			"!**/node_modules/**",
-			"!**/__TEST__/**"
-		],
-		"coverageDirectory": "./coverage/",
-		"collectCoverage": true
 	}
 }

--- a/packages/spruce-skill-server/services/acl.js
+++ b/packages/spruce-skill-server/services/acl.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('spruce-skill-server')
 // This service can be accessed by ctx.services.acl from the controllers
 
 // From: https://stackoverflow.com/questions/11233498/json-stringify-without-quotes-on-properties
@@ -57,6 +58,18 @@ module.exports = {
 		const { userId, permissions, locationId, organizationId } = options
 		let query
 
+		debug(`Checking ACL permissions`, options)
+
+		if (!userId || !organizationId) {
+			throw new Error(
+				'Missing required parameters "userId" and "organizationId" for ACL check'
+			)
+		}
+
+		if (!permissions) {
+			throw new Error('Missing required parameter "permission" for ACL check')
+		}
+
 		if (locationId) {
 			query = `
 			{
@@ -91,20 +104,37 @@ module.exports = {
 		}
 		const result = await this.sb.query(query)
 
+		const permsHash = {}
+		Object.keys(permissions).forEach(slug => {
+			permissions[slug].forEach(perm => {
+				permsHash[`${slug}:${perm}`] = false
+			})
+		})
+
 		if (result.data && result.data.Acls) {
 			for (let i = 0; i < result.data.Acls.length; i += 1) {
 				const acl = result.data.Acls[i]
 				if (acl && acl.slug && acl.permissions) {
 					for (let j = 0; j < acl.permissions.length; j += 1) {
 						const permission = acl.permissions[j]
+						permsHash[`${acl.slug}:${permission.name}`] =
+							permission.value === true
 						if (permission.value === false) {
 							return false
 						}
 					}
 				}
 			}
+		} else {
+			debug(`ACL check query failed`, {
+				data: result.data,
+				errors: result.errors
+			})
+			return false
 		}
 
-		return true
+		const isAllowed = Object.values(permsHash).every(value => value === true)
+
+		return isAllowed
 	}
 }

--- a/packages/spruce-skill-server/services/acl.js
+++ b/packages/spruce-skill-server/services/acl.js
@@ -67,7 +67,7 @@ module.exports = {
 		}
 
 		if (!permissions) {
-			throw new Error('Missing required parameter "permission" for ACL check')
+			throw new Error('Missing required parameter "permissions" for ACL check')
 		}
 
 		if (locationId) {

--- a/packages/spruce-skill-server/tests/ACLTests.js
+++ b/packages/spruce-skill-server/tests/ACLTests.js
@@ -244,5 +244,6 @@ class ACLTests extends SpruceTest(`${__dirname}/../../spruce-skill/`) {
 }
 
 describe('ACLTests', function Tests() {
+	this.timeout(30000)
 	new ACLTests()
 })

--- a/packages/spruce-skill-server/tests/ACLTests.js
+++ b/packages/spruce-skill-server/tests/ACLTests.js
@@ -1,0 +1,248 @@
+const assert = require('chai').assert
+const SpruceTest = require('./SpruceTest')
+const config = require('config')
+
+class ACLTests extends SpruceTest(`${__dirname}/../../spruce-skill/`) {
+	setup() {
+		it('Checks location acls as owner', () => this.checkLocationAcls('owner'))
+		it('Checks location acls as groupManager', () =>
+			this.checkLocationAcls('groupManager'))
+		it('Checks location acls as manager', () =>
+			this.checkLocationAcls('manager'))
+		it('Checks location acls as teammate', () =>
+			this.checkLocationAcls('teammate'))
+		it('Checks location acls as guest', () => this.checkLocationAcls('guest'))
+
+		it('Checks organization acls as owner', () =>
+			this.checkOrganizationAcls('owner'))
+		it('Checks organization acls as groupManager', () =>
+			this.checkOrganizationAcls('groupManager'))
+		it('Checks organization acls as manager', () =>
+			this.checkOrganizationAcls('manager'))
+		it('Checks organization acls as teammate', () =>
+			this.checkOrganizationAcls('teammate'))
+		it('Checks organization acls as guest', () =>
+			this.checkOrganizationAcls('guest'))
+
+		it('Checks multiple acls as owner', () => this.checkMultipleAcls('owner'))
+		it('Checks multiple acls as groupManager', () =>
+			this.checkMultipleAcls('groupManager'))
+		it('Checks multiple acls as manager', () =>
+			this.checkMultipleAcls('manager'))
+		it('Checks multiple acls as teammate', () =>
+			this.checkMultipleAcls('teammate'))
+		it('Checks multiple acls as guest', () => this.checkMultipleAcls('guest'))
+
+		it('Returns false for acl that is not defined', () => this.aclUndefined())
+		it('Returns false for invalid slug', () => this.invalidSlug())
+		it('Throws error on missing parameter userId', () =>
+			this.missingParametersUserId())
+		it('Throws error on missing parameter organizationId', () =>
+			this.missingParametersOrganizationId())
+		it('Throws error on missing parameter permissions', () =>
+			this.missingParametersPermissions())
+	}
+
+	async checkLocationAcls(as) {
+		let expected
+		let userId
+
+		switch (as) {
+			case 'owner':
+				expected = true
+				userId = this.organization.owner[0].id
+				break
+			case 'groupManager':
+				expected = true
+				userId = this.organization.groupManager[0].id
+				break
+			case 'manager':
+				expected = true
+				userId = this.location.owner[0].id
+				break
+			case 'teammate':
+				expected = true
+				userId = this.location.teammate[0].id
+				break
+			case 'guest':
+				expected = false
+				userId = this.location.guest[0].id
+				break
+
+			default:
+				throw new Error('Invalid option')
+		}
+
+		const isAuthorized = await this.ctx.services.acl.userIsAuthorizedForAcls({
+			userId,
+			permissions: {
+				[config.SLUG]: ['can_do_example_location']
+			},
+			locationId: this.location.id,
+			organizationId: this.organization.id
+		})
+
+		assert.equal(isAuthorized, expected)
+	}
+
+	async checkOrganizationAcls(as) {
+		let expected
+		let userId
+
+		switch (as) {
+			case 'owner':
+				expected = true
+				userId = this.organization.owner[0].id
+				break
+			case 'groupManager':
+				expected = true
+				userId = this.organization.groupManager[0].id
+				break
+			case 'manager':
+				expected = true
+				userId = this.location.owner[0].id
+				break
+			case 'teammate':
+				expected = true
+				userId = this.location.teammate[0].id
+				break
+			case 'guest':
+				expected = false
+				userId = this.location.guest[0].id
+				break
+
+			default:
+				throw new Error('Invalid option')
+		}
+
+		const isAuthorized = await this.ctx.services.acl.userIsAuthorizedForAcls({
+			userId,
+			permissions: {
+				[config.SLUG]: ['can_do_example_organization']
+			},
+			organizationId: this.organization.id
+		})
+
+		assert.equal(isAuthorized, expected)
+	}
+
+	async checkMultipleAcls(as) {
+		let expected
+		let userId
+
+		switch (as) {
+			case 'owner':
+				expected = true
+				userId = this.organization.owner[0].id
+				break
+			case 'groupManager':
+				expected = false
+				userId = this.organization.groupManager[0].id
+				break
+			case 'manager':
+				expected = false
+				userId = this.location.owner[0].id
+				break
+			case 'teammate':
+				expected = false
+				userId = this.location.teammate[0].id
+				break
+			case 'guest':
+				expected = false
+				userId = this.location.guest[0].id
+				break
+
+			default:
+				throw new Error('Invalid option')
+		}
+
+		const isAuthorized = await this.ctx.services.acl.userIsAuthorizedForAcls({
+			userId,
+			permissions: {
+				[config.SLUG]: [
+					'can_do_example_organization',
+					'can_do_example_location_owner_only'
+				]
+			},
+			organizationId: this.organization.id
+		})
+
+		assert.equal(isAuthorized, expected)
+	}
+
+	async aclUndefined() {
+		const isAuthorized = await this.ctx.services.acl.userIsAuthorizedForAcls({
+			userId: this.organization.owner[0].id,
+			permissions: {
+				[config.SLUG]: ['not_a_real_permission']
+			},
+			locationId: this.location.id,
+			organizationId: this.organization.id
+		})
+
+		assert.isFalse(isAuthorized)
+	}
+
+	async invalidSlug() {
+		const isAuthorized = await this.ctx.services.acl.userIsAuthorizedForAcls({
+			userId: this.organization.owner[0].id,
+			permissions: {
+				not_a_real_slug: ['can_do_example_location']
+			},
+			locationId: this.location.id,
+			organizationId: this.organization.id
+		})
+
+		assert.isFalse(isAuthorized)
+	}
+
+	async missingParametersUserId() {
+		let didThrow = false
+		try {
+			await this.ctx.services.acl.userIsAuthorizedForAcls({
+				permissions: {
+					[config.SLUG]: ['can_do_example_location']
+				},
+				locationId: this.location.id,
+				organizationId: this.organization.id
+			})
+		} catch (e) {
+			didThrow = true
+		}
+		assert.isTrue(didThrow)
+	}
+
+	async missingParametersOrganizationId() {
+		let didThrow = false
+		try {
+			await this.ctx.services.acl.userIsAuthorizedForAcls({
+				userId,
+				permissions: {
+					[config.SLUG]: ['can_do_example_location']
+				},
+				locationId: this.location.id
+			})
+		} catch (e) {
+			didThrow = true
+		}
+		assert.isTrue(didThrow)
+	}
+
+	async missingParametersPermissions() {
+		let didThrow = false
+		try {
+			await this.ctx.services.acl.userIsAuthorizedForAcls({
+				userId,
+				locationId: this.location.id,
+				organizationId: this.organization.id
+			})
+		} catch (e) {
+			didThrow = true
+		}
+		assert.isTrue(didThrow)
+	}
+}
+
+describe('ACLTests', function Tests() {
+	new ACLTests()
+})

--- a/packages/spruce-skill-server/tests/SpruceTest.js
+++ b/packages/spruce-skill-server/tests/SpruceTest.js
@@ -95,6 +95,7 @@ module.exports = basePath => {
 				const { koa, server } = await require(`${basePath}/server/server`)
 				this.server = server
 				this.koa = koa
+				this.ctx = this.koa.context
 				this.request = supertest(this.server)
 
 				if (!options || !options.disableMocks) {

--- a/packages/spruce-skill-server/tests/apiMocks.js
+++ b/packages/spruce-skill-server/tests/apiMocks.js
@@ -1,8 +1,10 @@
+const debug = require('debug')('spruce-skill-server')
 const config = require('config')
 
 module.exports = ctx => ({
 	// Mock version of acls. Can't do real checks so we'll just check defaults in the config file and return true if any of them are valid.  This should be accurate enough for automated tests
 	Acl: async (source, args, context, info) => {
+		debug('Doing ACL check using Mock server')
 		if (args.userId && args.permissions) {
 			const user = await ctx.db.models.User.findOne({
 				where: {
@@ -62,17 +64,22 @@ module.exports = ctx => ({
 
 				for (let j = 0; j < permissions.length; j += 1) {
 					const permission = permissions[j]
-
-					if (
-						config.acl.publishes[permission] &&
-						config.acl.publishes[permission].defaults
-					) {
-						slugResponse.permissions.push({
-							name: permission,
-							value:
-								userRole === 'owner' ||
-								config.acl.publishes[permission].defaults[userRole] === true
-						})
+					if (slug === config.SLUG) {
+						if (
+							config.acl.publishes[permission] &&
+							config.acl.publishes[permission].defaults
+						) {
+							slugResponse.permissions.push({
+								name: permission,
+								value:
+									userRole === 'owner' ||
+									config.acl.publishes[permission].defaults[userRole] === true
+							})
+						}
+					} else {
+						debug(
+							'Checking for permissions from a different skill in tests is not currently supported'
+						)
 					}
 				}
 

--- a/packages/spruce-skill/config/default.js
+++ b/packages/spruce-skill/config/default.js
@@ -105,6 +105,12 @@ module.exports = {
 					groupManager: true
 				}
 			},
+			can_do_example_location_owner_only: {
+				label:
+					'If the user can do this example thing for a location. Org owner only',
+				type: 'location',
+				defaults: {}
+			},
 			can_do_example_organization: {
 				label: 'If the user can do this example thing for an organization.',
 				type: 'organization',

--- a/packages/spruce-skill/package.json
+++ b/packages/spruce-skill/package.json
@@ -27,8 +27,8 @@
 		"interface": "next ./interface -p 3080",
 		"lint": "eslint --ext .js .",
 		"test": "yarn run build && jest",
-		"test:server": "rm tmp/testing.db | true && PORT=3010 BLUEBIRD_W_FORGOTTEN_RETURN=0 ALLOW_NON_SSL=true ORM_LOGGING=false TESTING=true API_ONLY=true DB_MIGRATIONS=false mocha -r flow-remove-types/register --exit 'server/tests/**/*Tests.js'",
-		"test:server:single": "PORT=3010 BLUEBIRD_W_FORGOTTEN_RETURN=0 ALLOW_NON_SSL=true ORM_LOGGING=false TESTING=true API_ONLY=true DB_MIGRATIONS=false mocha -r flow-remove-types/register --exit",
+		"test:server": "rm tmp/testing.db | true && mkdir -p tmp/ | true && PORT=3010 BLUEBIRD_W_FORGOTTEN_RETURN=0 ALLOW_NON_SSL=true ORM_LOGGING=false TESTING=true API_ONLY=true DB_MIGRATIONS=false mocha -r flow-remove-types/register --exit 'server/tests/**/*Tests.js'",
+		"test:server:single": "rm tmp/testing.db | true && mkdir -p tmp/ | true && PORT=3010 BLUEBIRD_W_FORGOTTEN_RETURN=0 ALLOW_NON_SSL=true ORM_LOGGING=false TESTING=true API_ONLY=true DB_MIGRATIONS=false mocha -r flow-remove-types/register --exit",
 		"icon": "svgo icon/icon.svg",
 		"heroku-postbuild": "npm run build",
 		"release": "semantic-release"


### PR DESCRIPTION
## What does this PR do?

* Adds strict ACL checks to the `ctx.services.acl. userIsAuthorizedForAcls()` method

  * Now assumes the user is *not* authorized and verifies that every ACL requested is valid

  * Now Throws errors on missing required parameters

* Adds check to API mock GQL server that the permission being checked is for the skill currently being tested

* Additional debug logging around ACLs and event contracts

* Removes (unused) jest and implements tests via mocha for `spruce-skill-server`

* Add tests around ACL check scenarios

* Update `package.json` scripts for tests to create the `tmp/` directory if it doesn't already exist

* Adds `this.ctx` to base test class for convenience

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-852](https://sprucelabsai.atlassian.net/browse/SDEV3-852)