### PR TITLE
[SDEV3-319] create new ImageSSR component to handle image load errors

### DIFF
--- a/packages/heartwood-components/components/07-navigation/tabs.scss
+++ b/packages/heartwood-components/components/07-navigation/tabs.scss
@@ -46,6 +46,10 @@
 
 .tab .tab__inner {
 	height: auto;
+
+	&.btn:hover {
+		background-color: transparent;
+	}
 }
 
 .tab-group {

--- a/packages/heartwood-components/stylesheets/base/_base.scss
+++ b/packages/heartwood-components/stylesheets/base/_base.scss
@@ -30,6 +30,10 @@ strong {
 	visibility: hidden;
 }
 
+img.error {
+	display: none;
+}
+
 // Handle FOIT if desired
 @if global-variable-exists(foit) == false or $foit == true {
 	.fonts-loading {

--- a/packages/react-heartwood-components/src/components/Avatar/Avatar.tsx
+++ b/packages/react-heartwood-components/src/components/Avatar/Avatar.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import cx from 'classnames'
 
+import ImageSSR from '../../components/ImageSSR/ImageSSR'
+
 interface IProps {
 	/** Avatar image url. */
 	image: string
@@ -35,6 +37,8 @@ interface IProps {
 	/** Provided HTML classNames. */
 	className?: string
 }
+
+
 const Avatar = (props: IProps): React.ReactNode => {
 	const {
 		image,
@@ -75,7 +79,7 @@ const Avatar = (props: IProps): React.ReactNode => {
 	return (
 		<div className={wrapperClass}>
 			<div className="avatar__image-wrapper">
-				<img
+				<ImageSSR
 					className="avatar"
 					src={image}
 					alt={alt}

--- a/packages/react-heartwood-components/src/components/ImageSSR/ImageSSR.js
+++ b/packages/react-heartwood-components/src/components/ImageSSR/ImageSSR.js
@@ -1,0 +1,34 @@
+// @flow
+
+import React, {Fragment} from 'react'
+
+type Props = { src: string,
+	alt: string,
+	className: string,
+	width: string,
+	height: string
+}
+
+// This component returns a wrapped img element that will handle image sources that fail to load.
+// Regular JSX <img /> tag onError event does not work correclty with SSR so
+// this component is used as a workaround.
+
+const ImageSSR = (props: Props) => {
+	const { className, alt, src, width, height } = props
+	return (
+		<div
+			className="image-wrapper"
+			dangerouslySetInnerHTML={{
+				__html: `
+					<img class=${className} alt=${alt} src="${src}"
+					onerror="this.onerror=null;this.classList.add('error');"
+					width=${width}
+					height=${height} 
+					/>
+				`
+			}}
+		/>
+	);
+}
+
+export default ImageSSR

--- a/packages/react-heartwood-components/src/components/ImageSSR/ImageSSR.js
+++ b/packages/react-heartwood-components/src/components/ImageSSR/ImageSSR.js
@@ -1,8 +1,9 @@
 // @flow
 
-import React, {Fragment} from 'react'
+import React from 'react'
 
-type Props = { src: string,
+type Props = {
+	src: string,
 	alt: string,
 	className: string,
 	width: string,
@@ -28,7 +29,7 @@ const ImageSSR = (props: Props) => {
 				`
 			}}
 		/>
-	);
+	)
 }
 
 export default ImageSSR

--- a/packages/react-heartwood-components/src/index.js
+++ b/packages/react-heartwood-components/src/index.js
@@ -60,6 +60,7 @@ export {
 export { default as Text, Span } from './components/Text/Text'
 export { default as TextStyle } from './components/TextStyle/TextStyle'
 export { default as Image } from './components/Image/Image'
+export { default as ImageSSR } from './components/ImageSSR/ImageSSR'
 export { default as ImageCropper } from './components/ImageCropper/ImageCropper'
 export { default as Layout, LayoutSection } from './components/Layout'
 export {


### PR DESCRIPTION
## What does this PR do?

* Removes hover state from tab buttons. This was a side-effect of adding a default hover state to the button component.
* Adds ImageSSR component to handle broken image urls. NOTE: This component is a workaround that fixes a known issue where the JSX `img` component does not handle `onError` events correctly.
* Update Avatar component to use new ImageSSR component to hide broken avatar urls.

## Type

- [X] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

## Screenshots (if appropriate)

## What gif best describes this PR or how it makes you feel?