### PR TITLE
[SDEV3-503] Add "secondaryCTA" option to BigCalendar EventDetails footer

### DIFF
--- a/packages/react-heartwood-components/src/components/BigCalendar/components/EventDetails/components/EventDetailsFooter/EventDetailsFooter.js
+++ b/packages/react-heartwood-components/src/components/BigCalendar/components/EventDetails/components/EventDetailsFooter/EventDetailsFooter.js
@@ -4,15 +4,19 @@ import Button from '../../../../../Button/Button'
 import type { Props as ButtonProps } from '../../../../../Button/Button'
 
 export type Props = {
-	primaryCTA: ButtonProps
+	primaryCTA: ButtonProps,
+	secondaryCTA: ButtonProps
 }
 
 const EventDetailsFooter = (props: Props) => {
-	const { primaryCTA } = props
+	const { primaryCTA, secondaryCTA } = props
 
 	return (
 		<div className="event-details-footer">
-			<Button kind="primary" isFullWidth {...primaryCTA} />
+			{primaryCTA && <Button kind="primary" isFullWidth {...primaryCTA} />}
+			{secondaryCTA && (
+				<Button kind="secondary" isFullWidth {...secondaryCTA} />
+			)}
 		</div>
 	)
 }


### PR DESCRIPTION
## What does this PR do?

* Adds `secondaryCTA` to the `BigCalendar` event details footer

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-503](https://sprucelabsai.atlassian.net/browse/SDEV3-503)

## Screeshots

<img width="550" alt="Screen Shot 2019-06-05 at 11 13 04 AM" src="https://user-images.githubusercontent.com/1094411/58975780-02dcc880-8783-11e9-99d7-d85c06b5e9f4.png">
<img width="546" alt="Screen Shot 2019-06-05 at 11 12 24 AM" src="https://user-images.githubusercontent.com/1094411/58975781-02dcc880-8783-11e9-94b4-2509e1dca6b8.png">

