### PR TITLE
[SDEV3-2361] Update gql helper types

### DIFF
--- a/packages/spruce-skill-server/gql/helpers.ts
+++ b/packages/spruce-skill-server/gql/helpers.ts
@@ -4,7 +4,7 @@ import { ISpruceContext } from '../interfaces/ctx'
 import parseFields from 'graphql-parse-fields'
 import Debug from 'debug'
 
-import { GraphQLInt, GraphQLResolveInfo } from 'graphql'
+import { GraphQLInt, GraphQLResolveInfo, GraphQLObjectType } from 'graphql'
 import {
 	resolver,
 	attributeFields,
@@ -20,8 +20,44 @@ import config from 'config'
 
 import { has } from 'lodash'
 import SpruceCoreModel from '../lib/SpruceModel'
+import { FindOptions } from 'sequelize'
 
 const debug = Debug('spruce-skill-server')
+
+type SpruceCoreModelType = typeof SpruceCoreModel
+
+export interface ISpruceGQLHelpers {
+	attributes(model: SpruceCoreModelType, options?: Record<string, any>): any
+
+	enhancedResolver(
+		/** The model. For example ctx.db.models.User */
+		model: SpruceCoreModel<any>,
+		options?: Record<string, any>,
+		scope?: string
+	): IResolverLikeFunction<any, any>
+
+	buildConnection(options: {
+		/** Name your connection. This must be unique */
+		name?: string
+		/** The model you're connecting. For example ctx.db.models.User */
+		model: SpruceCoreModelType
+		associationName: string
+		type: GraphQLObjectType
+		connectionOptions: {
+			before?: (
+				findOptions: FindOptions,
+				args: Record<string, any>,
+				context: any
+			) => Promise<FindOptions>
+			// TODO: Define after
+			// after?: (
+			// 	findOptions: FindOptions,
+			// 	args: Record<string, any>,
+			// 	context: any
+			// ) => Promise<FindOptions>
+		}
+	}): any
+}
 
 export default (ctx: ISpruceContext) => {
 	// Get any custom connectionOptions and save for later when we're building connections

--- a/packages/spruce-skill-server/interfaces/ctx.ts
+++ b/packages/spruce-skill-server/interfaces/ctx.ts
@@ -33,6 +33,9 @@ export interface ISpruceContext<
 		helpers: {
 			attributes(model: SpruceCoreModelType, options?: Record<string, any>): any
 			buildConnection(options: {
+				/** Name your connection. This must be unique */
+				name?: string
+				/** The model you're connecting. For example ctx.db.models.User */
 				model: SpruceCoreModelType
 				associationName: string
 				type: GraphQLObjectType

--- a/packages/spruce-skill-server/interfaces/ctx.ts
+++ b/packages/spruce-skill-server/interfaces/ctx.ts
@@ -6,12 +6,8 @@ import { ISpruceServices } from './services'
 import { ISpruceUtilities } from './utilities'
 import { ISpruceAuth } from './auth'
 import { Sequelize } from 'sequelize/types'
-import SpruceCoreModel from '../lib/SpruceModel'
 import { ISpruceGQLTypes } from './gql'
-import { FindOptions } from 'sequelize'
-import { GraphQLObjectType } from 'graphql'
-
-type SpruceCoreModelType = typeof SpruceCoreModel
+import { ISpruceGQLHelpers } from '../gql/helpers'
 
 export interface ISpruceContext<
 	ISkillModels = ISpruceModels,
@@ -30,30 +26,7 @@ export interface ISpruceContext<
 	utilities: ISkillUtilities
 	gql: {
 		types: ISkillGQLTypes
-		helpers: {
-			attributes(model: SpruceCoreModelType, options?: Record<string, any>): any
-			buildConnection(options: {
-				/** Name your connection. This must be unique */
-				name?: string
-				/** The model you're connecting. For example ctx.db.models.User */
-				model: SpruceCoreModelType
-				associationName: string
-				type: GraphQLObjectType
-				connectionOptions: {
-					before?: (
-						findOptions: FindOptions,
-						args: Record<string, any>,
-						context: any
-					) => Promise<FindOptions>
-					// TODO: Define after
-					// after?: (
-					// 	findOptions: FindOptions,
-					// 	args: Record<string, any>,
-					// 	context: any
-					// ) => Promise<FindOptions>
-				}
-			}): any
-		}
+		helpers: ISpruceGQLHelpers
 	}
 }
 

--- a/packages/spruce-skill/package.json
+++ b/packages/spruce-skill/package.json
@@ -102,6 +102,7 @@
 		"@storybook/addon-links": "^5.1.10",
 		"@storybook/addons": "^5.1.10",
 		"@storybook/react": "^5.1.10",
+		"@types/chai": "^4.2.0",
 		"@types/config": "^0.0.34",
 		"@types/mocha": "^5.2.7",
 		"@types/storybook__addon-knobs": "^5.0.3",


### PR DESCRIPTION
## What does this PR do?

* Move GQL helper definition to helpers file and import the type for `ctx`

* Adds missing `enhancedResolver` gql helper definition

* Update `buildConnection` type to take optional `name`

## Type

- [ ] Feature
- [ ] Bug
- [X] Tech debt

## What are the relevant tickets?

- [SDEV3-2361](https://sprucelabsai.atlassian.net/browse/SDEV3-2361)