### PR TITLE
fix(CI): Cache yarn packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,17 @@ jobs:
             - 'ec:9f:2e:aa:1f:c9:ab:49:57:8f:c0:cd:2e:5b:f3:b0'
       - checkout
       - run: node -v && npm -v
+      - restore_cache:
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn lint
       - run: yarn test
+      - save_cache:
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
   pre_release:
     docker:
       - image: circleci/python:3-node
@@ -24,6 +31,9 @@ jobs:
       - run: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
       - run: node -v && npm -v && aws --version
       - checkout
+      - restore_cache:
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: git config --global user.email "$GIT_AUTHOR_EMAIL"
@@ -45,6 +55,9 @@ jobs:
       - run: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
       - run: node -v && npm -v && aws --version
       - checkout
+      - restore_cache:
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: git config --global user.email "$GIT_AUTHOR_EMAIL"
@@ -69,6 +82,9 @@ jobs:
       - run: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
       - run: node -v && npm -v && aws --version
       - checkout
+      - restore_cache:
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: git config --global user.email "$GIT_AUTHOR_EMAIL"
@@ -92,6 +108,9 @@ jobs:
       - run: echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
       - run: node -v && npm -v && aws --version
       - checkout
+      - restore_cache:
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: git config --global user.email "$GIT_AUTHOR_EMAIL"


### PR DESCRIPTION
- Only need to update the cache for `test`, since that's a prerequisite 
for the others.
- This has been working fine for months in ai-web, and can hopefully 
speed up our builds in workspace as well.

## Type

- [ ] Feature
- [ ] Bug
- [x] Tech debt