### PR TITLE
fix(PageHeader): Allow setting of additional classnames

### DIFF
--- a/packages/react-heartwood-components/src/components/Page/Page-story.js
+++ b/packages/react-heartwood-components/src/components/Page/Page-story.js
@@ -20,6 +20,7 @@ stories
 	.add('Page', () => (
 		<Page
 			header={{
+				className: 'custom-classname',
 				title: text('title', '') || 'Page Title'
 			}}
 		>

--- a/packages/react-heartwood-components/src/components/Page/components/PageHeader/PageHeader.js
+++ b/packages/react-heartwood-components/src/components/Page/components/PageHeader/PageHeader.js
@@ -42,16 +42,17 @@ export type PageHeaderProps = {
 
 const PageHeader = (props: PageHeaderProps) => {
 	const {
-		title,
-		backLinkHref,
-		onClickBack,
-		backLinkText,
 		backLinkComponent: RelativeBackLinkComponent = Link,
-		linkProps,
-		primaryAction,
-		tabs,
+		backLinkHref,
+		backLinkText,
+		className,
 		hasBottomBorder,
-		sidebarExpander
+		linkProps,
+		onClickBack,
+		primaryAction,
+		sidebarExpander,
+		tabs,
+		title
 	} = props
 
 	const backLinkClass = 'page__header-back-link'
@@ -100,10 +101,14 @@ const PageHeader = (props: PageHeaderProps) => {
 
 	return (
 		<header
-			className={cx('page__header', {
-				'page__header--has-bottom-border': hasBottomBorder,
-				'page__header--has-tabs': tabs && tabs.length > 0
-			})}
+			className={cx(
+				'page__header',
+				{
+					'page__header--has-bottom-border': hasBottomBorder,
+					'page__header--has-tabs': tabs && tabs.length > 0
+				},
+				className
+			)}
 		>
 			<div className="page__header-inner">
 				{anchor && anchor}


### PR DESCRIPTION
- In core I'll need this to prevent jank when switching between skill 
view iframes with/without headers
- Cleanup, alphabetize long list of props

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/1ymaijxEKyIm1cH5vY/giphy.gif)