### PR TITLE
[SDEV3-1631] React Heartwood: Date Range Picker start date should have a "tail"

### DIFF
--- a/packages/heartwood-components/components/02-forms/datepicker.scss
+++ b/packages/heartwood-components/components/02-forms/datepicker.scss
@@ -71,37 +71,38 @@
 	background: transparent;
 	color: $c-white;
 	border: none;
+
 	&.CalendarDay__today:before {
 		background-color: $c-white;
 	}
-}
 
-.CalendarDay__selected_start {
-	&:before {
-		background-color: rgba($c-primary, 0.5);
-		content: '';
-		display: block;
-		position: absolute;
-		height: 2rem;
-		width: 50%;
-		right: 0;
-		top: 50%;
-		transform: translateY(-50%);
-		z-index: -1;
+	&.CalendarDay__selected_start {
+		&:before {
+			background-color: rgba($c-primary, 0.5);
+			content: '';
+			display: block;
+			position: absolute;
+			height: 2rem;
+			width: 50%;
+			right: 0;
+			top: 50%;
+			transform: translateY(-50%);
+			z-index: -1;
+		}
 	}
-}
-.CalendarDay__selected_end {
-	&:before {
-		background-color: rgba($c-primary, 0.5);
-		content: '';
-		display: block;
-		position: absolute;
-		height: 2rem;
-		width: 50%;
-		left: 0;
-		top: 50%;
-		transform: translateY(-50%);
-		z-index: -1;
+	&.CalendarDay__selected_end {
+		&:before {
+			background-color: rgba($c-primary, 0.5);
+			content: '';
+			display: block;
+			position: absolute;
+			height: 2rem;
+			width: 50%;
+			left: 0;
+			top: 50%;
+			transform: translateY(-50%);
+			z-index: -1;
+		}
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Style fixes to `DatePicker` that keep a "tail" on today's cell when it's selected as the start of a range.

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1631](https://sprucelabsai.atlassian.net/browse/SDEV3-1631)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)
No

## Screenshots (if appropriate)
<img width="317" alt="Screen Shot 2019-06-13 at 8 35 05 AM" src="https://user-images.githubusercontent.com/13734175/59441665-2d97d400-8db6-11e9-800c-fa9a7558b4bd.png">


## What gif best describes this PR or how it makes you feel?