### PR TITLE
fix(build): Run clean before build

### DIFF
--- a/packages/react-heartwood-components/package.json
+++ b/packages/react-heartwood-components/package.json
@@ -19,7 +19,7 @@
 		"url": "https://github.com/sprucelabsai/workspace.sprucebot-skills-kit/issues"
 	},
 	"scripts": {
-		"build": "npm run icons && npm run compile_javascript",
+		"build": "npm run clean && npm run icons && npm run compile_javascript",
 		"compile_javascript": "babel --extensions \".js\",\".tsx\" ./src --out-dir ./lib && tsc --declaration --outDir lib/ --emitDeclarationOnly --declarationMap",
 		"icons": "node ./scripts/generateIcons.js",
 		"clean": "rm -rf lib/*",


### PR DESCRIPTION
- If you don't clean the `lib` folder, `tsc` has issues with overriding the previous definition files.