### PR TITLE
[SDEV3-1333] [SDEV3-1327] calendar scroll

### DIFF
--- a/packages/heartwood-components/components/09-bigcalendar/bigcalendar.scss
+++ b/packages/heartwood-components/components/09-bigcalendar/bigcalendar.scss
@@ -31,10 +31,6 @@ $event-indent-width: rem(50);
 }
 
 .bigcalendar {
-	height: 100%;
-	overflow: hidden;
-	display: flex;
-	flex-direction: column;
 	background-color: #fff;
 	-webkit-touch-callout: none;
 	-webkit-user-select: none; /* Disable selection/copy in UIWebView */
@@ -42,6 +38,9 @@ $event-indent-width: rem(50);
 	* {
 		box-sizing: border-box;
 	}
+}
+
+body.sb-show-main {
 }
 
 .bigcalendar__header-top {
@@ -216,17 +215,7 @@ $event-indent-width: rem(50);
 	}
 }
 
-.bigcalendar__view-wrapper {
-	flex: 1;
-	overflow: hidden;
-}
-
 .bigcalendar__view-day {
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	overflow: hidden;
-
 	.bigcalendar__time-gutter {
 		@include type-style-label;
 		min-width: $time-gutter-width;
@@ -403,6 +392,9 @@ $event-indent-width: rem(50);
 
 	&.is-drag-source {
 		opacity: 0.5;
+	}
+
+	&.is-active-drag {
 	}
 
 	&.animate,

--- a/packages/react-heartwood-components/src/components/BigCalendar/BigCalendar-story.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/BigCalendar-story.js
@@ -165,12 +165,7 @@ class BigCalendarExample extends Component<Props, State> {
 		const { users, events, userMode, toasts } = this.state
 
 		return (
-			<div
-				style={{
-					width: '100vw',
-					height: '50vh'
-				}}
-			>
+			<div>
 				<BigCalendar
 					// users={object('users', users, CATEGORIES.data)}
 					// allEvents={object('allEvents', events, CATEGORIES.data)}

--- a/packages/react-heartwood-components/src/components/BigCalendar/components/Views/Day.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/components/Views/Day.js
@@ -1382,6 +1382,9 @@ class Day extends PureComponent<Props, State> {
 						dragScrollSpeed={dragScrollSpeed}
 						enableAutoScrollX={enableAutoScrollX}
 						enableAutoScrollY={enableAutoScrollY}
+						style={{
+							height: calendarBodyHeight
+						}}
 					>
 						<div className="scroll-inner" ref={this.scrollInnerRef}>
 							{users.map((user, idx) => (

--- a/packages/react-heartwood-components/src/components/BigCalendar/utils/size.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/utils/size.js
@@ -1,4 +1,10 @@
 export default {
+	bodyWidth() {
+		return document.body.clientWidth
+	},
+	bodyHeight() {
+		return document.body.clientHeight
+	},
 	getLocalTop(node) {
 		return node.offsetTop
 	},


### PR DESCRIPTION
## What does this PR do?

* Reverts changes to BigCalendar that were made in preparation for new web that were breaking calendar scrolling in legacy booking. NOTE: Since BigCalendar is now in new web this change should not impact new web calendar.

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1333](https://sprucelabsai.atlassian.net/browse/SDEV3-1333)
- [SDEV3-1327](https://sprucelabsai.atlassian.net/browse/SDEV3-1327)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

* Need to update `react-heartwood-components` package in booking

## Screenshots (if appropriate)

## What gif best describes this PR or how it makes you feel?

![electric slide](https://media.giphy.com/media/3otPoD3m0h16iRbgNG/giphy.gif)