### PR TITLE
[SDEV3-1534] SDK is now exposing multiple orgs on the sandbox data

### DIFF
--- a/packages/spruce-skill-server/tests/SpruceTest.js
+++ b/packages/spruce-skill-server/tests/SpruceTest.js
@@ -83,6 +83,13 @@ module.exports = basePath => {
 				const locationId = Object.keys(this.mocks.sandbox.locations)[0]
 				this.location = this.mocks.sandbox.locations[locationId]
 				this.skill = this.mocks.sandbox.skill
+
+				this.otherOrganization = this.mocks.sandbox.otherOrganization
+				const otherLocationId = Object.keys(
+					this.mocks.sandbox.otherLocations
+				)[0]
+				this.otherLocation = this.mocks.sandbox.otherLocations[otherLocationId]
+				this.otherSkill = this.mocks.sandbox.otherSkill
 			} else {
 				throw new Error(
 					'@sprucelabs/spruce-skill-server: SandboxMock has not been initialized. If this is deliberate you should override the before() method in your test'

--- a/packages/spruce-skill-server/tests/mocks/SandboxMock.js
+++ b/packages/spruce-skill-server/tests/mocks/SandboxMock.js
@@ -33,10 +33,27 @@ module.exports = class SandboxMock {
 			numGuests: options.numGuests || 4
 		})
 
+		const sandboxOther = await this.createSandbox({
+			numLocations: options.numLocations || 1,
+			numOwners: options.numOwners || 3,
+			numGroupManagers: options.numGroupManagers || 3,
+			numManagers: options.numManagers || 2,
+			numTeammates: options.numTeammates || 3,
+			numGuests: options.numGuests || 4
+		})
+
 		const { locations, organization } = this.parseUsers(sandbox)
+		const {
+			locations: otherLocations,
+			organization: otherOrganization
+		} = this.parseUsers(sandboxOther)
 
 		this.locations = locations
 		this.organization = organization
+
+		this.otherLocations = otherLocations
+		this.otherOrganization = otherOrganization
+
 		debug('Sandbox mock created')
 	}
 
@@ -119,7 +136,7 @@ module.exports = class SandboxMock {
 
 	async createOrganization() {
 		try {
-			const orgName = uuid.v4()
+			const orgName = faker.company.companyName()
 			const organization = await this.ctx.db.models.Organization.create({
 				id: uuid.v4(),
 				name: orgName

--- a/packages/spruce-skill-server/tests/mocks/SandboxMock.js
+++ b/packages/spruce-skill-server/tests/mocks/SandboxMock.js
@@ -50,9 +50,11 @@ module.exports = class SandboxMock {
 
 		this.locations = locations
 		this.organization = organization
+		this.skill = sandbox.skill
 
 		this.otherLocations = otherLocations
 		this.otherOrganization = otherOrganization
+		this.otherSkill = sandboxOther.skill
 
 		debug('Sandbox mock created')
 	}
@@ -76,7 +78,7 @@ module.exports = class SandboxMock {
 	async createSandbox(options) {
 		const sandbox = {}
 
-		this.skill = await this.createSkill()
+		sandbox.skill = await this.createSkill()
 
 		const numLocations = options.numLocations
 		const numOwners = options.numOwners
@@ -387,11 +389,12 @@ module.exports = class SandboxMock {
 		})
 		const location = options.locations[0]
 		const organization = options.organization
+		const skill = options.skill
 
 		if (users && users.users) {
 			users.users.forEach(user => {
 				const jwt = generateSkillJWT({
-					skill: this.skill,
+					skill,
 					user,
 					location,
 					organization


### PR DESCRIPTION
This will allow for more diverse tests during skills development and testing.

## What does this PR do?

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1534](https://sprucelabsai.atlassian.net/browse/SDEV3-1534)

## What gif best describes this PR or how it makes you feel?