### PR TITLE
[SDEV3-1575] API mocks default response for emits should be an empty array

### DIFF
--- a/packages/spruce-skill-server/tests/v1APIMocks.js
+++ b/packages/spruce-skill-server/tests/v1APIMocks.js
@@ -40,7 +40,7 @@ module.exports = ctx => ({
 		return Promise.resolve({})
 	},
 	async post(path, data, query, method) {
-		const response = {
+		let response = {
 			// Pass back the request options so it can be validated in tests
 			requestOptions: {
 				path,
@@ -54,11 +54,15 @@ module.exports = ctx => ({
 		// `organizations/${organizationId}/emit`
 		const isEmit = /\/emit$/.test(path)
 		if (isEmit) {
+			// If it's an emit, the default response is an empty array. The request options can be checked via callback
+			response = []
 			if (global.testEmitResponse && global.testEmitResponse[data.eventName]) {
 				if (global.testEmitResponse[data.eventName].callback) {
 					await global.testEmitResponse[data.eventName].callback({
+						path,
 						data,
-						query
+						query,
+						method
 					})
 				}
 


### PR DESCRIPTION
## What does this PR do?

* Fixes issue where an object instead of an empty array is returned by default (when `global.testEmitResponse` is not set) in tests

* Adds additional parameters `path` and `method` to emit callback in case we ever need to do additional checking of the underlying call that is made

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1575](https://sprucelabsai.atlassian.net/browse/SDEV3-1575)