### PR TITLE
fix(lint): Get TS(X) in workspace linted correctly

### DIFF
--- a/packages/eslint-config-spruce/package.json
+++ b/packages/eslint-config-spruce/package.json
@@ -19,6 +19,7 @@
 	},
 	"dependencies": {
 		"@typescript-eslint/eslint-plugin": "1.13.0",
+		"@typescript-eslint/parser": "1.13.0",
 		"babel-eslint": "10.0.1",
 		"eslint-config-prettier": "4.1.0",
 		"eslint-plugin-flowtype": "3.4.2",

--- a/packages/react-heartwood-components/package.json
+++ b/packages/react-heartwood-components/package.json
@@ -23,7 +23,7 @@
 		"compile_javascript": "babel --source-maps --extensions \".js\",\".tsx\" ./src --out-dir ./lib && tsc --declaration --outDir lib/ --emitDeclarationOnly --declarationMap",
 		"icons": "node ./scripts/generateIcons.js",
 		"clean": "rm -rf lib/*",
-		"lint": "eslint src",
+		"lint": "eslint --max-warnings=0 --ext=.js,.jsx,.ts,.tsx src && tsc -p . --noEmit",
 		"test": "jest",
 		"watch": "npm run build && chokidar 'src/**/*.(js|jsx|ts|tsx)' -c 'npm run compile_javascript'",
 		"storybook": "npm run icons && start-storybook -p 6006 -s ./static",

--- a/packages/react-heartwood-components/src/components/Button/Button.tsx
+++ b/packages/react-heartwood-components/src/components/Button/Button.tsx
@@ -120,7 +120,7 @@ const Button = (props: IButtonProps): React.ReactElement => {
 								isLineIcon={icon.isLineIcon}
 								className={cx(
 									{
-										btn__icon: true,
+										['btn__icon']: true,
 										'btn__line-icon': icon.isLineIcon
 									},
 									icon.className

--- a/packages/react-heartwood-components/src/components/Core/components/Sidebar/components/SidebarHeader/SidebarHeader.tsx
+++ b/packages/react-heartwood-components/src/components/Core/components/Sidebar/components/SidebarHeader/SidebarHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import SidebarSection from '../SidebarSection/SidebarSection'
-import Button, { IButtonProps } from '../../../../../Button/Button'
+import Button from '../../../../../Button/Button'
 import Text from '../../../../../Text/Text'
 
 interface ISidebarHeaderProps {

--- a/packages/react-heartwood-components/src/components/TruncatedList/TruncatedList.tsx
+++ b/packages/react-heartwood-components/src/components/TruncatedList/TruncatedList.tsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component, Fragment, ReactElement } from 'react'
 import cx from 'classnames'
 
 import Button from '../Button/Button'
@@ -59,14 +59,14 @@ export default class TruncatedList extends Component<
 	ITruncatedListProps,
 	ITruncatedListState
 > {
-	recordSelectionListRef: React.RefObject<RecordSelectionList>
-
 	public static defaultProps = {
 		isTruncated: false,
 		canRemove: false,
 		recordSelectionListItems: [],
 		noItemsText: 'Nothing to see here.'
 	}
+
+	private recordSelectionListRef: React.RefObject<RecordSelectionList>
 
 	public constructor(props: ITruncatedListProps) {
 		super(props)
@@ -80,7 +80,7 @@ export default class TruncatedList extends Component<
 		}
 	}
 
-	public render() {
+	public render(): ReactElement {
 		const {
 			className,
 			header,

--- a/packages/spruce-skill/interface/components/ExampleCard/ExampleCard-story.tsx
+++ b/packages/spruce-skill/interface/components/ExampleCard/ExampleCard-story.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withKnobs, text } from '@storybook/addon-knobs/react'
 

--- a/packages/spruce-skill/interface/components/ExampleCard/index.tsx
+++ b/packages/spruce-skill/interface/components/ExampleCard/index.tsx
@@ -3,7 +3,6 @@ import {
 	Card,
 	CardHeader,
 	CardBody,
-	CardFooter,
 	Text
 } from '@sprucelabs/react-heartwood-components'
 

--- a/packages/spruce-skill/package.json
+++ b/packages/spruce-skill/package.json
@@ -25,7 +25,7 @@
 		"local": "nodemon ./server/server.js --exec \"npm run kill-inspect && flow-node --inspect=4080\" --watch server --watch config --verbose --ignore server/swagger --ignore server/static",
 		"kill-inspect": "kill-port 4080",
 		"interface": "next ./interface -p 3080",
-		"lint": "eslint --ext .js .",
+		"lint": "eslint --max-warnings=0 --ext=.js,.jsx,.ts,.tsx . && tsc -p . --noEmit",
 		"test": "yarn run build && jest",
 		"test:server": "rm tmp/testing.db | true && mkdir -p tmp/ | true && PORT=3010 BLUEBIRD_W_FORGOTTEN_RETURN=0 ALLOW_NON_SSL=true ORM_LOGGING=false TESTING=true API_ONLY=true DB_MIGRATIONS=false mocha -r flow-remove-types/register --exit 'server/tests/**/*Tests.js'",
 		"test:server:single": "rm tmp/testing.db | true && mkdir -p tmp/ | true && PORT=3010 BLUEBIRD_W_FORGOTTEN_RETURN=0 ALLOW_NON_SSL=true ORM_LOGGING=false TESTING=true API_ONLY=true DB_MIGRATIONS=false mocha -r flow-remove-types/register --exit",

--- a/packages/spruce-skill/tsconfig.json
+++ b/packages/spruce-skill/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"compilerOptions": {
+		"target": "es6",
+		"jsx": "react",
+		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true
+	},
+	"exclude": ["node_modules", "lib"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,6 +3494,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -3612,6 +3617,16 @@
     "@types/json-schema" "^7.0.3"
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-scope "^4.0.0"
+
+"@typescript-eslint/parser@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.13.0.tgz#61ac7811ea52791c47dc9fd4dd4a184fae9ac355"
+  integrity sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "1.13.0"
+    "@typescript-eslint/typescript-estree" "1.13.0"
+    eslint-visitor-keys "^1.0.0"
 
 "@typescript-eslint/typescript-estree@1.13.0":
   version "1.13.0"


### PR DESCRIPTION
- We weren't actually checking TS files, nor running `tsc` during lint.
- Added tsconfig for react-heartwood.

## Type

- [ ] Feature
- [x] Bug
- [x] Tech debt