### PR TITLE
[SDEV3-940] Fix EVENT_VERSION=1 eventId and retryId not passed through on ctx.event

### DIFF
--- a/packages/spruce-skill-server/middleware/events.js
+++ b/packages/spruce-skill-server/middleware/events.js
@@ -73,18 +73,29 @@ module.exports = (router, options) => {
 				ctx.event.organizationId = body.organizationId
 			}
 
-			if (ctx.event && body && body.payload) {
-				ctx.event.payload = body.payload
-			}
-
-			if (body && body.firstSentAt) {
-				ctx.event.firstSentAt = body.firstSentAt
-			}
-			if (body && body.deliveryTry) {
-				ctx.event.deliveryTry = body.deliveryTry
-			}
-
 			if (ctx.event) {
+				if (body) {
+					if (body.payload) {
+						ctx.event.payload = body.payload
+					}
+
+					if (body.firstSentAt) {
+						ctx.event.firstSentAt = body.firstSentAt
+					}
+
+					if (body.deliveryTry) {
+						ctx.event.deliveryTry = body.deliveryTry
+					}
+
+					if (body.eventId) {
+						ctx.event.eventId = body.eventId
+					}
+
+					if (body.retryId) {
+						ctx.event.retryId = body.retryId
+					}
+				}
+
 				ctx.event.name = eventName // pass through event name
 			}
 		} else if (ctx.path === '/hook.json' && eventName) {


### PR DESCRIPTION
## What does this PR do?

* Fixes bug where skills w/ `EVENT_VERSION=1` was not logging or passing through the `eventId` or `retryId` 

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-940](https://sprucelabsai.atlassian.net/browse/SDEV3-940)