### PR TITLE
Pass message type when creating messages and add tests (SDEV3-794)

### DIFF
--- a/packages/spruce-node/index.js
+++ b/packages/spruce-node/index.js
@@ -253,10 +253,10 @@ class Sprucebot {
 		locationId,
 		userId,
 		message,
-		{ linksToWebView, webViewQueryData, payload, sendAtTimestamp } = {},
+		{ linksToWebView, webViewQueryData, payload, sendAtTimestamp, type } = {},
 		query = {}
 	) {
-		const data = Array.from(arguments)[3] || {}
+		const data = Array.from(arguments)[3] || { type: 'promotional' }
 		data.userId = userId
 		data.message = message
 		if (data.webViewQueryData) {
@@ -305,8 +305,8 @@ class Sprucebot {
 	 * @param {String} userId
 	 * @param {String} message
 	 */
-	async globalMessage(userId, message) {
-		return this.adapter.post('/messages', { userId, message })
+	async globalMessage(userId, message, type = 'promotional') {
+		return this.adapter.post('/messages', { userId, message, type })
 	}
 
 	/**

--- a/packages/spruce-skill-server/tests/MessageTests.js
+++ b/packages/spruce-skill-server/tests/MessageTests.js
@@ -1,0 +1,55 @@
+const assert = require('chai').assert
+const faker = require('faker')
+const SpruceTest = require('./SpruceTest')
+const config = require('config')
+
+class MessageTests extends SpruceTest(`${__dirname}/../../spruce-skill/`) {
+	setup() {
+		it('Sends a message as promotional by default', () =>
+			this.sendMessageDefault())
+		it('Sends a message as promotional', () => this.sendMessagePromotional())
+		it('Sends a message as transactional', () =>
+			this.sendMessageTransactional())
+	}
+
+	async sendMessageDefault() {
+		const result = await this.ctx.sb.message(
+			this.location.id,
+			this.location.guest[0].id,
+			faker.lorem.sentences()
+		)
+
+		assert.equal(result.requestOptions.data.type, 'promotional')
+	}
+
+	async sendMessagePromotional() {
+		const result = await this.ctx.sb.message(
+			this.location.id,
+			this.location.guest[0].id,
+			faker.lorem.sentences(),
+			{
+				type: 'promotional'
+			}
+		)
+
+		assert.equal(result.requestOptions.data.type, 'promotional')
+	}
+
+	async sendMessageTransactional() {
+		const result = await this.ctx.sb.message(
+			this.location.id,
+			this.location.guest[0].id,
+			faker.lorem.sentences(),
+			{
+				type: 'transactional'
+			}
+		)
+
+		assert.equal(result.requestOptions.data.type, 'transactional')
+	}
+}
+
+describe('MessageTests', function Tests() {
+	this.timeout(30000)
+	new MessageTests()
+})

--- a/packages/spruce-skill-server/tests/v1APIMocks.js
+++ b/packages/spruce-skill-server/tests/v1APIMocks.js
@@ -40,7 +40,15 @@ module.exports = ctx => ({
 		return Promise.resolve({})
 	},
 	async post(path, data, query, method) {
-		const response = {}
+		const response = {
+			// Pass back the request options so it can be validated in tests
+			requestOptions: {
+				path,
+				data,
+				query,
+				method
+			}
+		}
 
 		// `locations/${locationId}/emit`
 		// `organizations/${organizationId}/emit`


### PR DESCRIPTION
## What does this PR do?

* Sets the message `type` when creating messages

* Adds `requestOptions` to the mock api response for tests so that we can validate the parameters that are getting passed through on helper methods. In this scenario since we call `ctx.sb.message(...)` which then calls (and returns) `ctx.sb.post(...)` this will let us write basic tests around our helper methods to ensure that the proper parameters are getting sent to the API

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-794](https://sprucelabsai.atlassian.net/browse/SDEV3-794)