### PR TITLE
[SDEV3-1590] Heartwood List Item: Entire Row Should be Clickable

### DIFF
--- a/packages/heartwood-components/components/08-lists/lists.scss
+++ b/packages/heartwood-components/components/08-lists/lists.scss
@@ -180,6 +180,17 @@
 	}
 }
 
+.list-item .checkbox-item {
+	position: relative;
+	.checkbox-item__label {
+		margin: 0;
+	}
+
+	.list-small & {
+		top: -2px;
+	}
+}
+
 .drag-handle {
 	width: rem(20);
 	height: rem(20);

--- a/packages/react-heartwood-components/src/components/List/List-story.js
+++ b/packages/react-heartwood-components/src/components/List/List-story.js
@@ -281,3 +281,21 @@ stories
 		/>
 	))
 	.add('People Tabbed', () => <TabbedList />)
+	.add('Selectable Items', () => (
+		<List
+			items={object('selectable items', [
+				{
+					title: 'Clean Up',
+					subtitle: '$20 | 15min'
+				},
+				{
+					title: 'Shampoo',
+					subtitle: '$7 | 45min'
+				},
+				{
+					title: 'Young Spruce',
+					subtitle: '$23 | 50min'
+				}
+			])}
+		/>
+	))

--- a/packages/react-heartwood-components/src/components/List/List-story.js
+++ b/packages/react-heartwood-components/src/components/List/List-story.js
@@ -286,15 +286,18 @@ stories
 			items={object('selectable items', [
 				{
 					title: 'Clean Up',
-					subtitle: '$20 | 15min'
+					subtitle: '$20 | 15min',
+					checkboxId: 'cleanUp'
 				},
 				{
 					title: 'Shampoo',
-					subtitle: '$7 | 45min'
+					subtitle: '$7 | 45min',
+					checkboxId: 'shampoo'
 				},
 				{
 					title: 'Young Spruce',
-					subtitle: '$23 | 50min'
+					subtitle: '$23 | 50min',
+					checkboxId: 'youngSpruce'
 				}
 			])}
 		/>

