### PR TITLE
fix(TextInput): Correct type for helper

### DIFF
--- a/packages/react-heartwood-components/src/components/Forms/components/TextInput/TextInput.tsx
+++ b/packages/react-heartwood-components/src/components/Forms/components/TextInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 import cx from 'classnames'
 import { InputPre, InputInner, InputHelper } from '../../FormPartials'
 
@@ -31,7 +31,7 @@ interface ITextInputProps extends React.HTMLProps<HTMLInputElement> {
 	error?: string
 
 	/** Helper text */
-	helper?: string | Node
+	helper?: string | ReactNode
 
 	/** Set true to make the input less tall */
 	isSmall?: boolean


### PR DESCRIPTION
- Should be `ReactNode`, not DOM `Node`.