### PR TITLE
[SDEV3-2165] Workspace should return valid card data

### DIFF
--- a/packages/spruce-skill-server/tests/CoreStartupTests.js
+++ b/packages/spruce-skill-server/tests/CoreStartupTests.js
@@ -1,0 +1,25 @@
+const assert = require('chai').assert
+const SpruceTest = require('./SpruceTest')
+const config = require('config')
+
+class CoreStartupTests extends SpruceTest(`${__dirname}/../../spruce-skill/`) {
+	setup() {
+		it('Loads services', () => this.loadsServices())
+	}
+
+	async loadsServices() {
+		assert.isOk(this.ctx.services)
+		assert.isOk(this.ctx.services.acl)
+		assert.isOk(this.ctx.services.cache)
+		assert.isOk(this.ctx.services.cards)
+		assert.isOk(this.ctx.services.mock)
+		assert.isOk(this.ctx.services.onboarding)
+		assert.isOk(this.ctx.services.sample)
+		assert.isOk(this.ctx.services.uploads)
+	}
+}
+
+describe('CoreStartupTests', function Tests() {
+	this.timeout(30000)
+	new CoreStartupTests()
+})

--- a/packages/spruce-skill/server/services/cards.js
+++ b/packages/spruce-skill/server/services/cards.js
@@ -1,4 +1,4 @@
-const dashboardUserCards = require('./dashboardUserCards')
+const dashboardUserCards = require('./cards/dashboardUserCards')
 
 const pages = {
 	dashboard_user: dashboardUserCards,

--- a/packages/spruce-skill/server/services/cards/dashboardUserCards.js
+++ b/packages/spruce-skill/server/services/cards/dashboardUserCards.js
@@ -522,6 +522,7 @@ const congratsCard: CardBuilder = {
 					'https://images.unsplash.com/photo-1513151233558-d860c5398176?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=6b2b3eeca79a80926667ec71b01eac12&auto=format&fit=crop&w=1000&q=80'
 			},
 			{
+				type: 'text',
 				key: '002',
 				text:
 					"I've learned that people will forget what you said, people will forget what you did, but people will never forget how you made them feel."


### PR DESCRIPTION
## What does this PR do?

* Fixes card service not getting loaded

* Fix example data so it's valid and renders cards in HW web properly

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2165](https://sprucelabsai.atlassian.net/browse/SDEV3-2165)