### PR TITLE
fix(RecordTable): Correct usage of getNoDataProps [SDEV3-2018]

### DIFF
--- a/packages/react-heartwood-components/src/components/RecordTable/RecordTable-story.tsx
+++ b/packages/react-heartwood-components/src/components/RecordTable/RecordTable-story.tsx
@@ -17,12 +17,15 @@ interface IDummyRecordTableRecord {
 	count: number
 }
 
-stories.add('RecordTable', () => {
+stories.add('Basic RecordTable', () => {
 	const records: IDummyRecordTableRecord[] = [...Array(1000)].map(() => ({
 		name: `${Math.floor(Math.random() * 1000)}-Dummy`,
 		count: Math.floor(Math.random() * 1000)
 	}))
 
+	// Faked API, made syncronous to populate initial state of the table.
+	// In the real world you'd just make a `fetchRecords` async method and call it
+	// in `getInitialProps` to populate your server-rendered state.
 	function syncFetchRecords(
 		options: IRecordTableFetchOptions
 	): IRecordTableFetchResults {
@@ -80,7 +83,60 @@ stories.add('RecordTable', () => {
 					},
 					{
 						Header: 'Count',
-						sortable: false,
+						id: 'count',
+						accessor: function renderCountColumn(
+							record: IDummyRecordTableRecord
+						) {
+							return <div>{record.count}</div>
+						}
+					}
+				]}
+				noDataIcon="trip_pin_multiple_light_large"
+				noDataHeadline={'No data!'}
+				noDataPrimaryAction={{
+					text: 'Try Again',
+					onClick: () => {},
+					type: 'submit'
+				}}
+			/>
+		</div>
+	)
+})
+
+stories.add('Empty RecordTable', () => {
+	const records = []
+
+	return (
+		<div>
+			<RecordTable
+				fetchRecords={async () => ({ visibleRows: [], totalRows: 0 })}
+				enableFilter={true}
+				searchPlaceholder={'Search groups...'}
+				fetchError={false}
+				initialLimit={10}
+				initialSortColumn={'name'}
+				initialSortDirection={'ASC'}
+				initialSelectedTab={'all'}
+				initialVisibleRows={records}
+				totalRows={records.length}
+				tabs={[
+					{
+						key: 'all',
+						text: 'All things'
+					}
+				]}
+				columns={[
+					{
+						Header: 'Name',
+						id: 'name',
+						accessor: function renderNameColumn(
+							record: IDummyRecordTableRecord
+						) {
+							return <div>{record.name}</div>
+						}
+					},
+					{
+						Header: 'Count',
 						id: 'count',
 						accessor: function renderCountColumn(
 							record: IDummyRecordTableRecord

--- a/packages/react-heartwood-components/src/components/RecordTable/RecordTable.tsx
+++ b/packages/react-heartwood-components/src/components/RecordTable/RecordTable.tsx
@@ -329,12 +329,14 @@ class RecordTable extends Component<IRecordTableProps, IRecordTableState> {
 					onSortedChange={this.handleSortChanged}
 					onClickRow={handleClickRow}
 					key="id"
-					noDataIcon={this.getNoDataIcon()}
-					noDataHeadline={this.getNoDataHeadline()}
-					noDataSubheadline={this.getNoDataSubheadline()}
-					noDataPrimaryAction={this.getNoDataPrimaryAction()}
-					noDataPrimaryActionButtonKind={noDataPrimaryActionButtonKind}
-					noDataPrimaryActionButtonIcon={noDataPrimaryActionButtonIcon}
+					getNoDataProps={() => ({
+						icon: this.getNoDataIcon(),
+						headline: this.getNoDataHeadline(),
+						subheadline: this.getNoDataSubheadline(),
+						primaryAction: this.getNoDataPrimaryAction(),
+						primaryActionButtonKind: noDataPrimaryActionButtonKind,
+						primaryActionButtonIcon: noDataPrimaryActionButtonIcon
+					})}
 					{...rest}
 				/>
 			</Fragment>
@@ -468,11 +470,13 @@ class RecordTable extends Component<IRecordTableProps, IRecordTableState> {
 	private isFiltered = () => {
 		const { enableFilter } = this.props
 		const { currentFilter } = this.state
+
 		return currentFilter.length > 0 && enableFilter
 	}
 
 	private getNoDataIcon = () => {
 		const { noDataIcon, fetchError } = this.props
+
 		return fetchError
 			? 'caution'
 			: this.isFiltered()
@@ -482,6 +486,7 @@ class RecordTable extends Component<IRecordTableProps, IRecordTableState> {
 
 	private getNoDataHeadline = () => {
 		const { noDataHeadline, fetchError } = this.props
+
 		return fetchError
 			? 'Data not available'
 			: this.isFiltered()


### PR DESCRIPTION
- Ensures proper "clear filter" state if zero records are returned

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2018](https://sprucelabsai.atlassian.net/browse/SDEV3-2018)