### PR TITLE
[SDEV3-1889] Fix double JWT authentication issues

### DIFF
--- a/packages/spruce-next-helpers/src/skillskit/next/PageWrapper.js
+++ b/packages/spruce-next-helpers/src/skillskit/next/PageWrapper.js
@@ -145,14 +145,14 @@ const PageWrapper = Wrapped => {
 					)
 				} catch (e) {
 					debug(err)
-					debug('Error fetching user from jwt')
+					debug('Error fetching user from jwtV2')
 				}
 			} else if (jwt) {
 				try {
 					await store.dispatch(actions.auth.go(jwt))
 				} catch (err) {
 					debug(err)
-					debug('Error fetching user from jwtV2')
+					debug('Error fetching user from jwt')
 				}
 			}
 


### PR DESCRIPTION
Fixes issue where loading a v2 skill in legacy web and then navigating to that skill in heartwood web would cause errors until cookies were cleared.

This _could_ also fix other authentication issues we've seen. Previously, if the jwt was set in the cookie it would use that over the query string which is wrong because the one in cookies might have expired.

### Details

* Prioritize JWTs in the query string over what's in cookies

  * If jwt is found in query string, set it in cookies

* For authentication purposes prefer `jwtV2` over `jwt`

## What does this PR do?

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1889](https://sprucelabsai.atlassian.net/browse/SDEV3-1889)

![intersection](https://user-images.githubusercontent.com/1094411/60626376-d4650400-9da7-11e9-9da1-a156caa253ff.gif)

