### PR TITLE
fix(RSList): Handle filtered EmptyState separately [SDEV3-2110]

### DIFF
--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectList-story.js
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectList-story.js
@@ -60,7 +60,7 @@ class RecordListItemsExample extends Component<
 			totalRecordCount,
 			maxRowsVisible
 		} = this.props
-		const { selectedIds, locations, unselectableIds, emptyState } = this.state
+		const { selectedIds, locations, unselectableIds } = this.state
 		return (
 			<RecordSelectionList
 				canSearch
@@ -83,18 +83,6 @@ class RecordListItemsExample extends Component<
 						})
 
 						results = filteredLocations.slice(offset, offset + limit)
-
-						if (results.length === 0) {
-							this.setState({
-								emptyState: {
-									headline: 'No matches found',
-									icon: 'search',
-									primaryAction: {
-										text: 'Show all'
-									}
-								}
-							})
-						}
 					} else {
 						results = locations.slice(offset, offset + limit)
 					}
@@ -146,7 +134,13 @@ class RecordListItemsExample extends Component<
 						? parseInt(maxRowsVisible, 10)
 						: maxRowsVisible
 				}
-				emptyState={emptyState}
+				noSearchResultsEmptyState={{
+					headline: "Nothin' here...",
+					icon: 'no_matches',
+					primaryAction: {
+						text: "Show all, y'all!"
+					}
+				}}
 			/>
 		)
 	}
@@ -161,10 +155,10 @@ stories
 					<RecordListItemsExample
 						canSelect={select('Can Select', [null, 'many', 'one'], null)}
 						canRemove={boolean('Can Remove', false)}
