### PR TITLE
[SDEV3-2361] Send eventContract and acl as stringified json

### DIFF
--- a/packages/spruce-node/index.ts
+++ b/packages/spruce-node/index.ts
@@ -219,10 +219,10 @@ export default class Sprucebot {
 					webhookUrl: this.webhookUrl,
 					iframeUrl: this.iframeUrl,
 					marketingUrl: this.marketingUrl,
-					eventContract: this.eventContract,
+					eventContract: JSON.stringify(this.eventContract),
 					version: this.version,
 					skillsKitVersion: this.skillsKitVersion,
-					acl: this.acl,
+					acl: JSON.stringify(this.acl),
 					viewVersion: this.viewVersion,
 					useDB: this.dbEnabled
 				}

--- a/packages/spruce-skill-server/package.json
+++ b/packages/spruce-skill-server/package.json
@@ -66,6 +66,7 @@
 	},
 	"peerDependencies": {
 		"graphql": "^14.2.0",
+		"supertest": "^3.0.0",
 		"sqlite3": "^4.0.4",
 		"typescript": "~3.4.5"
 	},

--- a/packages/spruce-skill/package.json
+++ b/packages/spruce-skill/package.json
@@ -80,6 +80,7 @@
 		"slug": "^0.9.3",
 		"subscriptions-transport-ws": "^0.9.15",
 		"superagent": "^4.1.0",
+		"supertest": "^3.3.0",
 		"swagger-jsdoc": "^3.0.2",
 		"typescript": "~3.4.5",
 		"universal-cookie": "^2.1.0"
@@ -118,7 +119,6 @@
 		"react-docgen-typescript-loader": "^3.1.1",
 		"semantic-release": "16.0.0-beta.22",
 		"sqlite3": "^4.0.4",
-		"supertest": "^3.3.0",
 		"svgo": "^1.0.3",
 		"ts-node": "^8.0.2",
 		"ts-node-dev": "^1.0.0-pre.32",


### PR DESCRIPTION
## What does this PR do?

Keeps backwards compatibility w/ API sync by sending `eventContract` and `acl` as stringified json

Accepting input as JSON is possible but breaks compatibility so we'll need to evaluate if/how we introduce that: https://github.com/sprucelabsai/com-sprucebot-api/pull/598

A union would have been ideal but unfortunately GQL doesn't yet support input union types: https://github.com/graphql/graphql-spec/issues/488

Also, fixes issue where `supertest` needs to be in `dependencies` and not `devDependencies`

## Type

- [ ] Feature
- [ ] Bug
- [X] Tech debt

## What are the relevant tickets?

- [SDEV3-2361](https://sprucelabsai.atlassian.net/browse/SDEV3-2361)