### PR TITLE
fix(AutoSuggest): Allow helper/postLabel to both accept a node or a string

### DIFF
--- a/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.tsx
+++ b/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.tsx
@@ -37,13 +37,13 @@ export interface IAutosuggestInterfaceProps {
 	label?: string
 
 	/** Text after label */
-	postLabel?: string
+	postLabel?: string | React.ReactNode
 
 	/** Error text */
 	error?: string
 
 	/** Helper text */
-	helper?: string | Node
+	helper?: string | React.ReactNode
 
 	/** Set true to make the input less tall */
 	isSmall?: boolean


### PR DESCRIPTION
- ProfileUserLocation in Core supplies a node to postLabel, so that we can have a click handler to show permissions / style it as a link

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt
