### PR TITLE
[SDEV3-1628] followupText not visible on neutral toast

### DIFF
--- a/packages/heartwood-components/components/05-feedback/toast.scss
+++ b/packages/heartwood-components/components/05-feedback/toast.scss
@@ -20,6 +20,8 @@
 
 	.btn {
 		@include type-style-body-sm-em;
+		position: relative;
+		left: rem(-4);
 		width: auto;
 		padding-left: 0;
 		height: rem(32);
@@ -39,7 +41,6 @@
 	@include type-style-body-sm-em;
 	display: flex;
 	justify-content: space-between;
-	padding-bottom: spacing('extra-tight');
 
 	.btn {
 		@include type-style-body-sm-em;

--- a/packages/heartwood-components/components/05-feedback/toast.scss
+++ b/packages/heartwood-components/components/05-feedback/toast.scss
@@ -23,6 +23,7 @@
 		width: auto;
 		padding-left: 0;
 		height: rem(32);
+		color: inherit;
 
 		.btn__inner {
 			align-items: flex-end;


### PR DESCRIPTION
## What does this PR do?
Makes the followup text (e.g. "Undo") visible in toasts.

## Type

- [ ] Feature
- [x ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1628](https://sprucelabsai.atlassian.net/browse/SDEV3-1628)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)
Nope 

## Screenshots (if appropriate)
<img width="309" alt="Screen Shot 2019-06-10 at 4 03 20 PM" src="https://user-images.githubusercontent.com/13734175/59229992-4c6d4f00-8b99-11e9-89fe-3addc5612d95.png">


## What gif best describes this PR or how it makes you feel?
![giphy (1)](https://user-images.githubusercontent.com/13734175/59230024-627b0f80-8b99-11e9-9b9f-3e11403a3caa.gif)
