### PR TITLE
feat(Skillskit): Restore the concept of forced auth for the safari case [SDEV3-1945]

### DIFF
--- a/packages/spruce-next-helpers/src/skillskit/index.js
+++ b/packages/spruce-next-helpers/src/skillskit/index.js
@@ -36,6 +36,14 @@ const skill = {
 		})
 	},
 
+	forceAuth: () => {
+		Iframes.sendMessage({
+			to: window.parent,
+			eventName: 'Skill:ForceAuth',
+			data: {}
+		})
+	},
+
 	ready: function({ showHeader = true }: { showHeader: boolean } = {}) {
 		Iframes.sendMessage({
 			to: window.parent,

--- a/packages/spruce-next-helpers/src/skillskit/next/PageWrapper.js
+++ b/packages/spruce-next-helpers/src/skillskit/next/PageWrapper.js
@@ -98,7 +98,7 @@ const PageWrapper = Wrapped => {
 		constructor(props: Props) {
 			super(props)
 			this.state = {
-				// attemptingReAuth: !!props.attemptingReAuth,
+				attemptingReAuth: !!props.attemptingReAuth,
 				isIframed: true
 			}
 		}
@@ -169,8 +169,9 @@ const PageWrapper = Wrapped => {
 
 			if (
 				query.back &&
-				query.jwt &&
+				(query.jwt || query.jwtV2) &&
 				(query.back.search('sprucebot.com') > 0 ||
+					query.back.search('spruce.ai') > 0 ||
 					query.back.search('bshop.io') > 0)
 			) {
 				// if there is a jwt, we are being authed
@@ -212,12 +213,12 @@ const PageWrapper = Wrapped => {
 
 			// if we are /unauthorized, don't have a cookie, but have NOT done cookie check
 			// TODO Remove re-auth after proving it works as expected in legacy skill
-			// if (
-			// 	props.pathname === '/unauthorized' &&
-			// 	(!state.auth || !state.auth.role)
-			// ) {
-			// 	props.attemptingReAuth = true
-			// }
+			if (
+				props.pathname === '/unauthorized' &&
+				(!state.auth || !state.auth.role)
+			) {
+				props.attemptingReAuth = true
+			}
 
 			// v2 authentication
 			if (state.auth && state.auth.User) {
@@ -235,23 +236,23 @@ const PageWrapper = Wrapped => {
 
 		handleIframeMessage = e => {
 			// we are not going to try and authenticate again (cookie setting)
-			// if (e.data === 'Skill:NotReAuthing') {
-			// 	this.setState({
-			// 		attemptingReAuth: false
-			// 	})
-			// 	return
-			// }
+			if (e.data === 'Skill:NotReAuthing') {
+				this.setState({
+					attemptingReAuth: false
+				})
+				return
+			}
 		}
 		async componentDidMount() {
 			if (window.self === window.top || window.__SBTEAMMATE__) {
 				// make sure we are being loaded inside sb
 				console.error('NOT LOADED FROM SPRUCEBOT!! BAIL BAIL BAIL')
 				this.setState({
-					// attemptingReAuth: false,
+					attemptingReAuth: false,
 					isIframed: !!window.__SBTEAMMATE__
 				})
-				// } else if (this.props.attemptingReAuth) {
-				// skill.forceAuth()
+			} else if (this.props.attemptingReAuth) {
+				skill.forceAuth()
 			}
 
 			// NOTE: Need to do this require here so that we can be sure the global window is defined
@@ -331,9 +332,10 @@ const PageWrapper = Wrapped => {
 		}
 
 		render() {
-			// if (this.state.attemptingReAuth) {
-			// return <Loader />
-			// }
+			if (this.state.attemptingReAuth) {
+				return <Loader />
+			}
+
 			if (this.props.config.DEV_MODE) {
 				return (
 					<Container>


### PR DESCRIPTION
This adds the ability to force-authenticate Safari if no cookies have ever been set for that skill, as was done in legacy web. See https://gist.github.com/iansltx/18caf551baaa60b79206 for an overview of the issue.

- Allow redirect if JWTv2 is supplied
- Allow spruce.ai backlinks from skill redirects

## What does this PR do?

## Type

- [x] Feature
- [x] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1945](https://sprucelabsai.atlassian.net/browse/SDEV3-1945)