### PR TITLE
Fix ctx.sb.mutation not properly calling api SDEV3-1353

### DIFF
--- a/packages/spruce-node/https/index.js
+++ b/packages/spruce-node/https/index.js
@@ -47,37 +47,6 @@ module.exports = class Https {
 		})
 	}
 
-	async mutation(query) {
-		return new Promise((resolve, reject) => {
-			const path = '/graphql'
-			// API Key must go with each request
-			const headers = {
-				'x-skill-id': this.id,
-				'x-skill-api-key': this.apiKey,
-				'Content-Type': 'application/json'
-			}
-
-			const request = https.request(
-				{
-					method: 'POST',
-					host: this.host,
-					headers,
-					rejectUnauthorized: !this.allowSelfSignedCerts,
-					path
-				},
-				response => {
-					this.handleResponse(request, response, resolve, reject)
-				}
-			)
-
-			request.end(
-				JSON.stringify({
-					mutation: query
-				})
-			)
-		})
-	}
-
 	/**
 	 * GET an endpoint.
 	 *

--- a/packages/spruce-node/index.js
+++ b/packages/spruce-node/index.js
@@ -124,7 +124,7 @@ class Sprucebot {
 	}
 
 	async mutation(query) {
-		return this.adapter.mutation(query)
+		return this.adapter.query(`mutation ${query}`)
 	}
 
 	/**

--- a/packages/spruce-skill-server/tests/GQLMethodTests.js
+++ b/packages/spruce-skill-server/tests/GQLMethodTests.js
@@ -8,7 +8,7 @@ class GQLMethodTests extends SpruceTest(`${__dirname}/../../spruce-skill/`) {
 		it('Can call query', () => this.doQuery())
 		it('Can not call query as mutation', () => this.doQueryAsMutate())
 		it('Can call mutation', () => this.doMutate())
-		it('Can call mutation as query', () => this.doMutateAsQuery())
+		it('Can not call mutation as query', () => this.doMutateAsQuery())
 	}
 
 	async doQuery() {

--- a/packages/spruce-skill-server/tests/GQLMethodTests.js
+++ b/packages/spruce-skill-server/tests/GQLMethodTests.js
@@ -1,0 +1,76 @@
+const assert = require('chai').assert
+const SpruceTest = require('./SpruceTest')
+const config = require('config')
+const faker = require('faker')
+
+class GQLMethodTests extends SpruceTest(`${__dirname}/../../spruce-skill/`) {
+	setup() {
+		it('Can call query', () => this.doQuery())
+		it('Can not call query as mutation', () => this.doQueryAsMutate())
+		it('Can call mutation', () => this.doMutate())
+		it('Can call mutation as query', () => this.doMutateAsQuery())
+	}
+
+	async doQuery() {
+		const result = await this.ctx.sb.query(`
+		{
+				Location (
+				id: "${this.location.id}"
+			) {
+				name
+			}
+		}`)
+		assert.isOk(result.data.Location.name)
+	}
+
+	async doQueryAsMutate() {
+		const result = await this.ctx.sb.mutation(`
+		{
+				Location (
+				id: "${this.location.id}"
+			) {
+				name
+			}
+		}`)
+		assert.isUndefined(result.data)
+		assert.isOk(result.errors)
+		assert.isOk(result.errors[0])
+	}
+
+	async doMutate() {
+		const result = await this.ctx.sb.mutation(`
+		{
+			updateLocation (input: {
+				id: "${this.location.id}"
+				name: "${faker.lorem.words()}"
+			}) {
+				Location {
+					name
+				}
+			}
+		}`)
+		assert.isOk(result.data.updateLocation.Location.name)
+	}
+
+	async doMutateAsQuery() {
+		const result = await this.ctx.sb.query(`
+		{
+			updateLocation (input: {
+				id: "${this.location.id}"
+				name: "${faker.lorem.words()}"
+			}) {
+				Location {
+					name
+				}
+			}
+		}`)
+		assert.isUndefined(result.data)
+		assert.isOk(result.errors)
+		assert.isOk(result.errors[0])
+	}
+}
+
+describe('GQLMethodTests', function Tests() {
+	this.timeout(30000)
+	new GQLMethodTests()
+})


### PR DESCRIPTION
## What does this PR do?

* Fixes issue where the query was being incorrectly sent from the helper method.  It's now been simplified to re-use the `https adapter "query" method` since mutations/queries follow the same request format for GQL

* Add tests for `ctx.sb.query` and `ctx.sb.mutation` helper methods

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1353](https://sprucelabsai.atlassian.net/browse/SDEV3-1353)