-						locations={map(generateLocations({ amount: 5 }), o => ({
+						locations={map(generateLocations({ amount: 50 }), o => ({
 							node: { ...o }
 						}))}
-						totalRecordCount={5}
+						totalRecordCount={50}
 						maxRowsVisible={select('Max Rows Visible', [null, 3, 'auto'], 3)}
 					/>
 				</CardBody>
@@ -197,7 +191,7 @@ stories
 						selectedIds={[]}
 						unselectableIds={[]}
 						loadRecordListItems={async () => []}
-						emptyState={{
+						noDataEmptyState={{
 							headline: text('emptyState:headline', 'Nothing to see here'),
 							subheadline: text(
 								'emptyState:subheadline',

--- a/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.tsx
+++ b/packages/react-heartwood-components/src/components/RecordSelectionList/RecordSelectionList.tsx
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from 'react'
+import { get } from 'lodash'
 
 import {
 	List,
@@ -92,8 +93,11 @@ export interface IRecordSelectionListProps {
 
 	maxRowsVisible?: number | 'auto'
 
-	/** Props for the empty state */
-	emptyState?: IEmptyStateProps
+	/** Props for the no-result empty state */
+	noSearchResultsEmptyState?: IEmptyStateProps
+
+	/** Props for the no-data empty state */
+	noDataEmptyState?: IEmptyStateProps
 }
 
 interface IRecordSelectionListState {
@@ -233,14 +237,15 @@ export default class RecordSelectionList extends Component<
 
 	public render(): React.ReactElement {
 		const {
-			selectedIds = [],
-			totalRecordCount,
 			canSearch,
+			maxRowsVisible,
+			noDataEmptyState,
+			noSearchResultsEmptyState,
 			searchLabel,
 			searchPlaceholder,
+			selectedIds = [],
 			showSelectedCount,
-			maxRowsVisible,
-			emptyState
+			totalRecordCount
 		} = this.props
 
 		const { loadedRecords, search, listHeight, isLoading } = this.state
@@ -281,63 +286,88 @@ export default class RecordSelectionList extends Component<
 							iconBefore="search"
 							placeholder={searchPlaceholder || 'Search...'}
 							value={search}
-							onChange={this.handleSearchUpdate}
+							onChange={e => {
+								this.updateSearchValue(e.target.value)
+							}}
 						/>
 					</Fragment>
 				)}
 
-				{!maxRowsVisible ? (
-					loadedRecords.map(record => {
-						return this.renderInnerRow({
-							record,
-							style: {}
-						})
-					})
+				{loadedRecords.length > 0 ? (
+					<Fragment>
+						{!maxRowsVisible ? (
+							loadedRecords.map(record => {
+								return this.renderInnerRow({
+									record,
+									style: {}
+								})
+							})
+						) : (
+							<div
+								className="record-selection__list-wrapper"
+								// Only set listHeight if maxRowsVisible is not undefined or 'auto'
+								{...(typeof maxRowsVisible === 'number'
+									? { style: { height: `${listHeight}px` } }
+									: {})}
+							>
+								<InfiniteLoader
+									ref={ref => (this.infiniteLoader = ref)}
+									isRowLoaded={isRowLoaded}
+									loadMoreRows={() => this.handleInfiniteLoad()}
+									rowCount={totalRecordCount || Infinity}
+									threshold={1}
+								>
+									{({ onRowsRendered, registerChild }) => (
+										<AutoSizer onResize={onResize}>
+											{({ height, width }) => {
+												return (
+													<List
+														ref={ref => {
+															registerChild(ref)
+															this.virtualizedList = ref
+														}}
+														className="record-selection__virtual-list"
+														deferredMeasurementCache={this.cache}
+														height={height}
+														width={width}
+														rowHeight={this.cache.rowHeight}
+														rowCount={loadedRecords.length}
+														rowRenderer={this.renderRow}
+														onRowsRendered={args => {
+															onRowsRendered(args)
+														}}
+														selectedIds={JSON.stringify(selectedIds)}
+													/>
+												)
+											}}
+										</AutoSizer>
+									)}
+								</InfiniteLoader>
+							</div>
+						)}
+					</Fragment>
 				) : (
-					<div
-						className="record-selection__list-wrapper"
-						// Only set listHeight if maxRowsVisible is not undefined or 'auto'
-						{...(typeof maxRowsVisible === 'number'
-							? { style: { height: `${listHeight}px` } }
-							: {})}
-					>
-						<InfiniteLoader
-							ref={ref => (this.infiniteLoader = ref)}
-							isRowLoaded={isRowLoaded}
-							loadMoreRows={() => this.handleInfiniteLoad()}
-							rowCount={totalRecordCount || Infinity}
-							threshold={1}
-						>
-							{({ onRowsRendered, registerChild }) => (
-								<AutoSizer onResize={onResize}>
-									{({ height, width }) => {
-										return (
-											<List
-												ref={ref => {
-													registerChild(ref)
-													this.virtualizedList = ref
-												}}
-												className="record-selection__virtual-list"
-												deferredMeasurementCache={this.cache}
-												height={height}
-												width={width}
-												rowHeight={this.cache.rowHeight}
-												rowCount={loadedRecords.length}
-												rowRenderer={this.renderRow}
-												onRowsRendered={args => {
-													onRowsRendered(args)
-												}}
-												selectedIds={JSON.stringify(selectedIds)}
-											/>
-										)
-									}}
-								</AutoSizer>
-							)}
-						</InfiniteLoader>
-					</div>
-				)}
-				{!isLoading && loadedRecords.length === 0 && (
-					<EmptyState headline="No records" {...emptyState} />
+					<Fragment>
+						{search ? (
+							<EmptyState
+								icon="no_matches"
+								headline="No search results"
+								{...noSearchResultsEmptyState}
+								primaryAction={{
+									text: 'Show all',
+									type: 'submit',
+									...get(noSearchResultsEmptyState, 'primaryAction', {}),
+									onClick: () => {
+										this.updateSearchValue('')
+									}
+								}}
+							/>
+						) : (
+							!isLoading && (
+								<EmptyState headline="No records" {...noDataEmptyState} />
+							)
+						)}
+					</Fragment>
 				)}
 			</div>
 		)
@@ -569,14 +599,14 @@ export default class RecordSelectionList extends Component<
 		return true
 	}
 
-	private handleSearchUpdate = async e => {
+	private updateSearchValue = async (value: string) => {
 		// Search will rapid-fire, but we only want to use the last result.
 		// If this value doesn't change by the time the API responds, we'll use
 		// that data to update the list!
 		const uniqueId = `${Math.random()}`
 
 		this.setState({
-			search: e.target.value,
+			search: value,
 			isLoading: true,
 			loadingId: uniqueId
 		})
@@ -584,7 +614,7 @@ export default class RecordSelectionList extends Component<
 		// When we search, we'll want to reset the list, so back to offset 0!
 		const newRows = await this.loadRecordsRequest({
 			offset: 0,
-			search: e.target.value
+			search: value
 		})
 
 		if (uniqueId === this.state.loadingId) {


### PR DESCRIPTION
- Need a separate prop for the filtered empty state, since it needs the "show all" field, which taps into internal methods to clear the search.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2110](https://sprucelabsai.atlassian.net/browse/SDEV3-2110)