### PR TITLE
[SDEV3-2060] Make "graphql" a dependency in spruce-skill

### DIFF
--- a/packages/spruce-skill/package.json
+++ b/packages/spruce-skill/package.json
@@ -54,6 +54,7 @@
 		"enzyme-to-json": "^3.3.1",
 		"flow-node": "^1.2.3",
 		"globby": "^8.0.1",
+		"graphql": "^14.2.0",
 		"graphql-parse-fields": "^1.2.0",
 		"graphql-relay": "^0.5.5",
 		"graphql-sequelize": "^9.2.0",
@@ -103,9 +104,6 @@
 		"sqlite3": "^4.0.4",
 		"supertest": "^3.3.0",
 		"svgo": "^1.0.3"
-	},
-	"peerDependencies": {
-		"graphql": "^14.2.0"
 	},
 	"gitHead": "eac8d4ea6df58218b78c9c866b22c761df1e6447"
 }


### PR DESCRIPTION
## What does this PR do?

Moves `graphql` to a dependency in `spruce-skill` and keeps it as a `peerDependency` in other skills kit packages

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2060](https://sprucelabsai.atlassian.net/browse/SDEV3-2060)