### PR TITLE
[SDEV3-1717] Context Menu - avoid clipping

### DIFF
--- a/packages/heartwood-components/components/01-button/context-menu.scss
+++ b/packages/heartwood-components/components/01-button/context-menu.scss
@@ -24,9 +24,7 @@
 
 .context-menu__menu {
 	position: absolute;
-	// top: 100%;
-	// right: 0;
-	// z-index: 2;
+	z-index: 2;
 	width: rem(160);
 
 	&.context-menu__menu-large {
@@ -34,29 +32,16 @@
 	}
 
 	&.context-menu__menu-left {
-		// right: auto;
-		// left: 0;
 		transform: translate(-100%, 0);
 	}
 
 	&.context-menu__menu-top {
-		// top: auto;
-		// bottom: 100%;
 		transform: translate(0, calc(-100% - 8px));
 	}
 
 	&.context-menu__menu-left.context-menu__menu-top {
 		transform: translate(-100%, calc(-100% - 8px));
 	}
-
-	// .context-menu--is-hidden & {
-	// 	transform: translate(0, 4px);
-	// 	opacity: 0;
-	// 	visibility: hidden;
-	// 	transition: opacity 300ms ease, transform 300ms ease,
-	// 		visibility 0s linear 300ms;
-	// }
-
 	.button-group {
 		width: 100%;
 		max-height: rem(224);

--- a/packages/heartwood-components/components/01-button/context-menu.scss
+++ b/packages/heartwood-components/components/01-button/context-menu.scss
@@ -24,9 +24,9 @@
 
 .context-menu__menu {
 	position: absolute;
-	top: 100%;
-	right: 0;
-	z-index: 2;
+	// top: 100%;
+	// right: 0;
+	// z-index: 2;
 	width: rem(160);
 
 	&.context-menu__menu-large {
@@ -34,22 +34,28 @@
 	}
 
 	&.context-menu__menu-left {
-		right: auto;
-		left: 0;
+		// right: auto;
+		// left: 0;
+		transform: translate(-100%, 0);
 	}
 
 	&.context-menu__menu-top {
-		top: auto;
-		bottom: 100%;
+		// top: auto;
+		// bottom: 100%;
+		transform: translate(0, -100%);
 	}
 
-	.context-menu--is-hidden & {
-		transform: translate(0, 4px);
-		opacity: 0;
-		visibility: hidden;
-		transition: opacity 300ms ease, transform 300ms ease,
-			visibility 0s linear 300ms;
+	&.context-menu__menu-left.context-menu__menu-left {
+		transform: translate(-100%, -100%);
 	}
+
+	// .context-menu--is-hidden & {
+	// 	transform: translate(0, 4px);
+	// 	opacity: 0;
+	// 	visibility: hidden;
+	// 	transition: opacity 300ms ease, transform 300ms ease,
+	// 		visibility 0s linear 300ms;
+	// }
 
 	.button-group {
 		width: 100%;

--- a/packages/heartwood-components/components/01-button/context-menu.scss
+++ b/packages/heartwood-components/components/01-button/context-menu.scss
@@ -42,11 +42,11 @@
 	&.context-menu__menu-top {
 		// top: auto;
 		// bottom: 100%;
-		transform: translate(0, -100%);
+		transform: translate(0, calc(-100% - 8px));
 	}
 
-	&.context-menu__menu-left.context-menu__menu-left {
-		transform: translate(-100%, -100%);
+	&.context-menu__menu-left.context-menu__menu-top {
+		transform: translate(-100%, calc(-100% - 8px));
 	}
 
 	// .context-menu--is-hidden & {

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu-story.js
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu-story.js
@@ -8,92 +8,16 @@ const stories = storiesOf('Context Menu', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Example', () => (
-	<div
-		style={{
-			position: 'relative',
-			width: '100vw',
-			height: '200vh'
-		}}
-	>
-		<div
-			style={{
-				position: 'absolute',
-				top: 0,
-				left: 0
-			}}
-		>
-			<ContextMenu
-				actions={object('actions', [
-					{ text: 'Rebook' },
-					{ text: 'Cancel appointment' },
-					{ text: 'Ask for feedback' }
-				])}
-				isRightAligned={boolean('isRightAligned', false)}
-				isBottomAligned={boolean('isBottomAligned', false)}
-				size={text('size', 'large')}
-				isSimple={boolean('isSimple', false)}
-				isSmall={boolean('isSmall', false)}
-			/>
-		</div>
-		<div
-			style={{
-				position: 'absolute',
-				top: 0,
-				right: 0
-			}}
-		>
-			<ContextMenu
-				actions={object('actions', [
-					{ text: 'Rebook' },
-					{ text: 'Cancel appointment' },
-					{ text: 'Ask for feedback' }
-				])}
-				isRightAligned={boolean('isRightAligned', false)}
-				isBottomAligned={boolean('isBottomAligned', false)}
-				size={text('size', 'large')}
-				isSimple={boolean('isSimple', false)}
-				isSmall={boolean('isSmall', false)}
-			/>
-		</div>
-		<div
-			style={{
-				position: 'absolute',
-				bottom: 0,
-				left: 0
-			}}
-		>
-			<ContextMenu
-				actions={object('actions', [
-					{ text: 'Rebook' },
-					{ text: 'Cancel appointment' },
-					{ text: 'Ask for feedback' }
-				])}
-				isRightAligned={boolean('isRightAligned', false)}
-				isBottomAligned={boolean('isBottomAligned', false)}
-				size={text('size', 'large')}
-				isSimple={boolean('isSimple', false)}
-				isSmall={boolean('isSmall', false)}
-			/>
-		</div>
-		<div
-			style={{
-				position: 'absolute',
-				bottom: 0,
-				right: 0
-			}}
-		>
-			<ContextMenu
-				actions={object('actions', [
-					{ text: 'Rebook' },
-					{ text: 'Cancel appointment' },
-					{ text: 'Ask for feedback' }
-				])}
-				isRightAligned={boolean('isRightAligned', false)}
-				isBottomAligned={boolean('isBottomAligned', false)}
-				size={text('size', 'large')}
-				isSimple={boolean('isSimple', false)}
-				isSmall={boolean('isSmall', false)}
-			/>
-		</div>
-	</div>
+	<ContextMenu
+		actions={object('actions', [
+			{ text: 'Rebook' },
+			{ text: 'Cancel appointment' },
+			{ text: 'Ask for feedback' }
+		])}
+		isRightAligned={boolean('isRightAligned', false)}
+		isBottomAligned={boolean('isBottomAligned', false)}
+		size={text('size', 'large')}
+		isSimple={boolean('isSimple', false)}
+		isSmall={boolean('isSmall', false)}
+	/>
 ))

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu-story.js
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu-story.js
@@ -17,9 +17,10 @@ stories.add('Example', () => (
 			])}
 			isRightAligned={boolean('isRightAligned', false)}
 			isBottomAligned={boolean('isBottomAligned', false)}
-			size={text('size', '')}
+			size={text('size', 'large')}
 			isSimple={boolean('isSimple', false)}
+			isSmall={boolean('isSmall', false)}
 		/>
-		<p style={{ height: '200px' }}>Here is some more content</p>
+		<p style={{ height: '2000px' }}>Here is some more content</p>
 	</Fragment>
 ))

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu-story.js
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu-story.js
@@ -8,19 +8,92 @@ const stories = storiesOf('Context Menu', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Example', () => (
-	<Fragment>
-		<ContextMenu
-			actions={object('actions', [
-				{ text: 'Rebook' },
-				{ text: 'Cancel appointment' },
-				{ text: 'Ask for feedback' }
-			])}
-			isRightAligned={boolean('isRightAligned', false)}
-			isBottomAligned={boolean('isBottomAligned', false)}
-			size={text('size', 'large')}
-			isSimple={boolean('isSimple', false)}
-			isSmall={boolean('isSmall', false)}
-		/>
-		<p style={{ height: '2000px' }}>Here is some more content</p>
-	</Fragment>
+	<div
+		style={{
+			position: 'relative',
+			width: '100vw',
+			height: '200vh'
+		}}
+	>
+		<div
+			style={{
+				position: 'absolute',
+				top: 0,
+				left: 0
+			}}
+		>
+			<ContextMenu
+				actions={object('actions', [
+					{ text: 'Rebook' },
+					{ text: 'Cancel appointment' },
+					{ text: 'Ask for feedback' }
+				])}
+				isRightAligned={boolean('isRightAligned', false)}
+				isBottomAligned={boolean('isBottomAligned', false)}
+				size={text('size', 'large')}
+				isSimple={boolean('isSimple', false)}
+				isSmall={boolean('isSmall', false)}
+			/>
+		</div>
+		<div
+			style={{
+				position: 'absolute',
+				top: 0,
+				right: 0
+			}}
+		>
+			<ContextMenu
+				actions={object('actions', [
+					{ text: 'Rebook' },
+					{ text: 'Cancel appointment' },
+					{ text: 'Ask for feedback' }
+				])}
+				isRightAligned={boolean('isRightAligned', false)}
+				isBottomAligned={boolean('isBottomAligned', false)}
+				size={text('size', 'large')}
+				isSimple={boolean('isSimple', false)}
+				isSmall={boolean('isSmall', false)}
+			/>
+		</div>
+		<div
+			style={{
+				position: 'absolute',
+				bottom: 0,
+				left: 0
+			}}
+		>
+			<ContextMenu
+				actions={object('actions', [
+					{ text: 'Rebook' },
+					{ text: 'Cancel appointment' },
+					{ text: 'Ask for feedback' }
+				])}
+				isRightAligned={boolean('isRightAligned', false)}
+				isBottomAligned={boolean('isBottomAligned', false)}
+				size={text('size', 'large')}
+				isSimple={boolean('isSimple', false)}
+				isSmall={boolean('isSmall', false)}
+			/>
+		</div>
+		<div
+			style={{
+				position: 'absolute',
+				bottom: 0,
+				right: 0
+			}}
+		>
+			<ContextMenu
+				actions={object('actions', [
+					{ text: 'Rebook' },
+					{ text: 'Cancel appointment' },
+					{ text: 'Ask for feedback' }
+				])}
+				isRightAligned={boolean('isRightAligned', false)}
+				isBottomAligned={boolean('isBottomAligned', false)}
+				size={text('size', 'large')}
+				isSimple={boolean('isSimple', false)}
+				isSmall={boolean('isSmall', false)}
+			/>
+		</div>
+	</div>
 ))

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu-story.js
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu-story.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withKnobs, object, boolean, text } from '@storybook/addon-knobs/react'
 import ContextMenu from './ContextMenu'

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu-story.js
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu-story.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { storiesOf } from '@storybook/react'
 import { withKnobs, object, boolean, text } from '@storybook/addon-knobs/react'
 import ContextMenu from './ContextMenu'
