### PR TITLE
feat(RecordSelectionList): Add reset method

### DIFF
--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
@@ -103,11 +103,11 @@ export default class RecordSelectionList extends Component<
 	}
 
 	async componentDidMount() {
-		const { loadRecords } = this.props
+		const { loadRecords, recordsPerRequest } = this.props
 
 		const initialRecords = await loadRecords({
 			offset: 0,
-			limit: 10
+			limit: recordsPerRequest
 		})
 
 		this.setState({
@@ -131,11 +131,11 @@ export default class RecordSelectionList extends Component<
 	}
 
 	async reset() {
-		const { loadRecords } = this.props
+		const { loadRecords, recordsPerRequest } = this.props
 
 		const initialRecords = await loadRecords({
 			offset: 0,
-			limit: 10
+			limit: recordsPerRequest
 		})
 
 		this.setState({
@@ -231,7 +231,7 @@ export default class RecordSelectionList extends Component<
 	}
 
 	handleInfiniteLoad = async () => {
-		const { loadRecords } = this.props
+		const { loadRecords, recordsPerRequest } = this.props
 		const { loadedRecords, isLoading, search } = this.state
 
 		if (isLoading) {
@@ -242,7 +242,7 @@ export default class RecordSelectionList extends Component<
 
 		const newRows = await loadRecords({
 			offset: loadedRecords.length,
-			limit: 10,
+			limit: recordsPerRequest,
 			search
 		})
 
@@ -257,7 +257,7 @@ export default class RecordSelectionList extends Component<
 	}
 
 	handleSearchUpdate = async (e: SyntheticInputEvent<HTMLInputElement>) => {
-		const { loadRecords } = this.props
+		const { loadRecords, recordsPerRequest } = this.props
 
 		// Search will rapid-fire, but we only want to use the last result.
 		// If this value doesn't change by the time the API responds, we'll use
@@ -273,7 +273,7 @@ export default class RecordSelectionList extends Component<
 		// When we search, we'll want to reset the list, so back to offset 0!
 		const newRows = await loadRecords({
 			offset: 0,
-			limit: 10,
+			limit: recordsPerRequest,
 			search: e.target.value
 		})
 
@@ -370,5 +370,6 @@ export default class RecordSelectionList extends Component<
 }
 
 RecordSelectionList.defaultProps = {
-	showSelectedCount: true
+	showSelectedCount: false,
+	recordsPerRequest: 10
 }

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
@@ -130,6 +130,23 @@ export default class RecordSelectionList extends Component<
 		}
 	}
 
+	async reset() {
+		const { loadRecords } = this.props
+
+		const initialRecords = await loadRecords({
+			offset: 0,
+			limit: 10
+		})
+
+		this.setState({
+			loadedRecords: initialRecords
+		})
+
+		this.cache.clearAll()
+		this.list.recomputeRowHeights(0)
+		this.list.forceUpdateGrid()
+	}
+
 	renderRow = ({
 		index,
 		key,


### PR DESCRIPTION
- Since RSL maintains its own state for the sake of infinite scrolling, needed a method to reset the state.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt