### PR TITLE
fix(Select): Create defaults around placeholder option

### DIFF
--- a/packages/react-heartwood-components/src/components/Forms/Forms-story.js
+++ b/packages/react-heartwood-components/src/components/Forms/Forms-story.js
@@ -255,6 +255,11 @@ stories
 	))
 	.add('Select', () => (
 		<Fragment>
+			<p>
+				For controlled usage, default `value` to an empty-string in order to
+				display the placeholder.
+			</p>
+
 			<Select
 				label={text('label', 'Country')}
 				placeholder={text('placeholder', 'Select something...')}

--- a/packages/react-heartwood-components/src/components/Forms/components/Select/Select.js
+++ b/packages/react-heartwood-components/src/components/Forms/components/Select/Select.js
@@ -51,13 +51,26 @@ const Select = (props: Props) => {
 		'select--has-error': error
 	})
 
+	let defaultSelectProps = {}
+	let defaultOptionProps = {}
+
+	// For uncontrolled Select, we'll create a default value for the placeholder.
+	// For controlled Select, we'll require that the value be defaulted to
+	//   empty-string in order to set the placeholder.
+	if (!props.value) {
+		defaultSelectProps = { defaultValue: '__DEFAULT' }
+		defaultOptionProps = { value: '__DEFAULT' }
+	} else {
+		defaultOptionProps = { value: '' }
+	}
+
 	return (
 		<div className="select-wrapper">
 			{label && <InputPre id={id} label={label} postLabel={postLabel} />}
 			<div className={parentClass}>
-				<select {...rest}>
+				<select {...defaultSelectProps} {...rest}>
 					{placeholder && (
-						<option key="placeholder" disabled selected>
+						<option {...defaultOptionProps} key="placeholder" disabled>
 							{placeholder}
 						</option>
 					)}


### PR DESCRIPTION
- The previous version threw errors, since React doesn't like the 
`selected` attribute.
- This provides an automatic default for uncontrolled Selects, and a 
requirement for how to handle defaults on controlled Selects.
- Added a note in storybook

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt