### PR TITLE
fix(Auth): Remove client-side cookie setting for JWT token

### DIFF
--- a/packages/react-heartwood-components/package.json
+++ b/packages/react-heartwood-components/package.json
@@ -101,7 +101,6 @@
 		"image-webpack-loader": "^4.3.1",
 		"imagesloaded": "^4.1.4",
 		"is_js": "^0.9.0",
-		"js-cookies": "^1.0.4",
 		"jsdom": "14.0.0",
 		"jsdom-global": "3.0.2",
 		"memoize-one": "^4.0.2",

--- a/packages/spruce-next-helpers/package.json
+++ b/packages/spruce-next-helpers/package.json
@@ -77,7 +77,6 @@
 		"cookies": "^0.7.3",
 		"debug": "^3.1.0",
 		"is_js": "^0.9.0",
-		"js-cookies": "^1.0.4",
 		"next": "^7.0.0",
 		"next-redux-wrapper": "^1.0.0",
 		"prop-types": "^15.6.0",

--- a/packages/spruce-next-helpers/src/skillskit/next/PageWrapper.js
+++ b/packages/spruce-next-helpers/src/skillskit/next/PageWrapper.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react'
 
 import * as actions from '../store/actions'
 import ServerCookies from 'cookies'
-import ClientCookies from 'js-cookies'
 import skill from '../index'
 import { Loader, FontLoader } from '@sprucelabs/react-heartwood-components'
 import qs from 'qs'
@@ -21,8 +20,6 @@ const setCookie = (named, value, req, res) => {
 			httpOnly: false
 		})
 		return cookies.set(named, value)
-	} else {
-		return ClientCookies.setItem(named, value)
 	}
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12349,11 +12349,6 @@ js-beautify@^1.6.2:
     mkdirp "~0.5.0"
     nopt "~4.0.1"
 
-js-cookies@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/js-cookies/-/js-cookies-1.0.4.tgz#d46e576c420ff6d5542c0f52b6d4ef7d637e754e"
-  integrity sha1-1G5XbEIP9tVULA9SttTvfWN+dU4=
-
 js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"


### PR DESCRIPTION
- As written, this can't actually set the token client-side, since a 
client cookie can't overwrite a server cookie.
- Also, the client cookie wasn't setting a path, resulting in duplicated 
cookies that broke auth in skills.
- Since it doesn't actually do anything and server-cookies covers our 
needs, removing it entirely.
- This was the only place the library was actually used in workspace, so 
removing the dependency

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt