### PR TITLE
[SDEV3-1627] Record selector should have variable height

### DIFF
--- a/packages/heartwood-components/components/08-lists/lists.scss
+++ b/packages/heartwood-components/components/08-lists/lists.scss
@@ -238,7 +238,6 @@
 	}
 
 	.record-selection__list-wrapper {
-		// position: relative;
 		flex: 1;
 	}
 

--- a/packages/heartwood-components/components/08-lists/lists.scss
+++ b/packages/heartwood-components/components/08-lists/lists.scss
@@ -219,6 +219,16 @@
 }
 
 .record-selection__list {
+	display: flex;
+	flex-flow: column;
+	height: 100%;
+	overflow: hidden;
+
+	&:not(.record-selection__list--is-short) {
+		// Min Height is only needed for long lists
+		min-height: 28rem;
+	}
+
 	.text-container {
 		align-items: flex-start;
 		display: flex;
@@ -228,8 +238,8 @@
 	}
 
 	.record-selection__list-wrapper {
-		position: relative;
-		min-height: 28rem;
+		// position: relative;
+		flex: 1;
 	}
 
 	.record-selection__record-wrapper {

--- a/packages/react-heartwood-components/.storybook/Wrapper.js
+++ b/packages/react-heartwood-components/.storybook/Wrapper.js
@@ -70,9 +70,7 @@ const Wrapper = props => {
 				{meta}
 			</Helmet>
 			<FontLoader fonts={fonts} />
-			<Page>
-				<PageContent>{props.children}</PageContent>
-			</Page>
+			<Page>{props.children}</Page>
 		</div>
 	)
 }

--- a/packages/react-heartwood-components/.storybook/Wrapper.js
+++ b/packages/react-heartwood-components/.storybook/Wrapper.js
@@ -70,7 +70,9 @@ const Wrapper = props => {
 				{meta}
 			</Helmet>
 			<FontLoader fonts={fonts} />
-			<Page>{props.children}</Page>
+			<Page>
+				<PageContent>{props.children}</PageContent>
+			</Page>
 		</div>
 	)
 }

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectList-story.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectList-story.js
@@ -18,7 +18,8 @@ stories.addDecorator(withKnobs)
 type Props = {
 	canSelect?: 'many' | 'one',
 	canRemove: boolean,
-	locations: Array<Object>
+	locations: Array<Object>,
+	totalRecordCount: number
 }
 
 type State = {
@@ -50,7 +51,7 @@ class BasicExample extends Component<Props, State> {
 	}
 
 	render() {
-		const { canSelect, canRemove } = this.props
+		const { canSelect, canRemove, totalRecordCount } = this.props
 		const { selectedIds, locations, unselectableIds } = this.state
 
 		return (
@@ -125,20 +126,33 @@ class BasicExample extends Component<Props, State> {
 						locations: locations.filter(location => location.id !== id)
 					})
 				}}
+				totalRecordCount={totalRecordCount}
 			/>
 		)
 	}
 }
 
-stories.add('Default', () => (
-	<BasicExample
-		canSelect={select('Can Select', [null, 'many', 'one'], null)}
-		canRemove={select('Can Remove', [true, false], false)}
-		locations={map(generateLocations({ amount: 100 }), o => ({
-			node: { ...o }
-		}))}
-	/>
-))
+stories
+	.add('Default', () => (
+		<BasicExample
+			canSelect={select('Can Select', [null, 'many', 'one'], null)}
+			canRemove={select('Can Remove', [true, false], false)}
+			locations={map(generateLocations({ amount: 100 }), o => ({
+				node: { ...o }
+			}))}
+			totalRecordCount={100}
+		/>
+	))
+	.add('Few Entries', () => (
+		<BasicExample
+			canSelect={select('Can Select', [null, 'many', 'one'], null)}
+			canRemove={select('Can Remove', [true, false], false)}
+			locations={map(generateLocations({ amount: 2 }), o => ({
+				node: { ...o }
+			}))}
+			totalRecordCount={2}
+		/>
+	))
 
 // class WithModalExample extends Component<Props, State> {
 // 	state = {

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
@@ -160,16 +160,6 @@ export default class RecordSelectionList extends Component<
 		parent: any,
 		style: Object
 	}) => {
-		const {
-			selectedIds,
-			unselectableIds,
-			renderRecord,
-			getRecordId,
-			canSelect,
-			canRemove,
-			onSelect,
-			onRemove
-		} = this.props
 		const { loadedRecords } = this.state
 
 		const record = loadedRecords[index]
@@ -328,11 +318,7 @@ export default class RecordSelectionList extends Component<
 			totalRecordCount,
 			canSearch,
 			searchPlaceholder,
-			showSelectedCount,
-			onSelect,
-			unselectableIds,
-			getRecordId,
-			renderRecord
+			showSelectedCount
 		} = this.props
 		const { loadedRecords, search } = this.state
 		const totalSelected = selectedIds.length

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
@@ -173,7 +173,6 @@ export default class RecordSelectionList extends Component<
 		const { loadedRecords } = this.state
 
 		const record = loadedRecords[index]
-		const SelectionComponent = canSelect === 'one' ? Radio : Checkbox
 
 		return (
 			record && (
@@ -184,50 +183,81 @@ export default class RecordSelectionList extends Component<
 					parent={parent}
 					rowIndex={index}
 				>
-					<div
-						className="record-selection__record-wrapper"
-						style={{ ...style }}
-					>
-						{onSelect && canSelect && (
-							<SelectionComponent
-								className="record-selection__record-select"
-								onChange={() => {
-									onSelect(getRecordId(record), record)
-								}}
-								disabled={
-									unselectableIds &&
-									unselectableIds.indexOf(getRecordId(record)) >= 0
-								}
-								checked={
-									selectedIds && selectedIds.indexOf(getRecordId(record)) >= 0
-								}
-							/>
-						)}
-
-						<div className="record-selection__record-content" key={key}>
-							{renderRecord(record)}
-						</div>
-
-						{onRemove && canRemove && (
-							<Button
-								kind="simple"
-								disabled={false}
-								isSmall
-								icon={{ name: 'remove_circle', className: 'btn__line-icon' }}
-								onClick={() => {
-									this.setState({
-										loadedRecords: loadedRecords.filter(
-											loadedRecord =>
-												getRecordId(loadedRecord) !== getRecordId(record)
-										)
-									})
-
-									onRemove(getRecordId(record), record)
-								}}
-							/>
-						)}
-					</div>
+					{this.renderInnerRow({ index, key, style })}
 				</CellMeasurer>
+			)
+		)
+	}
+
+	renderInnerRow = ({
+		index,
+		key,
+		style
+	}: {
+		index: number,
+		key: string,
+		style: Object
+	}) => {
+		const {
+			selectedIds,
+			unselectableIds,
+			renderRecord,
+			getRecordId,
+			canSelect,
+			canRemove,
+			onSelect,
+			onRemove
+		} = this.props
+		const { loadedRecords } = this.state
+		const record = loadedRecords[index]
+		const SelectionComponent = canSelect === 'one' ? Radio : Checkbox
+
+		return (
+			record && (
+				<div
+					className="record-selection__record-wrapper"
+					key={key}
+					style={{ ...style }}
+				>
+					{onSelect && canSelect && (
+						<SelectionComponent
+							className="record-selection__record-select"
+							onChange={() => {
+								onSelect(getRecordId(record), record)
+							}}
+							disabled={
+								unselectableIds &&
+								unselectableIds.indexOf(getRecordId(record)) >= 0
+							}
+							checked={
+								selectedIds && selectedIds.indexOf(getRecordId(record)) >= 0
+							}
+						/>
+					)}
+
+					<div className="record-selection__record-content" key={key}>
+						{renderRecord(record)}
+					</div>
+
+					{onRemove && canRemove && (
+						<Button
+							kind="simple"
+							disabled={false}
+							isSmall
+							icon={{ name: 'remove_circle', className: 'btn__line-icon' }}
+							onClick={() => {
+								this.setState({
+									loadedRecords: loadedRecords.filter(
+										loadedRecord =>
+											getRecordId(loadedRecord) !== getRecordId(record)
+									)
+								})
+
+								onRemove(getRecordId(record), record)
+							}}
+						/>
+					)}
+				</div>
 			)
 		)
 	}
@@ -349,34 +379,7 @@ export default class RecordSelectionList extends Component<
 					loadedRecords.map((rec, idx) => {
 						const { node } = rec
 						const { id } = node
-						const record = loadedRecords[idx]
-
-						const SelectionComponent =
-							node.canSelect === 'one' ? Radio : Checkbox
-						return (
-							<div className="record-selection__record-wrapper" key={id}>
-								{node.onSelect && node.canSelect && (
-									<SelectionComponent
-										className="record-selection__record-select"
-										onChange={() => {
-											onSelect(getRecordId(record), record)
-										}}
-										disabled={
-											unselectableIds &&
-											unselectableIds.indexOf(getRecordId(record)) >= 0
-										}
-										checked={
-											selectedIds &&
-											selectedIds.indexOf(getRecordId(record)) >= 0
-										}
-									/>
-								)}
-
-								<div className="record-selection__record-content">
-									{renderRecord(rec)}
-								</div>
-							</div>
-						)
+						return this.renderInnerRow({ index: idx, key: id, style: {} })
 					})
 				) : (
 					<div className="record-selection__list-wrapper">

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
@@ -358,7 +358,9 @@ export default class RecordSelectionList extends Component<
 								{node.onSelect && node.canSelect && (
 									<SelectionComponent
 										className="record-selection__record-select"
-										onChange={() => console.log('onChange')}
+										onChange={() => {
+											onSelect(getRecordId(record), record)
+										}}
 										disabled={
 											unselectableIds &&
 											unselectableIds.indexOf(getRecordId(record)) >= 0


### PR DESCRIPTION
## What does this PR do?

This addresses the issue of RecordSelectionLists and, by extension, RecordSelectors not having variable heights and never shrinking when they contain few items. This approach is a POC that you can see in Storybook, but isn't production ready, so please don't merge.

The idea here is to only use `react-virtualized` when the request returns a `totalRecordCount` large enough to require a virtualized list. Otherwise, a simple list is returned since all of the records can be fetched and displayed with a single request. This sidesteps the complications of shrinking `react-virtualized`'s `AutoSizer` component, which is designed only to grow, but not to shrink.

To make the determination, the component checks if `totalRecordCount` is greater than the length of `loadedRecords` after the first request. This may be an oversimplification as we might want to check for a specific number of records based on the context in which the component is used. In any case, this seemed like the most reliable and safest assumption to make.

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1627](https://sprucelabsai.atlassian.net/browse/SDEV3-1627)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)
Nope

## Screenshots (if appropriate)

## What gif best describes this PR or how it makes you feel?
![giphy](https://user-images.githubusercontent.com/13734175/59229092-b89a8380-8b96-11e9-82be-ef1482cd991b.gif)
