### PR TITLE
[SDEV3-1718] Autosuggest should not push input up or clip suggestions

### DIFF
--- a/packages/heartwood-components/components/02-forms/autosuggest.scss
+++ b/packages/heartwood-components/components/02-forms/autosuggest.scss
@@ -26,6 +26,7 @@
 	}
 }
 
+.autosuggest__list li[aria-selected='true'],
 .autosuggest__list-item-inner:hover {
 	background-color: $c-bg;
 }

--- a/packages/heartwood-components/components/02-forms/autosuggest.scss
+++ b/packages/heartwood-components/components/02-forms/autosuggest.scss
@@ -6,11 +6,11 @@
 	display: none;
 	// display: block;
 	position: absolute;
-	top: 100%;
-	left: 0;
-	width: 100%;
-	margin-bottom: spacing('base');
-	max-height: rem(200);
+	// top: 100%;
+	// left: 0;
+	// width: 100%;
+	// margin-bottom: spacing('base');
+	// max-height: rem(200);
 	z-index: 1;
 	overflow: scroll;
 	background-color: $c-bg-light;

--- a/packages/heartwood-components/components/02-forms/autosuggest.scss
+++ b/packages/heartwood-components/components/02-forms/autosuggest.scss
@@ -4,13 +4,7 @@
 
 .autosuggest {
 	display: none;
-	// display: block;
 	position: absolute;
-	// top: 100%;
-	// left: 0;
-	// width: 100%;
-	// margin-bottom: spacing('base');
-	// max-height: rem(200);
 	z-index: 1;
 	overflow: scroll;
 	background-color: $c-bg-light;
@@ -20,6 +14,7 @@
 
 	&.autosuggest--show-suggestions {
 		display: block;
+		max-height: rem(200);
 	}
 }
 

--- a/packages/react-heartwood-components/src/components/Forms/Forms-story.js
+++ b/packages/react-heartwood-components/src/components/Forms/Forms-story.js
@@ -316,7 +316,38 @@ stories
 			</FormLayoutGroup>
 			<FormLayoutGroup isCondensed>
 				<FormLayoutItem>
-					<TextInput type="text" label="Price" />
+					{/* <TextInput type="text" label="Price" /> */}
+					<Autosuggest
+						alwaysRenderSuggestions={false}
+						label={text('label', 'Price')}
+						inputHelper={object('inputHelper', {
+							helper:
+								'We use this information to improve your shopping experience.'
+						})}
+						placeholder={text('placeholder', 'How much does it cost?')}
+						defaultSuggestions={object('defaultSuggestions', countries)}
+						shouldRenderSuggestions={() => true}
+						renderSuggestion={renderSuggestion}
+						getSuggestionValue={value => value.text}
+						getSuggestions={value => {
+							const results = countries.filter(
+								suggestion =>
+									suggestion.text.toLowerCase().slice(0, value.length) ===
+									value.toLowerCase()
+							)
+							// Here you could add click events to buttons or whatever else they need
+							// No Results Message
+							if (results.length === 0) {
+								return [
+									{
+										text: 'NO RESULTS',
+										isEmptyMessage: true
+									}
+								]
+							}
+							return results
+						}}
+					/>
 				</FormLayoutItem>
 				<FormLayoutItem>
 					<TextInput type="text" label="Duration" />

