### PR TITLE
[SDEV3-604] Allow data to be passed on modal close

### DIFF
--- a/packages/spruce-next-helpers/src/skillskit/index.js
+++ b/packages/spruce-next-helpers/src/skillskit/index.js
@@ -146,10 +146,11 @@ const skill = {
 					data
 				})
 			},
-			close: () => {
+			close: (data: Object) => {
 				Iframes.sendMessage({
 					to: window.parent,
-					eventName: 'SkillViewDialog:Close'
+					eventName: 'SkillViewDialog:Close',
+					data
 				})
 			},
 			onGoBack: (callback: Function) => {

--- a/packages/spruce-skill/interface/pages/skill-views/dashboard_location/index.js
+++ b/packages/spruce-skill/interface/pages/skill-views/dashboard_location/index.js
@@ -104,6 +104,9 @@ class DashboardLocationPage extends React.Component {
 				footerPrimaryActionText: 'Submit',
 				footerSecondaryActionText: 'Cancel'
 			})
+			this.modal.onClosed(data => {
+				console.log('MODAL CLOSED', data)
+			})
 		}
 	}
 

--- a/packages/spruce-skill/interface/pages/skill-views/example_skill_view_dialog.js
+++ b/packages/spruce-skill/interface/pages/skill-views/example_skill_view_dialog.js
@@ -52,7 +52,9 @@ class TestSkillView extends React.Component<Props, State> {
 			this.handleClickModalFooterPrimaryAction
 		)
 
-		this.modal.onClickFooterSecondaryAction(() => this.modal.close())
+		this.modal.onClickFooterSecondaryAction(() =>
+			this.modal.close({ something: 'here is some data!' })
+		)
 
 		if (this.props.query.isPaged) {
 			this.modal.onGoBack(this.handleModalGoBack)


### PR DESCRIPTION
## What does this PR do?

* Implements the ability to pass data back to parent iframe via modal `close` method. This is useful for things like parent iframe redirects or updating data after the modal is closed.

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-604](https://sprucelabsai.atlassian.net/browse/SDEV3-604)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

Need to merge https://github.com/sprucelabsai/ai-spruce-web/pull/224

## Screenshots (if appropriate)

## What gif best describes this PR or how it makes you feel?

![closed](https://media.giphy.com/media/l3q2Kgm3KOBUE6wF2/giphy.gif)