### PR TITLE
feat(Cards): Add concept of a footer action helper [SDEV3-1921]

### DIFF
--- a/packages/heartwood-components/components/03-structure/card.scss
+++ b/packages/heartwood-components/components/03-structure/card.scss
@@ -148,6 +148,11 @@
 	@include gt('small') {
 		padding: 0 spacing('loose') spacing('loose') spacing('loose');
 	}
+
+	&__helper {
+		margin-top: spacing('base');
+		color: $c-text-light;
+	}
 }
 
 .card--small {

--- a/packages/react-heartwood-components/src/components/Card/Card-story.js
+++ b/packages/react-heartwood-components/src/components/Card/Card-story.js
@@ -159,6 +159,28 @@ const cardJSON4 = {
 	}
 }
 
+const cardJSON5 = {
+	header: {
+		title: 'Danger Zone'
+	},
+	footer: {
+		actions: [
+			{
+				type: 'button',
+				text: 'Delete this thing forever',
+				icon: {
+					name: 'remove'
+				},
+				kind: 'caution',
+				isSmall: true,
+				onClick: () => {}
+			}
+		],
+		helper:
+			'This is a permanant thing you are doing, be sure you want to do the thing'
+	}
+}
+
 const stories = storiesOf('Card', module)
 
 stories.addDecorator(
@@ -348,5 +370,6 @@ stories
 		<CardBuilder key="foo-0" {...object('json', cardJSON)} />,
 		<CardBuilder key="foo-1" {...object('json2', cardJSON2)} />,
 		<CardBuilder key="foo-2" {...object('json3', cardJSON3)} />,
-		<CardBuilder key="foo-3" {...object('json4', cardJSON4)} />
+		<CardBuilder key="foo-3" {...object('json4', cardJSON4)} />,
+		<CardBuilder key="foo-4" {...object('json5', cardJSON5)} />
 	])

--- a/packages/react-heartwood-components/src/components/Card/components/CardBuilder.js
+++ b/packages/react-heartwood-components/src/components/Card/components/CardBuilder.js
@@ -163,9 +163,12 @@ const CardBuilder = (props: CardBuilderProps) => {
 					{Array.isArray(children) ? children.map(renderChild) : children}
 				</CardBody>
 			)}
-			{footer && footer.actions && (
+			{footer && (
 				<CardFooter>
-					<ButtonGroup {...footer} />
+					{footer.actions && <ButtonGroup {...footer} />}
+					{footer.helper && (
+						<div className={'card__footer__helper'}>{footer.helper}</div>
+					)}
 				</CardFooter>
 			)}
 		</Card>


### PR DESCRIPTION
- Needed for redesigned card in Update Group page
- Not 100% matched to comps for padding, font sizes, etc., but I believe Cards generally are off-spec now and need a design pass from Jeremy; trying to add the feature without variating too much from what is already there.

## What does this PR do?

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-1921](https://sprucelabsai.atlassian.net/browse/SDEV3-1921)

## Screenshots (if appropriate)

From comps:

<img width="1326" alt="Screen Shot 2019-07-11 at 11 20 38 PM" src="https://user-images.githubusercontent.com/1161192/61102330-ff4bf980-a432-11e9-93e9-7041cefe11f2.png">

Implemented:

<img width="729" alt="Screen Shot 2019-07-11 at 11 20 30 PM" src="https://user-images.githubusercontent.com/1161192/61102340-0a068e80-a433-11e9-94e7-3160ea524c76.png">
