### PR TITLE
fix: Sidebar links

### DIFF
--- a/packages/react-heartwood-components/src/components/Core/components/FooterPrimary/components/Legal/Legal.js
+++ b/packages/react-heartwood-components/src/components/Core/components/FooterPrimary/components/Legal/Legal.js
@@ -16,7 +16,7 @@ const Legal = (props: Props) => {
 		<Fragment>
 			<p className={className}>
 				<a
-					href="#"
+					href="/terms-of-service"
 					target="_blank"
 					rel="noopener noreferrer"
 					className={linkClassName}
@@ -24,7 +24,7 @@ const Legal = (props: Props) => {
 					{`Terms of Service`}
 				</a>
 				<a
-					href="#"
+					href="/privacy-policy"
 					target="_blank"
 					rel="noopener noreferrer"
 					className={linkClassName}

--- a/packages/react-heartwood-components/src/components/Core/components/Sidebar/components/SidebarFooter/SidebarFooter.js
+++ b/packages/react-heartwood-components/src/components/Core/components/Sidebar/components/SidebarFooter/SidebarFooter.js
@@ -1,18 +1,9 @@
 // @flow
 import React from 'react'
-import { HelpButton, Legal } from '../../../FooterPrimary'
+import { Legal } from '../../../FooterPrimary'
 
 const SidebarFooter = () => (
 	<div className="sidebar__footer">
-		<div className="sidebar-item">
-			<div className="sidebar-item__inner">
-				<HelpButton
-					className="sidebar-item__link"
-					iconClassName="sidebar-item__icon sidebar-item__line-icon"
-					textClassName="sidebar-item__text"
-				/>
-			</div>
-		</div>
 		<Legal
 			className="sidebar__footer-text"
 			linkClassName="sidebar__footer-link"


### PR DESCRIPTION
## What does this PR do?

Takes the "help" button out of the main sidebar and updates the privacy policy and terms links to point to the right place when used in core.

I realize this should go much further, e.g. converting the components to TS, moving them into core, but didn't want to slow us down given timing.

## Type

- [ ] Feature
- [ ] Bug
- [x] Tech debt

## What are the relevant tickets?

- [SDEV3-#](https://sprucelabsai.atlassian.net/browse/SDEV3-#)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

## Screenshots (if appropriate)

## What gif best describes this PR or how it makes you feel?