--- a/packages/react-heartwood-components/src/components/Forms/Forms-story.js
+++ b/packages/react-heartwood-components/src/components/Forms/Forms-story.js
@@ -68,6 +68,7 @@ stories.addDecorator(withKnobs)
 stories
 	.add('Autosuggest', () => (
 		<Autosuggest
+			alwaysRenderSuggestions={false}
 			label={stringify('label', 'Country')}
 			inputHelper={object('inputHelper', {
 				helper: 'We use this information to improve your shopping experience.'

--- a/packages/react-heartwood-components/src/components/Forms/Forms-story.js
+++ b/packages/react-heartwood-components/src/components/Forms/Forms-story.js
@@ -316,38 +316,7 @@ stories
 			</FormLayoutGroup>
 			<FormLayoutGroup isCondensed>
 				<FormLayoutItem>
-					{/* <TextInput type="text" label="Price" /> */}
-					<Autosuggest
-						alwaysRenderSuggestions={false}
-						label={text('label', 'Price')}
-						inputHelper={object('inputHelper', {
-							helper:
-								'We use this information to improve your shopping experience.'
-						})}
-						placeholder={text('placeholder', 'How much does it cost?')}
-						defaultSuggestions={object('defaultSuggestions', countries)}
-						shouldRenderSuggestions={() => true}
-						renderSuggestion={renderSuggestion}
-						getSuggestionValue={value => value.text}
-						getSuggestions={value => {
-							const results = countries.filter(
-								suggestion =>
-									suggestion.text.toLowerCase().slice(0, value.length) ===
-									value.toLowerCase()
-							)
-							// Here you could add click events to buttons or whatever else they need
-							// No Results Message
-							if (results.length === 0) {
-								return [
-									{
-										text: 'NO RESULTS',
-										isEmptyMessage: true
-									}
-								]
-							}
-							return results
-						}}
-					/>
+					<TextInput type="text" label="Price" />
 				</FormLayoutItem>
 				<FormLayoutItem>
 					<TextInput type="text" label="Duration" />

--- a/packages/react-heartwood-components/src/components/Forms/Forms-story.js
+++ b/packages/react-heartwood-components/src/components/Forms/Forms-story.js
@@ -69,7 +69,7 @@ stories
 	.add('Autosuggest', () => (
 		<Autosuggest
 			alwaysRenderSuggestions={false}
-			label={stringify('label', 'Country')}
+			label={text('label', 'Country')}
 			inputHelper={object('inputHelper', {
 				helper: 'We use this information to improve your shopping experience.'
 			})}

--- a/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.js
+++ b/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.js
@@ -1,5 +1,7 @@
 // @flow
 import React, { Component } from 'react'
+import { createPortal } from 'react-dom'
+import debounce from 'lodash/debounce'
 import { default as ReactAutosuggest } from 'react-autosuggest'
 import cx from 'classnames'
 import Button from '../../../Button/Button'
@@ -62,7 +64,12 @@ export type Props = {
 type State = {
 	value: string,
 	suggestions: Array<any>,
-	showClearButton: boolean
+	showClearButton: boolean,
+	containerPlacement: {
+		top: number,
+		left: number,
+		width: number
+	}
 }
 
 type ThemeProps = {
@@ -88,14 +95,60 @@ export default class Autosuggest extends Component<Props, State> {
 		defaultSuggestions: []
 	}
 
+	debouncedResize = debounce(() => this.handleWindowResize(), 500)
+
 	constructor(props: Props) {
 		super(props)
 
 		this.state = {
 			value: props.defaultValue || '',
 			suggestions: this.props.defaultSuggestions || [],
-			showClearButton: false
+			showClearButton: false,
+			containerPlacement: {
+				top: 0,
+				left: 0,
+				width: 0
+			}
 		}
+	}
+
+	componentDidMount = () => {
+		this.getContainerPlacement()
+		// TODO: Make sure that this strategy works when the container is down the page
+		if (typeof window !== 'undefined') {
+			window.addEventListener('resize', this.debouncedResize, false)
+		}
+	}
+
+	componentWillUnmount = () => {
+		if (typeof window !== 'undefined') {
+			window.removeEventListener('resize', this.debouncedResize, false)
+		}
+	}
+
+	getContainerPlacement = () => {
+		const input =
+			this.autosuggestRef &&
+			this.autosuggestRef.current &&
+			this.autosuggestRef.current.input
+
+		if (!input) {
+			return
+		}
+
+		const inputPosition = input.getBoundingClientRect()
+
+		this.setState({
+			containerPlacement: {
+				top: inputPosition.y + inputPosition.height,
+				left: inputPosition.x,
+				width: inputPosition.width
+			}
+		})
+	}
+
+	handleWindowResize = () => {
+		this.getContainerPlacement()
 	}
 
 	onChange = (event: any, { newValue }: any) => {
@@ -194,7 +247,12 @@ export default class Autosuggest extends Component<Props, State> {
 	}
 
 	render() {
-		const { value, suggestions, showClearButton } = this.state
+		const {
+			value,
+			suggestions,
+			showClearButton,
+			containerPlacement
+		} = this.state
 		const {
 			getSuggestionValue,
 			renderSuggestion,
@@ -238,6 +296,21 @@ export default class Autosuggest extends Component<Props, State> {
 						onSuggestionsClearRequested={this.onSuggestionsClearRequested}
 						getSuggestionValue={getSuggestionValue}
 						renderSuggestion={renderSuggestion}
+						renderSuggestionsContainer={({ containerProps, children }) => {
+							return createPortal(
+								<div
+									style={{
+										top: `${containerPlacement.top + 8}px`,
+										left: `${containerPlacement.left}px`,
+										width: `${containerPlacement.width}px`
+									}}
+									{...containerProps}
+								>
+									{children}
+								</div>,
+								document.body
+							)
+						}}
 						onSuggestionSelected={onSuggestionSelected}
 						inputProps={inputProps}
 						theme={theme({ isSmall })}

--- a/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.js
+++ b/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.js
@@ -8,6 +8,8 @@ import Button from '../../../Button/Button'
 import { InputPre, InputHelper } from '../../FormPartials'
 import ClearIcon from '../../../../../static/assets/icons/ic_cancel.svg'
 
+// TODO: Figure out max height setting. Should be based on results length or manual? Both?
+
 export type Props = {
 	/** Unique identifier */
 	id: string,
@@ -114,7 +116,6 @@ export default class Autosuggest extends Component<Props, State> {
 
 	componentDidMount = () => {
 		this.getContainerPlacement()
-		// TODO: Make sure that this strategy works when the container is down the page
 		if (typeof window !== 'undefined') {
 			window.addEventListener('resize', this.debouncedResize, false)
 		}


### PR DESCRIPTION
## What does this PR do?

Enables `Autosuggest` to use a [portal](https://reactjs.org/docs/portals.html) so that suggestions will not be clipped. Also, adds styling for the selected (via keyboard arrows) item. Verifiable in Storybook under Forms > Autosuggest.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1718](https://sprucelabsai.atlassian.net/browse/SDEV3-1718)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)
No, but it does block [SDEV3-1663](https://sprucelabsai.atlassian.net/browse/SDEV3-1663).

## Screenshots (if appropriate)

## What gif best describes this PR or how it makes you feel?