### PR TITLE
feat(SpruceSkill): Add status check listener for core to ping [SDEV3-587]

### DIFF
--- a/packages/spruce-next-helpers/src/skillskit/index.js
+++ b/packages/spruce-next-helpers/src/skillskit/index.js
@@ -5,6 +5,8 @@ function postMessage(message) {
 	return window.parent.postMessage(JSON.stringify(message), '*')
 }
 
+let skillStatusCheckListener = null
+
 const skill = {
 	editUserProfile: function({
 		userId,
@@ -32,6 +34,20 @@ const skill = {
 				showHeader
 			}
 		})
+
+		// This is a simple callback that Core can use to see if a skill is
+		// running inside the iframe. Necessary since we don't necessarily want
+		// to allow direct cross-domain access for security reasons.
+		if (!skillStatusCheckListener) {
+			skillStatusCheckListener = Iframes.onMessage(
+				'Skill:StatusCheck',
+				(data, responder) => {
+					responder({
+						eventName: 'Skill:IsAlive'
+					})
+				}
+			)
+		}
 	},
 
 	//TODO move to iframes?


### PR DESCRIPTION
## What does this PR do?

- This is necessary to allow core to see if a Skill is running. Usually we just listen to the iframe's load event, but in some cases that happens before the core app has a chance to mount.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-587](https://sprucelabsai.atlassian.net/browse/SDEV3-587)