### PR TITLE
Hotfix: types for ListWrapper

### DIFF
--- a/packages/react-heartwood-components/src/components/List/List.tsx
+++ b/packages/react-heartwood-components/src/components/List/List.tsx
@@ -6,9 +6,9 @@ import ListHeader, {
 import ListItem, { IListItemProps } from './components/ListItem/ListItem'
 import ExpandableListItem from './components/ExpandableListItem/ExpandableListItem'
 
-export const ListWrapper = (props: {
-	children: React.ReactElement
-}): React.ReactElement => <div className="list-wrapper">{props.children}</div>
+export const ListWrapper = (props): React.ReactElement => (
+	<div className="list-wrapper">{props.children}</div>
+)
 
 export interface IWrappedItemProps extends IListItemProps {
 	/** Optional; Set true to render an expandable item */


### PR DESCRIPTION
Hotfix, oversight in the types of List. Need before upgrading core, will merge once tests run.