### PR TITLE
[SDEV3-2151] Autosuggest Icon

### DIFF
--- a/packages/heartwood-components/components/02-forms/text-input.scss
+++ b/packages/heartwood-components/components/02-forms/text-input.scss
@@ -64,7 +64,8 @@ select:-webkit-autofill:focus {
 	opacity: 0.7;
 }
 
-.text-input__icon-pre ~ .text-input__input {
+.text-input__icon-pre ~ .text-input__input,
+.text-input__input.text-input__inner--has-icon {
 	padding-left: spacing('extra-loose');
 }
 

--- a/packages/react-heartwood-components/src/components/Forms/Forms-story.js
+++ b/packages/react-heartwood-components/src/components/Forms/Forms-story.js
@@ -98,6 +98,37 @@ stories
 			}}
 		/>
 	))
+	.add('Autosuggest Search', () => (
+		<Autosuggest
+			alwaysRenderSuggestions={false}
+			placeholder={text('placeholder', 'Search countries…')}
+			defaultSuggestions={object('defaultSuggestions', countries)}
+			shouldRenderSuggestions={() => true}
+			renderSuggestion={renderSuggestion}
+			getSuggestionValue={value => value.text}
+			getSuggestions={value => {
+				const results = countries.filter(
+					suggestion =>
+						suggestion.text.toLowerCase().slice(0, value.length) ===
+						value.toLowerCase()
+				)
+				// Here you could add click events to buttons or whatever else they need
+				// No Results Message
+				if (results.length === 0) {
+					return [
+						{
+							text: 'NO RESULTS',
+							isEmptyMessage: true
+						}
+					]
+				}
+				return results
+			}}
+			icon={{
+				icon: 'search'
+			}}
+		/>
+	))
 	.add('Duration Input', () => (
 		<DurationInput
 			label={stringify('label', 'Duration')}

--- a/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.tsx
+++ b/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.tsx
@@ -4,6 +4,7 @@ import debounce from 'lodash/debounce'
 import { default as ReactAutosuggest } from 'react-autosuggest'
 import cx from 'classnames'
 import Button from '../../../Button/Button'
+import Icon, { IIconProps } from '../../../Icon/Icon'
 import { InputPre, InputHelper } from '../../FormPartials'
 import ClearIcon from '../../../../../static/assets/icons/ic_cancel.svg'
 
@@ -58,6 +59,9 @@ export interface IAutosuggestInterfaceProps {
 
 	/** disable this input */
 	disabled?: boolean
+
+	/** Optional; adds an icon to the beginning of the text input */
+	icon?: IIconProps
 }
 
 interface IAutosuggestInterfaceState {
@@ -73,13 +77,16 @@ interface IAutosuggestInterfaceState {
 
 interface IThemeProps {
 	isSmall?: boolean
+	hasIcon?: boolean
 }
 
 const theme = (props: IThemeProps): any => ({
 	container: cx('text-input', {
 		'text-input-small': props.isSmall
 	}),
-	input: 'text-input__inner text-input__input',
+	input: cx('text-input__inner text-input__input', {
+		'text-input__inner--has-icon': props.hasIcon
+	}),
 	suggestionsContainer: 'autosuggest',
 	suggestionsContainerOpen: 'autosuggest--show-suggestions',
 	suggestionsList: 'autosuggest__list',
@@ -137,6 +144,7 @@ export default class Autosuggest extends Component<
 			showClearButton,
 			containerPlacement
 		} = this.state
+
 		const {
 			getSuggestionValue,
 			renderSuggestion,
@@ -152,6 +160,7 @@ export default class Autosuggest extends Component<
 			inputProps: originalInputProps = {},
 			className,
 			disabled,
+			icon,
 			...rest
 		} = this.props
 
@@ -201,7 +210,7 @@ export default class Autosuggest extends Component<
 						}}
 						onSuggestionSelected={onSuggestionSelected}
 						inputProps={inputProps}
-						theme={theme({ isSmall })}
+						theme={theme({ isSmall, hasIcon: icon })}
 						{...rest}
 					/>
 					{showClearButton && (
@@ -215,6 +224,7 @@ export default class Autosuggest extends Component<
 							onClick={this.handleClearInput}
 						/>
 					)}
+					{icon && <Icon {...icon} className="text-input__icon-pre" />}
 				</div>
 				{(helper || error) && <InputHelper helper={helper} error={error} />}
 			</div>

--- a/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.tsx
+++ b/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.tsx
@@ -210,7 +210,7 @@ export default class Autosuggest extends Component<
 						}}
 						onSuggestionSelected={onSuggestionSelected}
 						inputProps={inputProps}
-						theme={theme({ isSmall, hasIcon: icon })}
+						theme={theme({ isSmall, hasIcon: icon ? true : false })}
 						{...rest}
 					/>
 					{showClearButton && (

--- a/packages/react-heartwood-components/src/components/Table/components/TableSearch/TableSearch.tsx
+++ b/packages/react-heartwood-components/src/components/Table/components/TableSearch/TableSearch.tsx
@@ -11,7 +11,7 @@ const TableSearch = (props: ITableSearchProps): ReactElement => {
 
 	return (
 		<div className="table-search__wrapper">
-			<Autosuggest isSmall {...rest} />
+			<Autosuggest isSmall icon={{ icon: 'search' }} {...rest} />
 		</div>
 	)
 }


### PR DESCRIPTION
# What does this PR do?
Enables the `Autosuggest` to have an icon that it renders in the input. By default, there is no icon. Also updates `TableSearch` to always show the search icon in its input.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2151](https://sprucelabsai.atlassian.net/browse/SDEV3-2151)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)
No

## Screenshots (if appropriate)

## What gif best describes this PR or how it makes you feel?