### PR TITLE
fix: [SDEV3-1745] context and auto suggests z-index

### DIFF
--- a/packages/heartwood-components/components/01-button/context-menu.scss
+++ b/packages/heartwood-components/components/01-button/context-menu.scss
@@ -24,7 +24,7 @@
 
 .context-menu__menu {
 	position: absolute;
-	z-index: 2;
+	z-index: 10;
 	width: rem(160);
 
 	&.context-menu__menu-large {

--- a/packages/heartwood-components/components/02-forms/autosuggest.scss
+++ b/packages/heartwood-components/components/02-forms/autosuggest.scss
@@ -5,7 +5,7 @@
 .autosuggest {
 	display: none;
 	position: absolute;
-	z-index: 1;
+	z-index: 10;
 	overflow: scroll;
 	background-color: $c-bg-light;
 	border: 1px solid $c-border;


### PR DESCRIPTION
## What does this PR do?

Fixes context menu and autosuggest z-index so they show up above modals and other portal-ly components

NOTE: This doesn't need to be deployed to fix the issue as it's a redundant fix that is self-contained in booking at the moment, but could be present in future heartwood implementations.

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1745](https://sprucelabsai.atlassian.net/browse/SDEV3-1745)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

## Screenshots (if appropriate)

## What gif best describes this PR or how it makes you feel?

![zzzz](https://media.giphy.com/media/5qGaqI61k746IJcm2V/giphy.gif)