### PR TITLE
[SDEV3-1716] Prerelease/record selection list

### DIFF
--- a/packages/heartwood-components/components/08-lists/lists.scss
+++ b/packages/heartwood-components/components/08-lists/lists.scss
@@ -250,7 +250,6 @@
 
 	.record-selection__record-wrapper {
 		display: flex;
-		align-items: center;
 		+ .record-selection__record-wrapper {
 			border-top: 1px solid $c-border;
 		}

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectList-story.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectList-story.js
@@ -93,18 +93,12 @@ class BasicExample extends Component<Props, State> {
 					return results
 				}}
 				getRecordId={record => record.node.id}
-				renderRecord={record => (
-					<RecordSelectionListItem
-						id={record.node.id}
-						title={record.node.publicName}
-						subtitle={record.node.address}
-						isDisabled={unselectableIds.indexOf(record.node.id) >= 0}
-						note={
-							unselectableIds.indexOf(record.node.id) >= 0 &&
-							'Location already in group!'
-						}
-					/>
-				)}
+				recordKeys={{
+					id: 'id',
+					title: 'publicName',
+					subtitle: 'address',
+					note: 'Location already in group!'
+				}}
 				canSelect={canSelect}
 				canRemove={canRemove}
 				onSelect={id => {
@@ -169,7 +163,7 @@ stories
 			<Modal.Header title="Modal title" onRequestClose={() => null} />
 			<Modal.Body>
 				<BasicExample
-					canSelect={select('Can Select', [null, 'many', 'one'], null)}
+					canSelect={select('Can Select', [null, 'many', 'one'], 'many')}
 					canRemove={boolean('Can Remove', true)}
 					locations={map(generateLocations({ amount: 100 }), o => ({
 						node: { ...o }

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
@@ -14,6 +14,7 @@ import { TextInput, Checkbox, Radio } from '../Forms'
 import Button from '../Button/Button'
 import TextContainer from '../TextContainer/TextContainer'
 import Text from '../Text/Text'
+import ListItem from '../List/components/ListItem/ListItem'
 
 import type { Node } from 'react'
 
@@ -21,8 +22,11 @@ type Record = any
 type RecordId = string
 
 type RecordSelectionListProps = {|
-	/** Required method to render a record into a node */
+	/** DEPRECATED Required method to render a record into a node */
 	renderRecord: any => Node,
+
+	/** Required to describe how data passed maps to the component */
+	recordKeys: Object,
 
 	/** Get a unique ID for a record; given that data may be shaped in an unpredictable manner,
 	 * you must implement this at each usage.
@@ -245,69 +249,78 @@ export default class RecordSelectionList extends Component<
 		const {
 			selectedIds,
 			unselectableIds,
-			renderRecord,
 			getRecordId,
 			canSelect,
 			canRemove,
 			onSelect,
-			onRemove
+			onRemove,
+			recordKeys
 		} = this.props
 		const { loadedRecords } = this.state
 		const record = loadedRecords[index]
-		const SelectionComponent = canSelect === 'one' ? Radio : Checkbox
 
 		return (
 			record && (
-				<div
+				<ListItem
 					className="record-selection__record-wrapper"
 					key={key}
 					style={{ ...style }}
-				>
-					{onSelect && canSelect && (
-						<SelectionComponent
-							className="record-selection__record-select"
-							onChange={() => {
-								onSelect(getRecordId(record), record)
-							}}
-							disabled={
-								unselectableIds &&
-								unselectableIds.indexOf(getRecordId(record)) >= 0
-							}
-							checked={
-								selectedIds && selectedIds.indexOf(getRecordId(record)) >= 0
-							}
-						/>
-					)}
-
-					<div className="record-selection__record-content" key={key}>
-						{renderRecord(record)}
-					</div>
-
-					{onRemove && canRemove && (
-						<Button
-							kind="simple"
-							className="record-selection__record-remove-btn"
-							disabled={false}
-							isSmall
-							icon={{ name: 'cancel_solid', className: 'btn__line-icon' }}
-							onClick={() => {
-								this.setState(
+					id={record.node[recordKeys.id]}
+					title={record.node[recordKeys.title]}
+					subtitle={record.node[recordKeys.subtitle]}
+					note={
+						unselectableIds && unselectableIds.indexOf(getRecordId(record)) >= 0
+							? record.node[recordKeys.note]
+							: ''
+					}
+					isDisabled={
+						unselectableIds && unselectableIds.indexOf(getRecordId(record)) >= 0
+					}
+					selectableId={onSelect && canSelect && record.node[recordKeys.id]}
+					selectableProps={{
+						onChange: onSelect
+							? () => {
+									onSelect(getRecordId(record), record)
+							  }
+							: () => null,
+						checked:
+							selectedIds && selectedIds.indexOf(getRecordId(record)) >= 0
+					}}
+					selectableType={canSelect === 'one' ? 'radio' : 'checkbox'}
+					actions={
+						onRemove && canRemove
+							? [
 									{
-										loadedRecords: loadedRecords.filter(
-											loadedRecord =>
-												getRecordId(loadedRecord) !== getRecordId(record)
-										)
-									},
-									() => {
-										this.setState({ listHeight: this.getVisibleRecordHeight() })
-									}
-								)
+										kind: 'simple',
+										className: 'record-selection__record-remove-btn',
+										disabled: false,
+										isSmall: true,
+										icon: {
+											name: 'cancel_solid',
+											className: 'btn__line-icon'
+										},
+										onClick: () => {
+											this.setState(
+												{
+													loadedRecords: loadedRecords.filter(
+														loadedRecord =>
+															getRecordId(loadedRecord) !== getRecordId(record)
+													)
+												},
+												() => {
+													this.setState({
+														listHeight: this.getVisibleRecordHeight()
+													})
+												}
+											)
 
-								onRemove(getRecordId(record), record)
-							}}
-						/>
-					)}
-				</div>
+											onRemove(getRecordId(record), record)
+										}
+									}
+							  ]
+							: []
+					}
+				/>
 			)
 		)
 	}

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.js
@@ -10,8 +10,7 @@ import {
 } from 'react-virtualized'
 import cx from 'classnames'
 
-import { TextInput, Checkbox, Radio } from '../Forms'
-import Button from '../Button/Button'
+import { TextInput } from '../Forms'
 import TextContainer from '../TextContainer/TextContainer'
 import Text from '../Text/Text'
 import ListItem from '../List/components/ListItem/ListItem'


### PR DESCRIPTION
## What does this PR do?

Makes the `RecordSelectionList` use `ListItem`s consistently. Previously, it was using a hacky workaround because the `ListItem` didn't support select-ability. Now that it does, this ensures that the right component is in place.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?
None logged yet
- [SDEV3-1716](https://sprucelabsai.atlassian.net/browse/SDEV3-1716)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)
No, but it does deprecate the `renderRecord` prop and replaces it with `recordKeys` that tell `RecordSelectionList` how to map data into the `ListItem`s. This should ease dev effort as it will no longer be required to write out the render method for list items and instead you can just pass in the relevant keys.

This will also require a re-implementation effort eventually. I didn't remove the `renderRecord` prop, but without `recordKeys`, it won't render properly.
