### PR TITLE
[SDEV3-2280] friendly Error

### DIFF
--- a/packages/spruce-utils/lib/errors.js
+++ b/packages/spruce-utils/lib/errors.js
@@ -5,7 +5,6 @@ function SpruceWebError(message = '', data) {
 	this.message = `${this.name} :: ${message}`
 	this.data = data
 	this.stack = new Error().stack
-	this.friendlyReason = data && data.friendlyReason
 }
 
 SpruceWebError.prototype = new Error()

--- a/packages/spruce-utils/lib/errors.js
+++ b/packages/spruce-utils/lib/errors.js
@@ -5,6 +5,7 @@ function SpruceWebError(message = '', data) {
 	this.message = `${this.name} :: ${message}`
 	this.data = data
 	this.stack = new Error().stack
+	this.friendlyReason = data && data.friendlyReason
 }
 
 SpruceWebError.prototype = new Error()

--- a/packages/spruce-utils/lib/graphql.js
+++ b/packages/spruce-utils/lib/graphql.js
@@ -206,7 +206,7 @@ export class GraphQLClient {
 					{
 						friendlyReasons:
 							errors &&
-							errors[0]
+							errors
 								.filter(error => !!error.friendlyReason)
 								.map(error => error.friendlyReason),
 						originalError: e,

--- a/packages/spruce-utils/lib/graphql.js
+++ b/packages/spruce-utils/lib/graphql.js
@@ -204,7 +204,11 @@ export class GraphQLClient {
 						'/'
 					)}). Reasons: [${errors.map(error => error.reason).join(', ')}]`,
 					{
-						friendlyReason: errors && errors[0] && errors[0].friendlyReason,
+						friendlyReasons:
+							errors &&
+							errors[0]
+								.filter(error => !!error.friendlyReason)
+								.map(error => error.friendlyReason),
 						originalError: e,
 						gqlDocumentBody,
 						variables: options.variables

--- a/packages/spruce-utils/lib/graphql.js
+++ b/packages/spruce-utils/lib/graphql.js
@@ -204,11 +204,9 @@ export class GraphQLClient {
 						'/'
 					)}). Reasons: [${errors.map(error => error.reason).join(', ')}]`,
 					{
-						friendlyReasons:
-							errors &&
-							errors
-								.filter(error => !!error.friendlyReason)
-								.map(error => error.friendlyReason),
+						friendlyReasons: errors
+							.filter(error => !!error.friendlyReason)
+							.map(error => error.friendlyReason),
 						originalError: e,
 						gqlDocumentBody,
 						variables: options.variables

--- a/packages/spruce-utils/lib/graphql.js
+++ b/packages/spruce-utils/lib/graphql.js
@@ -204,9 +204,7 @@ export class GraphQLClient {
 						'/'
 					)}). Reasons: [${errors.map(error => error.reason).join(', ')}]`,
 					{
-						friendlyReasons: errors
-							.filter(error => !!error.friendlyReason)
-							.map(error => error.friendlyReason),
+						friendlyReasons: errors.map(error => error.friendlyReason),
 						originalError: e,
 						gqlDocumentBody,
 						variables: options.variables

--- a/packages/spruce-utils/lib/graphql.js
+++ b/packages/spruce-utils/lib/graphql.js
@@ -197,7 +197,6 @@ export class GraphQLClient {
 			if (e.networkError || e.graphQLErrors) {
 				const graphQLErrors = get(e, 'graphQLErrors', [])
 				const networkErrors = get(e, 'networkError.result.errors', [])
-
 				const errors = networkErrors.concat(graphQLErrors)
 
 				throw new SpruceWebError(
@@ -205,6 +204,7 @@ export class GraphQLClient {
 						'/'
 					)}). Reasons: [${errors.map(error => error.reason).join(', ')}]`,
 					{
+						friendlyReason: errors && errors[0] && errors[0].friendlyReason,
 						originalError: e,
 						gqlDocumentBody,
 						variables: options.variables

--- a/packages/spruce-utils/lib/graphql.js
+++ b/packages/spruce-utils/lib/graphql.js
@@ -204,6 +204,7 @@ export class GraphQLClient {
 						'/'
 					)}). Reasons: [${errors.map(error => error.reason).join(', ')}]`,
 					{
+						reasons: errors.map(error => error.reasons),
 						friendlyReasons: errors.map(error => error.friendlyReason),
 						originalError: e,
 						gqlDocumentBody,


### PR DESCRIPTION
## What does this PR do?

SpruceWebError supports`friendlyReason` and graphql now sets it when available on the first error returned.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2280](https://sprucelabsai.atlassian.net/browse/SDEV3-2280)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

NA

## Screenshots (if appropriate)

NA

## What gif best describes this PR or how it makes you feel?

NA