--- a/packages/react-heartwood-components/src/components/List/List-story.js
+++ b/packages/react-heartwood-components/src/components/List/List-story.js
@@ -293,24 +293,24 @@ stories
 				{
 					title: 'Clean Up',
 					subtitle: '$20 | 15min',
-					checkboxId: 'cleanUp',
-					checkboxProps: {
+					selectableId: 'cleanUp',
+					selectableProps: {
 						name: 'radio'
 					}
 				},
 				{
 					title: 'Shampoo',
 					subtitle: '$7 | 45min',
-					checkboxId: 'shampoo',
-					checkboxProps: {
+					selectableId: 'shampoo',
+					selectableProps: {
 						name: 'radio'
 					}
 				},
 				{
 					title: 'Young Spruce',
 					subtitle: '$23 | 50min',
-					checkboxId: 'youngSpruce',
-					checkboxProps: {
+					selectableId: 'youngSpruce',
+					selectableProps: {
 						name: 'radio'
 					}
 				}

--- a/packages/react-heartwood-components/src/components/List/List-story.js
+++ b/packages/react-heartwood-components/src/components/List/List-story.js
@@ -6,7 +6,8 @@ import {
 	withKnobsOptions,
 	text,
 	boolean,
-	object
+	object,
+	select
 } from '@storybook/addon-knobs/react'
 import {
 	userList,
@@ -283,22 +284,37 @@ stories
 	.add('People Tabbed', () => <TabbedList />)
 	.add('Selectable Items', () => (
 		<List
+			selectableType={select(
+				'selectableType',
+				['checkbox', 'radio'],
+				'checkbox'
+			)}
 			items={object('selectable items', [
 				{
 					title: 'Clean Up',
 					subtitle: '$20 | 15min',
-					checkboxId: 'cleanUp'
+					checkboxId: 'cleanUp',
+					checkboxProps: {
+						name: 'radio'
+					}
 				},
 				{
 					title: 'Shampoo',
 					subtitle: '$7 | 45min',
-					checkboxId: 'shampoo'
+					checkboxId: 'shampoo',
+					checkboxProps: {
+						name: 'radio'
+					}
 				},
 				{
 					title: 'Young Spruce',
 					subtitle: '$23 | 50min',
-					checkboxId: 'youngSpruce'
+					checkboxId: 'youngSpruce',
+					checkboxProps: {
+						name: 'radio'
+					}
 				}
 			])}
+			isSmall={boolean('isSmall', false)}
 		/>
 	))

--- a/packages/react-heartwood-components/src/components/List/List.js
+++ b/packages/react-heartwood-components/src/components/List/List.js
@@ -28,7 +28,10 @@ export type Props = {
 	children?: any,
 
 	/** Set to true to show separators between list items */
-	areSeparatorsVisible: boolean
+	areSeparatorsVisible: boolean,
+
+	/** Optional: set whether to use checkbox or radio for selectable list items */
+	selectableType?: 'checkbox' | 'radio'
 }
 
 const List = (props: Props) => {
@@ -38,7 +41,8 @@ const List = (props: Props) => {
 		className,
 		isSmall,
 		areSeparatorsVisible,
-		children
+		children,
+		selectableType
 	} = props
 	const parentClass = cx('list', className, {
 		'list-small': isSmall,
@@ -49,7 +53,10 @@ const List = (props: Props) => {
 		<Fragment>
 			{header && <ListHeader isSmall={isSmall} {...header} />}
 			<ul className={parentClass}>
-				{items && items.map((item, idx) => <ListItem key={idx} {...item} />)}
+				{items &&
+					items.map((item, idx) => (
+						<ListItem key={idx} selectableType={selectableType} {...item} />
+					))}
 				{children && children}
 			</ul>
 		</Fragment>

--- a/packages/react-heartwood-components/src/components/List/components/ListItem/ListItem.js
+++ b/packages/react-heartwood-components/src/components/List/components/ListItem/ListItem.js
@@ -7,7 +7,7 @@ import Icon from '../../../Icon/Icon'
 import type { Props as ButtonProps } from '../../../Button/Button'
 import ContextMenu from '../../../ContextMenu/ContextMenu'
 import type { Props as ContextMenuProps } from '../../../ContextMenu/ContextMenu'
-import { Toggle } from '../../../Forms'
+import { Toggle, Checkbox, Radio } from '../../../Forms'
 import DragHandle from '../../../../../static/assets/icons/ic_drag_handle.svg'
 
 export type Props = {
@@ -101,7 +101,7 @@ const ListItem = (props: Props) => {
 
 	const ListItemInner = () => (
 		<Fragment>
-			{(image || icon || avatar) && !isDraggable && (
+			{(image || icon || avatar || checkboxId) && !isDraggable && (
 				<div className="list-item__image-wrapper">
 					{icon && (
 						<Icon
@@ -121,13 +121,26 @@ const ListItem = (props: Props) => {
 						/>
 					)}
 					{avatar && <Avatar image={avatar} alt={title} />}
+					{checkboxId && (
+						<Fragment>
+							{selectableType === 'checkbox' && (
+								<Checkbox id={checkboxId} {...checkboxProps} />
+							)}
+							{selectableType === 'radio' && (
+								<Radio id={checkboxId} {...checkboxProps} />
+							)}
+						</Fragment>
+					)}
 				</div>
 			)}
 			{isDraggable && <DragHandle className="drag-handle" />}
 			<div className="list-item__text-wrapper">
 				{toggleId || checkboxId ? (
 					<p>
-						<label className="list-item__title" htmlFor={toggleId}>
+						<label
+							className="list-item__title"
+							htmlFor={toggleId || checkboxId}
+						>
 							{title}
 						</label>
 					</p>
@@ -138,7 +151,10 @@ const ListItem = (props: Props) => {
 					<Fragment>
 						{toggleId || checkboxId ? (
 							<p>
-								<label className="list-item__subtitle" htmlFor={toggleId}>
+								<label
+									className="list-item__subtitle"
+									htmlFor={toggleId || checkboxId}
+								>
 									{subtitle}
 								</label>
 							</p>

--- a/packages/react-heartwood-components/src/components/List/components/ListItem/ListItem.js
+++ b/packages/react-heartwood-components/src/components/List/components/ListItem/ListItem.js
@@ -57,7 +57,16 @@ export type Props = {
 	isSeparatorVisible: boolean,
 
 	/** Optional class name for list item */
-	className?: string
+	className?: string,
+
+	/** Optional id prop for selectable list items */
+	checkboxId?: string,
+
+	/** Optional props for selectable list items */
+	checkboxProps?: Object,
+
+	/** Optional: set whether to use checkbox or radio for selectable list items */
+	selectableType?: 'checkbox' | 'radio'
 }
 
 const ListItem = (props: Props) => {
@@ -76,7 +85,10 @@ const ListItem = (props: Props) => {
 		contextMenu,
 		toggleProps,
 		isSeparatorVisible,
-		className
+		className,
+		checkboxId,
+		checkboxProps,
+		selectableType
 	} = props
 
 	const parentClass = cx('list-item', className, {
@@ -113,18 +125,30 @@ const ListItem = (props: Props) => {
 			)}
 			{isDraggable && <DragHandle className="drag-handle" />}
 			<div className="list-item__text-wrapper">
-				{toggleId ? (
-					<label className="list-item__title" htmlFor={toggleId}>
-						{title}
-					</label>
+				{toggleId || checkboxId ? (
+					<p>
+						<label className="list-item__title" htmlFor={toggleId}>
+							{title}
+						</label>
+					</p>
 				) : (
 					<p className="list-item__title">{title}</p>
 				)}
 				{subtitle && (
-					<p
-						className="list-item__subtitle"
-						dangerouslySetInnerHTML={{ __html: subtitle }}
-					/>
+					<Fragment>
+						{toggleId || checkboxId ? (
+							<p>
+								<label className="list-item__subtitle" htmlFor={toggleId}>
+									{subtitle}
+								</label>
+							</p>
+						) : (
+							<p
+								className="list-item__subtitle"
+								dangerouslySetInnerHTML={{ __html: subtitle }}
+							/>
+						)}
+					</Fragment>
 				)}
 				{note && (
 					<p

--- a/packages/react-heartwood-components/src/components/List/components/ListItem/ListItem.js
+++ b/packages/react-heartwood-components/src/components/List/components/ListItem/ListItem.js
@@ -60,10 +60,10 @@ export type Props = {
 	className?: string,
 
 	/** Optional id prop for selectable list items */
-	checkboxId?: string,
+	selectableId?: string,
 
 	/** Optional props for selectable list items */
-	checkboxProps?: Object,
+	selectableProps?: Object,
 
 	/** Optional: set whether to use checkbox or radio for selectable list items */
 	selectableType?: 'checkbox' | 'radio'
@@ -86,8 +86,8 @@ const ListItem = (props: Props) => {
 		toggleProps,
 		isSeparatorVisible,
 		className,
-		checkboxId,
-		checkboxProps,
+		selectableId,
+		selectableProps,
 		selectableType
 	} = props
 
@@ -101,7 +101,7 @@ const ListItem = (props: Props) => {
 
 	const ListItemInner = () => (
 		<Fragment>
-			{(image || icon || avatar || checkboxId) && !isDraggable && (
+			{(image || icon || avatar || selectableId) && !isDraggable && (
 				<div className="list-item__image-wrapper">
 					{icon && (
 						<Icon
@@ -121,13 +121,13 @@ const ListItem = (props: Props) => {
 						/>
 					)}
 					{avatar && <Avatar image={avatar} alt={title} />}
-					{checkboxId && (
+					{selectableId && (
 						<Fragment>
 							{selectableType === 'checkbox' && (
-								<Checkbox id={checkboxId} {...checkboxProps} />
+								<Checkbox id={selectableId} {...selectableProps} />
 							)}
 							{selectableType === 'radio' && (
-								<Radio id={checkboxId} {...checkboxProps} />
+								<Radio id={selectableId} {...selectableProps} />
 							)}
 						</Fragment>
 					)}
@@ -135,11 +135,11 @@ const ListItem = (props: Props) => {
 			)}
 			{isDraggable && <DragHandle className="drag-handle" />}
 			<div className="list-item__text-wrapper">
-				{toggleId || checkboxId ? (
+				{toggleId || selectableId ? (
 					<p>
 						<label
 							className="list-item__title"
-							htmlFor={toggleId || checkboxId}
+							htmlFor={toggleId || selectableId}
 						>
 							{title}
 						</label>
@@ -149,11 +149,11 @@ const ListItem = (props: Props) => {
 				)}
 				{subtitle && (
 					<Fragment>
-						{toggleId || checkboxId ? (
+						{toggleId || selectableId ? (
 							<p>
 								<label
 									className="list-item__subtitle"
-									htmlFor={toggleId || checkboxId}
+									htmlFor={toggleId || selectableId}
 								>
 									{subtitle}
 								</label>


### PR DESCRIPTION
## What does this PR do?
Gives `ListItem` components the ability to be selectable either as checkboxes or radios. This also renders the list item text as `<label>`s so that clicking them toggles the checkbox or selects the radio option.

Adds the following props to `List` and `ListItem` respectively:
- `selectableType`: either 'checkbox' or 'radio'

- `checkboxId`
- `checkboxProps`

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1590](https://sprucelabsai.atlassian.net/browse/SDEV3-1590)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)
No

## Screenshots (if appropriate)
<img width="276" alt="Screen Shot 2019-06-10 at 5 12 08 PM" src="https://user-images.githubusercontent.com/13734175/59232753-f7363b00-8ba2-11e9-90e4-5d6d679694a3.png">


## What gif best describes this PR or how it makes you feel?