### PR TITLE
fix(Text): Update types to allow arbitrary HTML props

### DIFF
--- a/packages/react-heartwood-components/src/components/Text/Text-story.tsx
+++ b/packages/react-heartwood-components/src/components/Text/Text-story.tsx
@@ -1,13 +1,12 @@
-// @flow
-import React from 'react'
+import React, { Fragment } from 'react'
 import { storiesOf } from '@storybook/react'
 import { withKnobs, text, select, object } from '@storybook/addon-knobs/react'
-import Text, { Span } from './Text'
+import Text, { Span, ITextProps } from './Text'
 const stories = storiesOf('Text', module)
 
 stories.addDecorator(withKnobs)
 
-const options = [
+const options: ITextProps['element'][] = [
 	'a',
 	'abbr',
 	'blockquote',
@@ -20,7 +19,6 @@ const options = [
 	'dt',
 	'figcaption',
 	'figure',
-	'kbd',
 	'li',
 	'mark',
 	'ol',
@@ -38,7 +36,7 @@ const options = [
 stories
 	.add('Text', () => (
 		<Text
-			element={select('Element', options, 'p')}
+			element={select<ITextProps['element']>('Element', options, 'p')}
 			context={object('Context', {
 				planet: {
 					text: 'World!',
@@ -54,6 +52,13 @@ stories
 		>
 			{text('children', 'Hello, {{planet}}! {{link}}')}
 		</Text>
+	))
+	.add('Text - Specific Examples', () => (
+		<Fragment>
+			<Text element={'a'} href={'http://www.google.com'}>
+				Google
+			</Text>
+		</Fragment>
 	))
 	.add('Span', () => (
 		<Span

--- a/packages/react-heartwood-components/src/components/Text/Text.tsx
+++ b/packages/react-heartwood-components/src/components/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactNode, ReactElement } from 'react'
+import React, { Fragment, ReactNode, HTMLProps } from 'react'
 import cx from 'classnames'
 
 import Button from '../Button/Button'
@@ -56,7 +56,7 @@ const TemplateEngine = (text = '', context = {}): ReactNode[] => {
 	return children.map(renderText)
 }
 
-export interface ITextProps {
+export interface ITextProps extends HTMLProps<HTMLElement> {
 	/** Contents of the component. */
 	children: ReactNode
 


### PR DESCRIPTION
- Added a trivial example in the stories just to validate the issue. This was happening in ai-web after I upgraded; `href` wasn't in props so it was failing TSC checks there.