@@ -8,10 +8,18 @@ const stories = storiesOf('Context Menu', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Example', () => (
-	<ContextMenu
-		actions={object('actions', [{ text: 'one' }])}
-		isLeftAligned={boolean('isLeftAligned', true)}
-		size={text('size', '')}
-		isSimple={boolean('isSimple', false)}
-	/>
+	<Fragment>
+		<ContextMenu
+			actions={object('actions', [
+				{ text: 'Rebook' },
+				{ text: 'Cancel appointment' },
+				{ text: 'Ask for feedback' }
+			])}
+			isRightAligned={boolean('isRightAligned', false)}
+			isBottomAligned={boolean('isBottomAligned', false)}
+			size={text('size', '')}
+			isSimple={boolean('isSimple', false)}
+		/>
+		<p style={{ height: '200px' }}>Here is some more content</p>
+	</Fragment>
 ))

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.js
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.js
@@ -56,6 +56,7 @@ type State = {
 export default class ContextMenu extends Component<Props, State> {
 	ref = React.createRef()
 	menuRef = React.createRef()
+	portalEl = React.createRef()
 	state = {
 		isVisible: false,
 		overflowBottom: false,
@@ -74,6 +75,12 @@ export default class ContextMenu extends Component<Props, State> {
 		className: ''
 	}
 
+	constructor(props: Props) {
+		super(props)
+
+		this.portalEl = document.body
+	}
+
 	componentDidMount = () => {
 		this.getMenuPlacement()
 	}
@@ -88,10 +95,6 @@ export default class ContextMenu extends Component<Props, State> {
 		const triggerPosition =
 			this.ref.current && this.ref.current.getBoundingClientRect()
 
-		// if (typeof document !== 'undefined' && document.body) {
-		// 	console.log(document.body.getBoundingClientRect())
-		// }
-
 		if (!triggerPosition) {
 			return
 		}
@@ -103,8 +106,6 @@ export default class ContextMenu extends Component<Props, State> {
 				? triggerPosition.x + triggerPosition.width
 				: triggerPosition.x
 		}
-
-		// Decide where to place it
 
 		this.setState({
 			menuPosition
@@ -239,33 +240,6 @@ export default class ContextMenu extends Component<Props, State> {
 					text={text}
 					isSmall={isSmall}
 				/>
-				{/* <VelocityTransitionGroup
-					enter={{
-						animation: { opacity: 1, translateY: '4px' },
-						duration: 200
-					}}
-					leave={{
-						animation: { opacity: 0, translateY: '12px' },
-						duration: 200
-					}}
-				>
-					{isVisible && (
-						<div className={menuClass} ref={this.menuRef}>
-							<ButtonGroup
-								kind="floating"
-								actions={actions.map(action => {
-									const btnAction = { ...action }
-									const oldOnclick = btnAction.onClick
-									btnAction.onClick = () => {
-										this.handleClickAction(btnAction.payload, oldOnclick)
-									}
-									btnAction.className = 'context-menu__item-btn'
-									return btnAction
-								})}
-							/>
-						</div>
-					)}
-				</VelocityTransitionGroup> */}
 				{isVisible &&
 					createPortal(
 						<div
@@ -290,7 +264,7 @@ export default class ContextMenu extends Component<Props, State> {
 								})}
 							/>
 						</div>,
-						document.body
+						this.portalEl
 					)}
 			</div>
 		)

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.js
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react'
 import { createPortal } from 'react-dom'
 import cx from 'classnames'
-import { VelocityTransitionGroup } from 'velocity-react'
 import Button from '../Button/Button'
 import type { Props as ButtonProps } from '../Button/Button'
 import ButtonGroup from '../ButtonGroup/ButtonGroup'
@@ -13,7 +12,10 @@ export type Props = {
 	/** The actions to be shown on tap/click */
 	actions: Array<ButtonProps>,
 
-	/** Set true to left align the menu */
+	/** DEPRECATED Set true to left align the menu */
+	isLeftAligned?: boolean,
+
+	/** Set true to right align the menu */
 	isRightAligned?: boolean,
 
 	/** Set true to align menu above button */
@@ -42,7 +44,9 @@ export type Props = {
 	isTextOnly: boolean,
 
 	/** Optional classname that applies to the button */
-	className?: string
+	className?: string,
+
+	onToggleContextMenuVisible?: Function
 }
 
 type State = {
@@ -50,7 +54,13 @@ type State = {
 	isVisible: boolean,
 
 	/** Where the menu should be positioned when visible */
-	menuPosition: Object
+	menuPosition: Object,
+
+	overflowBottom: boolean,
+	overflowLeft: boolean,
+	isRightAligned: boolean,
+	isLeftAligned: boolean,
+	isBottomAligned: boolean
 }
 
 export default class ContextMenu extends Component<Props, State> {
@@ -64,7 +74,10 @@ export default class ContextMenu extends Component<Props, State> {
 		menuPosition: {
 			top: null,
 			left: null
-		}
+		},
+		isRightAligned: false,
+		isLeftAligned: false,
+		isBottomAligned: false
 	}
 
 	static defaultProps = {

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.js
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.js
@@ -16,10 +16,10 @@ export type Props = {
 	/** DEPRECATED Set true to left align the menu */
 	isLeftAligned?: boolean,
 
-	/** Set true to right align the menu */
+	/** DEPRECATED Set true to right align the menu */
 	isRightAligned?: boolean,
 
-	/** Set true to align menu above button */
+	/** DEPRECATED Set true to align menu above button */
 	isBottomAligned?: boolean,
 
 	/** Set the width of the menu. Helpful for longer text in buttons */


### PR DESCRIPTION
## What does this PR do?
Updates the `ContextMenu` component to use a [portal](https://reactjs.org/docs/portals.html) so that it won't be clipped when its parent has `overflow: hidden;`. This also required the addition of a resize handler to handle positioning. In addition, this deprecates `isLeftAligned`, `isRightAligned`, and `isBottomAligned` in favor of letting the component make its own layout decisions, rather than relying on a best guess. These props could be reintroduced if we deem them necessary.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1717](https://sprucelabsai.atlassian.net/browse/SDEV3-1717)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)
Every `ContextMenu` instance will need to be updated.

## Screenshots (if appropriate)
<img width="607" alt="Frame@2x" src="https://user-images.githubusercontent.com/13734175/59538109-ef81d980-8eb5-11e9-8d33-fb216854e8b5.png">


## What gif best describes this PR or how it makes you feel?
![giphy](https://user-images.githubusercontent.com/13734175/59538143-03c5d680-8eb6-11e9-8aba-284e60ac7894.gif)
