### PR TITLE
feat(Card): Add section separators

### DIFF
--- a/packages/heartwood-components/components/03-structure/card.scss
+++ b/packages/heartwood-components/components/03-structure/card.scss
@@ -91,6 +91,12 @@
 			padding: spacing('loose') 0 spacing('loose');
 		}
 	}
+	&--section-separators-visible {
+		.card__section + .card__section {
+			padding-top: 1rem;
+			border-top: 1px solid $c-border;
+		}
+	}
 }
 
 .card__section {

--- a/packages/react-heartwood-components/src/components/Card/components/CardBody.js
+++ b/packages/react-heartwood-components/src/components/Card/components/CardBody.js
@@ -2,6 +2,7 @@
 // NOTE: Cards should be built in a way that they can be created with JSON
 import React from 'react'
 import type { Node } from 'react'
+import cx from 'classnames'
 import CardSection from './CardSection'
 
 // Card Body
@@ -10,20 +11,27 @@ export type CardBodyProps = {
 	children: Node,
 
 	/** Whether to wrap children in CardSection */
-	isSectioned?: boolean
+	isSectioned?: boolean,
+
+	/** Set true to display line separators between CardSection components */
+	areSectionSeparatorsVisible: boolean
 }
 
 const CardBody = (props: CardBodyProps) => {
-	const { children, isSectioned } = props
+	const { children, isSectioned, areSectionSeparatorsVisible } = props
+	const className = cx('card__body', {
+		'card__body--section-separators-visible': areSectionSeparatorsVisible
+	})
 	return (
-		<div className="card__body">
+		<div className={className}>
 			{isSectioned ? <CardSection>{children}</CardSection> : children}
 		</div>
 	)
 }
 
 CardBody.defaultProps = {
-	isSectioned: true
+	isSectioned: true,
+	areSectionSeparatorsVisible: false
 }
 
 export default CardBody


### PR DESCRIPTION
## What does this PR do?

Adds ability to show line separators between card sections

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-581](https://sprucelabsai.atlassian.net/browse/SDEV3-581)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

Need to update react-heartwood-component package version in skills

## Screenshots (if appropriate)

<img width="726" alt="Screen Shot 2019-05-31 at 3 31 20 PM" src="https://user-images.githubusercontent.com/755542/58735885-37363a80-83b9-11e9-8179-905976064654.png">


## What gif best describes this PR or how it makes you feel?

![zebra dance](https://media.giphy.com/media/10hO3rDNqqg2Xe/giphy.gif)