### PR TITLE
DX - exclude build directories from vscode search/spotlight

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,13 +2,15 @@
 	"search.exclude": {
 		"**/node_modules": true,
 		"**/bower_components": true,
-		"**/.next": true
+		"**/.next": true,
+		"**/build/**": true
 	},
 	"git.ignoreLimitWarning": true,
 	"files.watcherExclude": {
 		"**/.git/objects/**": true,
 		"**/.git/subtree-cache/**": true,
-		"**/node_modules/**": true
+		"**/node_modules/**": true,
+		"**/build/**": true
 	},
 	"debug.node.autoAttach": "off",
 	"prettier.eslintIntegration": true,


### PR DESCRIPTION
## What does this PR do?

* Exclude `build/` directories from showing up in vscode file finder and search

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

N/A