### PR TITLE
feat(PageHeader): Add collapsibility for PageHeader

### DIFF
--- a/packages/heartwood-components/components/03-structure/page.scss
+++ b/packages/heartwood-components/components/03-structure/page.scss
@@ -11,6 +11,9 @@
 
 .page__header {
 	padding-top: spacing('base');
+	overflow: hidden;
+	flex: 1;
+	transition: 350ms 350ms flex, 350ms 350ms padding;
 
 	@include gt('small') {
 		padding-top: 1.5rem;
@@ -18,6 +21,11 @@
 
 	@include gt('medium') {
 		padding-top: 1.5rem;
+	}
+
+	&--is-collapsed {
+		flex: 0;
+		padding: 0;
 	}
 }
 
@@ -59,15 +67,6 @@
 	align-items: flex-start;
 	padding: 0 spacing('base') 00;
 
-	&--has-bottom-border {
-		padding-bottom: spacing('base');
-		border-bottom: 1px solid $c-border-light;
-
-		@include gt('small') {
-			padding-bottom: 1.5rem;
-		}
-	}
-
 	> .btn {
 		flex: 0 0 auto;
 		margin-top: spacing('tight');
@@ -95,6 +94,15 @@
 
 		.btn {
 			margin-top: 0;
+		}
+	}
+
+	&--has-bottom-border {
+		padding-bottom: spacing('base');
+		border-bottom: 1px solid $c-border-light;
+
+		@include gt('small') {
+			padding-bottom: 1.5rem;
 		}
 	}
 }

--- a/packages/heartwood-components/components/03-structure/page.scss
+++ b/packages/heartwood-components/components/03-structure/page.scss
@@ -12,8 +12,9 @@
 .page__header {
 	padding-top: spacing('base');
 	overflow: hidden;
-	flex: 1;
-	transition: 350ms 350ms flex, 350ms 350ms padding;
+	max-height: 200px;
+	opacity: 1;
+	transition: 350ms 350ms max-height, 350ms 350ms opacity, 350ms 350ms padding;
 
 	@include gt('small') {
 		padding-top: 1.5rem;
@@ -24,8 +25,9 @@
 	}
 
 	&--is-collapsed {
-		flex: 0;
+		max-height: 0;
 		padding: 0;
+		opacity: 0;
 	}
 }
 

--- a/packages/react-heartwood-components/src/components/Page/Page-story.js
+++ b/packages/react-heartwood-components/src/components/Page/Page-story.js
@@ -21,7 +21,8 @@ stories
 		<Page
 			header={{
 				className: 'custom-classname',
-				title: text('title', '') || 'Page Title'
+				title: text('title', '') || 'Page Title',
+				collapsed: boolean('isCollapsed', false)
 			}}
 		>
 			<PageContent>
@@ -35,7 +36,8 @@ stories
 				title: text('title', 'Page Title'),
 				backLinkHref: '#',
 				backLinkText: text('backLinkText', 'Back'),
-				hasBottomBorder: boolean('hasBottomBorder', false)
+				hasBottomBorder: boolean('hasBottomBorder', false),
+				collapsed: boolean('isCollapsed', false)
 			}}
 		>
 			<PageContent>
@@ -53,7 +55,8 @@ stories
 					icon: text('icon', ''),
 					isSmall: boolean('isSmall', true)
 				},
-				hasBottomBorder: boolean('hasBottomBorder', false)
+				hasBottomBorder: boolean('hasBottomBorder', false),
+				collapsed: boolean('isCollapsed', false)
 			}}
 		>
 			<PageContent>
@@ -73,7 +76,8 @@ stories
 					icon: text('icon', ''),
 					isSmall: boolean('isSmall', true)
 				},
-				hasBottomBorder: boolean('hasBottomBorder', false)
+				hasBottomBorder: boolean('hasBottomBorder', false),
+				collapsed: boolean('isCollapsed', false)
 			}}
 		>
 			<PageContent>
@@ -87,7 +91,8 @@ stories
 				title: text('title', 'Page Title'),
 				backLinkHref: '#',
 				backLinkText: text('backLinkText', 'Back'),
-				tabs: manyTabs
+				tabs: manyTabs,
+				collapsed: boolean('isCollapsed', false)
 			}}
 		>
 			<PageContent>

--- a/packages/react-heartwood-components/src/components/Page/components/PageHeader/PageHeader.js
+++ b/packages/react-heartwood-components/src/components/Page/components/PageHeader/PageHeader.js
@@ -27,6 +27,9 @@ export type PageHeaderProps = {
 	/** Props for Next router link: https://nextjs.org/docs/#routing. */
 	linkProps?: LinkProps,
 
+	/** Is the header collapsed? */
+	collapsed?: boolean,
+
 	/** Adds a button to the page header for its primary action. */
 	primaryAction?: ButtonProps,
 
@@ -46,6 +49,7 @@ const PageHeader = (props: PageHeaderProps) => {
 		backLinkHref,
 		backLinkText,
 		className,
+		collapsed = false,
 		hasBottomBorder,
 		linkProps,
 		onClickBack,
@@ -104,15 +108,18 @@ const PageHeader = (props: PageHeaderProps) => {
 			className={cx(
 				'page__header',
 				{
-					'page__header--has-bottom-border': hasBottomBorder,
-					'page__header--has-tabs': tabs && tabs.length > 0
+					'page__header--is-collapsed': collapsed
 				},
 				className
 			)}
 		>
 			<div className="page__header-inner">
 				{anchor && anchor}
-				<div className="page__header-main">
+				<div
+					className={cx('page__header-main', {
+						'page__header-main--has-bottom-border': hasBottomBorder
+					})}
+				>
 					<div className="page__header-title-wrapper">
 						<h1>{title}</h1>
 						{sidebarExpander && (


### PR DESCRIPTION
- This is a controlled attribute; downstream users are responsible for 
triggering it.
- In core we use it for skillview pages that may/may not have headers -- 
transitioning between them
- Also fixup the bottom-border attribute

## Type

- [x] Feature
- [x] Bug
- [ ] Tech debt

![Jun-20-2019 13-54-22](https://user-images.githubusercontent.com/1161192/59874049-f8b1f100-9362-11e9-8512-811cd154b062.gif)

(Smoother IRL than in GIF 😂)