### PR TITLE
fix: [SDEV3-1032] fix broken icon styles on buttons

### DIFF
--- a/packages/heartwood-components/components/01-button/button.scss
+++ b/packages/heartwood-components/components/01-button/button.scss
@@ -51,9 +51,12 @@ Button Variation mixins
 		fill: $color;
 	}
 
-	.btn__line-icon {
-		fill: none;
+	.icon--stroke {
 		stroke: $color;
+	}
+
+	.icon--no-fill {
+		fill: none;
 	}
 
 	// Button States
@@ -66,8 +69,11 @@ Button Variation mixins
 				fill: rgba($color, 0.8);
 			}
 
-			.btn__line-icon {
+			.icon--no-fill {
 				fill: none;
+			}
+
+			.icon--stroke {
 				stroke: rgba($color, 0.8);
 			}
 		} @else {
@@ -76,9 +82,12 @@ Button Variation mixins
 			.btn__icon {
 				fill: rgba($color, 0.5);
 
-				.btn__line-icon {
-					fill: none;
+				.icon--stroke {
 					stroke: rgba($color, 0.5);
+				}
+
+				.icon--no-fill {
+					fill: none;
 				}
 			}
 		}
@@ -147,8 +156,7 @@ Baseline styling for all buttons
 		}
 	}
 
-	.btn__line-icon {
-		fill: none;
+	.icon--stroke {
 		stroke: $c-text-icon;
 	}
 


### PR DESCRIPTION
## What does this PR do?

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1032](https://sprucelabsai.atlassian.net/browse/SDEV3-1032)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

- Skills/Web will need to be updated to the latest version of `react-heartwood-components`

## Screenshots (if appropriate)

**MAKE YOUR ICONS GO FROM THIS...**

![Screen Shot 2019-05-21 at 10 26 22 AM](https://user-images.githubusercontent.com/755542/58113587-17319a80-7bb3-11e9-8806-b47dfed8f711.png)

**TO THIS!**

![Screen Shot 2019-05-21 at 10 26 28 AM](https://user-images.githubusercontent.com/755542/58113588-17319a80-7bb3-11e9-8365-df36338f38b5.png)

## What gif best describes this PR or how it makes you feel?

![clean](https://media.giphy.com/media/dJEMs13SrsiuA/giphy.gif)