### PR TITLE
fix(RecordTable): Add loader when loading w/ no records [SDEV3-2215]

### DIFF
--- a/packages/heartwood-components/components/03-structure/table.scss
+++ b/packages/heartwood-components/components/03-structure/table.scss
@@ -1,4 +1,3 @@
-
 $easeOutBounce: cubic-bezier(0.6, 0.6, 0.7, 1.4);
 $expandDuration: 0.2s;
 
@@ -35,6 +34,10 @@ $expandDuration: 0.2s;
 	overflow: auto;
 }
 
+.table__inner__loader {
+	margin-top: 100px;
+}
+
 .table-row,
 .table-header-row {
 	display: flex;
@@ -52,7 +55,9 @@ $expandDuration: 0.2s;
 .table-row-group {
 	background-color: $c-white;
 	border-left-color: transparent;
-	transition: background-color $expandDuration ease-out, border-left-width 0.1s ease-out, border-left-color $expandDuration $easeOutBounce 0.1s;
+	transition: background-color $expandDuration ease-out,
+		border-left-width 0.1s ease-out,
+		border-left-color $expandDuration $easeOutBounce 0.1s;
 }
 
 .table-row-group.table-row-group--is-dirty {
@@ -61,7 +66,7 @@ $expandDuration: 0.2s;
 
 .table-row-group.table-row-group--expanded {
 	background-color: rgba($c-primary-light, 0.05);
-	
+
 	> .table-row {
 		border-bottom: none;
 	}
@@ -82,15 +87,14 @@ $expandDuration: 0.2s;
 	}
 }
 
-
-
 .table-subcomponent {
 	padding: 0 spacing('loose') spacing('loose');
 
 	.card {
 		opacity: 0;
 		transform: translate(0, 0.5rem);
-		transition: opacity $expandDuration ease-out 0.05s, transform $expandDuration $easeOutBounce;;
+		transition: opacity $expandDuration ease-out 0.05s,
+			transform $expandDuration $easeOutBounce;
 	}
 }
 

--- a/packages/react-heartwood-components/src/components/RecordTable/RecordTable-story.tsx
+++ b/packages/react-heartwood-components/src/components/RecordTable/RecordTable-story.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { filter, orderBy } from 'lodash'
 import { storiesOf } from '@storybook/react'
-import { withKnobs } from '@storybook/addon-knobs/react'
+import { withKnobs, number } from '@storybook/addon-knobs/react'
 
 import RecordTable, {
 	IRecordTableFetchOptions,
@@ -58,10 +58,18 @@ stories.add('Basic RecordTable', () => {
 		sortDirection: 'ASC'
 	})
 
+	const timeout = number('API Simulated Timeout (MS)', 50)
+
 	return (
 		<div>
 			<RecordTable
-				fetchRecords={async options => syncFetchRecords(options)}
+				fetchRecords={async options => {
+					await new Promise(resolve => {
+						setTimeout(resolve, timeout)
+					})
+
+					return syncFetchRecords(options)
+				}}
 				enableFilter={true}
 				searchPlaceholder={'Search groups...'}
 				fetchError={false}

--- a/packages/react-heartwood-components/src/components/RecordTable/RecordTable.tsx
+++ b/packages/react-heartwood-components/src/components/RecordTable/RecordTable.tsx
@@ -7,6 +7,8 @@ import {
 import Tabs from '../Tabs'
 import { TextInput } from '../Forms'
 import Button from '../Button/Button'
+import EmptyState from '../EmptyState/EmptyState'
+import Loader from '../Loader/Loader'
 
 const RECORD_TABLE_INITIAL_LIMIT = 10
 
@@ -359,6 +361,15 @@ class RecordTable extends Component<IRecordTableProps, IRecordTableState> {
 					onSortedChange={this.handleSortChanged}
 					onClickRow={handleClickRow}
 					key="id"
+					NoDataComponent={
+						loading && !currentFilter
+							? () => (
+									<div className="table__inner__loader">
+										<Loader />
+									</div>
+							  )
+							: EmptyState
+					}
 					getNoDataProps={() => ({
 						icon: this.getNoDataIcon(),
 						headline: this.getNoDataHeadline(),


### PR DESCRIPTION
- With a bit of latency, the table will flash the "no data" empty state if loading w/ no records. This happens if you add a filter that results in no records, then delete it.
- Added a latency simulator to the basic story to test this out.

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2215](https://sprucelabsai.atlassian.net/browse/SDEV3-2215)