### PR TITLE
[SDEV3-1449] Fix event handler not getting called properly

### DIFF
--- a/packages/spruce-skill-server/middleware/auth.js
+++ b/packages/spruce-skill-server/middleware/auth.js
@@ -149,6 +149,7 @@ module.exports = (router, options) => {
 					}
 
 					await listenersByEventName[eventName](ctx, next)
+					return
 				} catch (err) {
 					debug('(EVENT_VERSION=2) MIDDLEWARE/AUTH INVALID EVENT TOKEN', err)
 					if (config.LOG_EVENTS) {

--- a/packages/spruce-skill-server/middleware/auth.js
+++ b/packages/spruce-skill-server/middleware/auth.js
@@ -147,6 +147,8 @@ module.exports = (router, options) => {
 							event: ctx.event
 						})
 					}
+
+					await listenersByEventName[eventName](ctx, next)
 				} catch (err) {
 					debug('(EVENT_VERSION=2) MIDDLEWARE/AUTH INVALID EVENT TOKEN', err)
 					if (config.LOG_EVENTS) {


### PR DESCRIPTION
## What does this PR do?

* Fixes issue where the event handler for v2 events wasn't actually getting called

  * This is due to the previous PR's (https://github.com/sprucelabsai/workspace.sprucebot-skills-kit/pull/503) optimization to break apart v1 and v2 handlers

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1449](https://sprucelabsai.atlassian.net/browse/SDEV3-1449)

## What gif best describes this PR or how it makes you feel?

![panda-facepalm](https://user-images.githubusercontent.com/1094411/59383822-f544b700-8d1d-11e9-8d70-774c18a918c3.gif)
