### PR TITLE
[SDEV-2361] Strong config types

### DIFF
--- a/packages/spruce-skill-server/config/default.ts
+++ b/packages/spruce-skill-server/config/default.ts
@@ -5,13 +5,28 @@
 import fs from 'fs'
 import baseErrors from './errors'
 
+export type SpruceAuth = (options: {
+	userId?: string
+	organizationId?: string
+	locationId?: string
+}) => string
+
+export interface ISpruceEventContract {
+	events: {
+		[eventName: string]: {
+			description: string
+			subscribe: boolean
+		}
+	}
+}
+
 export default function SpruceConfig<
 	aclType,
 	settingsType,
 	errorsType,
 	eventContractType,
 	scopesType,
-	authType
+	authType = SpruceAuth
 >(baseDirectory: string) {
 	const HEARTWOOD_VERSION = encodeURIComponent(
 		require('@sprucelabs/heartwood-components').version
@@ -143,7 +158,7 @@ export default function SpruceConfig<
 		 * This can not be changed after you register your skill. Changing this value
 		 * will NOT update your slug
 		 */
-		SLUG: process.env.SLUG,
+		SLUG: process.env.SLUG || '',
 		/**
 		 * 🌲🤖 Your Skill's description
 		 */

--- a/packages/spruce-skill-server/config/default.ts
+++ b/packages/spruce-skill-server/config/default.ts
@@ -234,6 +234,10 @@ export default function SpruceConfig<
 		 * 🌲🤖 Your skills package.json version
 		 */
 		PACKAGE_VERSION: packageJSON.version,
+		/**
+		 * Special internal skills might set this to true. Most skills can ignore this setting.
+		 */
+		GLOBAL: process.env.GLOBAL === 'true',
 		gqlOptions: {
 			gqlDir: `${baseDirectory}/gql`
 		},

--- a/packages/spruce-skill-server/controllers/events.ts
+++ b/packages/spruce-skill-server/controllers/events.ts
@@ -6,13 +6,13 @@ const debug = Debug('spruce-skill-server')
 export default (router: any, options: any) => {
 	const listenersByEventName = options.listenersByEventName
 
-	if (!config.get('EVENT_VERSION') || config.get('EVENT_VERSION') === 1) {
+	if (!config.EVENT_VERSION || config.EVENT_VERSION === 1) {
 		router.post('/hook.json', async (ctx: any, next: any) => {
 			// only fire if we are listening to this event
 			if (ctx.event) {
 				const eventName = ctx.event.name
 				// debug('Event listener firing', ctx.event.name)
-				if (config.get('LOG_EVENTS')) {
+				if (config.LOG_EVENTS) {
 					log.info(`(EVENT_VERSION=1) Received event '${eventName}'`, {
 						event: ctx.event
 					})
@@ -24,9 +24,9 @@ export default (router: any, options: any) => {
 					debug(
 						`(EVENT_VERSION=1) No listeners found for eventName: '${eventName}'`
 					)
-					if (config.get('LOG_EVENTS')) {
+					if (config.LOG_EVENTS) {
 						log.debug(
-							`(EVENT_VERSION=1) No listener found for event: '${eventName}'. Check that you have created the corresponding file in server/events/. If you don't need to respond to this event, remove it from your config.get('eventContract')`
+							`(EVENT_VERSION=1) No listener found for event: '${eventName}'. Check that you have created the corresponding file in server/events/. If you don't need to respond to this event, remove it from your config.eventContract`
 						)
 					}
 				}

--- a/packages/spruce-skill-server/factories/context.ts
+++ b/packages/spruce-skill-server/factories/context.ts
@@ -20,7 +20,8 @@ export default (dir: string, key: string, ctx: any) => {
 
 			const configKey = `${key}.${filename}`
 
-			const serviceConfig = config.has(configKey) ? config.get(configKey) : {}
+			// @ts-ignore: IConfig index
+			const serviceConfig = config[configKey] || {}
 
 			const m = require(match)
 			if (m.default) {

--- a/packages/spruce-skill-server/factories/context.ts
+++ b/packages/spruce-skill-server/factories/context.ts
@@ -20,7 +20,6 @@ export default (dir: string, key: string, ctx: any) => {
 
 			const configKey = `${key}.${filename}`
 
-			// @ts-ignore: IConfig index
 			const serviceConfig = config[configKey] || {}
 
 			const m = require(match)

--- a/packages/spruce-skill-server/gql/helpers.ts
+++ b/packages/spruce-skill-server/gql/helpers.ts
@@ -92,9 +92,7 @@ export interface ISpruceGQLHelpers {
 export default (ctx: ISpruceContext) => {
 	// Get any custom connectionOptions and save for later when we're building connections
 	const connectionPaths = globby.sync([
-		`${
-			config.get<Record<string, any>>(`gqlOptions`).gqlDir
-		}/connections/**/!(index|types|_helpers).js`
+		`${config.gqlOptions.gqlDir}/connections/**/!(index|types|_helpers).js`
 	])
 	const connections: Record<string, any> = {}
 

--- a/packages/spruce-skill-server/gql/router.ts
+++ b/packages/spruce-skill-server/gql/router.ts
@@ -22,6 +22,11 @@ const auth = async (
 	next: () => Promise<any>
 ): Promise<void> => {
 	try {
+		if (!config.API_KEY) {
+			throw new Error(
+				'"API_KEY" is not defined. Check your .env and/or environment variables.'
+			)
+		}
 		let token =
 			ctx.cookies.get('jwt') ||
 			ctx.request.headers['x-skill-jwt'] ||
@@ -38,7 +43,7 @@ const auth = async (
 		}
 		const decoded: Record<string, any> = jwt.verify(
 			token,
-			config.get<string>('API_KEY').toLowerCase()
+			config.API_KEY.toLowerCase()
 		) as Record<string, any>
 		const userId = decoded.userId
 		const locationId = decoded.locationId || null

--- a/packages/spruce-skill-server/gql/router.ts
+++ b/packages/spruce-skill-server/gql/router.ts
@@ -108,7 +108,7 @@ export default (
 			return {
 				schema: schema.gqlSchema,
 				context: ctx,
-				graphiql: config.get('GRAPHIQL_ENABLED'),
+				graphiql: config.GRAPHIQL_ENABLED,
 				formatError: (e: Error) => {
 					const code = e.message
 					let formattedError: Record<string, any> = {}
@@ -134,7 +134,7 @@ export default (
 						}
 					}
 
-					if (config.get('ENABLE_DEBUG_ROUTES')) {
+					if (config.ENABLE_DEBUG_ROUTES) {
 						formattedError.stack = e.stack && e.stack.split('\n')
 					}
 
@@ -142,14 +142,14 @@ export default (
 				},
 				validationRules: [
 					// Limits the depth of queries
-					depthLimit(config.get('GRAPHQL_MAX_DEPTH')),
+					depthLimit(config.GRAPHQL_MAX_DEPTH),
 					// Can limit based on query cost analysis
 					queryComplexity({
 						estimators: [
 							fieldConfigEstimator(),
 							simpleEstimator({ defaultComplexity: 1 })
 						],
-						maximumComplexity: config.get('GRAPHQL_MAX_COMPLEXITY'),
+						maximumComplexity: config.GRAPHQL_MAX_COMPLEXITY,
 						variables:
 							request.body && request.body.variables
 								? request.body.variables

--- a/packages/spruce-skill-server/interfaces/acls.ts
+++ b/packages/spruce-skill-server/interfaces/acls.ts
@@ -30,6 +30,7 @@ export interface ISpruceAcls {
 				teammate?: boolean
 				manager?: boolean
 				groupManager?: boolean
+				[key: string]: boolean | undefined
 			}
 		}
 	}

--- a/packages/spruce-skill-server/interfaces/config.ts
+++ b/packages/spruce-skill-server/interfaces/config.ts
@@ -8,5 +8,7 @@ import defaultConfig from '../config/default'
 type configType = ReturnType<typeof defaultConfig>
 
 declare module 'config' {
-	interface IConfig extends configType {}
+	interface IConfig extends configType {
+		[key: string]: any
+	}
 }

--- a/packages/spruce-skill-server/lib/GraphQLSubscription.ts
+++ b/packages/spruce-skill-server/lib/GraphQLSubscription.ts
@@ -66,8 +66,8 @@ export default class GraphQLSubscriptions {
 			{
 				reconnect: true,
 				connectionParams: {
-					'x-skill-id': config.get('ID'),
-					'x-skill-api-key': config.get('API_KEY')
+					'x-skill-id': config.ID,
+					'x-skill-api-key': config.API_KEY
 				}
 			},
 			ws

--- a/packages/spruce-skill-server/middleware/auth.ts
+++ b/packages/spruce-skill-server/middleware/auth.ts
@@ -1,5 +1,5 @@
 import jwt from 'jsonwebtoken'
-import { default as config } from 'config'
+import config from 'config'
 import Debug from 'debug'
 
 const debug = Debug('spruce-skill-server')

--- a/packages/spruce-skill-server/middleware/auth.ts
+++ b/packages/spruce-skill-server/middleware/auth.ts
@@ -50,7 +50,7 @@ module.exports = (
 				const realRole = auth.role
 
 				// Allow override of role if in dev mode
-				if (config.get('DEV_MODE')) {
+				if (config.DEV_MODE) {
 					const devRole =
 						ctx.cookies.get('devRole') || ctx.request.headers['x-dev-role']
 
@@ -183,7 +183,7 @@ module.exports = (
 						name: eventName
 					}
 
-					if (config.get('LOG_EVENTS')) {
+					if (config.LOG_EVENTS) {
 						log.info(`(EVENT_VERSION=2) Received event '${eventName}'`, {
 							event: ctx.event
 						})
@@ -193,7 +193,7 @@ module.exports = (
 					return
 				} catch (err) {
 					debug('(EVENT_VERSION=2) MIDDLEWARE/AUTH INVALID EVENT TOKEN', err)
-					if (config.get('LOG_EVENTS')) {
+					if (config.LOG_EVENTS) {
 						log.debug(
 							'(EVENT_VERSION=2) MIDDLEWARE/AUTH INVALID EVENT TOKEN',
 							err
@@ -202,9 +202,9 @@ module.exports = (
 				}
 			} else {
 				debug(`(EVENT_VERSION=2) No listener found for event: '${eventName}'`)
-				if (config.get('LOG_EVENTS')) {
+				if (config.LOG_EVENTS) {
 					log.debug(
-						`(EVENT_VERSION=2) No listener found for event: '${eventName}'. Check that you have created the corresponding file in server/events/. If you don't need to respond to this event, remove it from your config.get('eventContract')`
+						`(EVENT_VERSION=2) No listener found for event: '${eventName}'. Check that you have created the corresponding file in server/events/. If you don't need to respond to this event, remove it from your config.eventContract`
 					)
 				}
 			}

--- a/packages/spruce-skill-server/middleware/auth.ts
+++ b/packages/spruce-skill-server/middleware/auth.ts
@@ -1,5 +1,5 @@
 import jwt from 'jsonwebtoken'
-import config from 'config'
+import { default as config } from 'config'
 import Debug from 'debug'
 
 const debug = Debug('spruce-skill-server')
@@ -11,7 +11,7 @@ interface INext {
 	(): Promise<any>
 }
 
-module.exports = (
+export default (
 	router: Router<{}, ISpruceContext>,
 	options: Record<string, any>
 ) => {

--- a/packages/spruce-skill-server/middleware/events.ts
+++ b/packages/spruce-skill-server/middleware/events.ts
@@ -71,7 +71,7 @@ export default (
 					LocationId: location.id,
 					Location: location
 				}
-			} else if (userId && config.has('GLOBAL') && config.get('GLOBAL')) {
+			} else if (userId && config.GLOBAL) {
 				// just user id if global
 				debug('Global skill handling event')
 				const user = await ctx.sb.globalUser(userId)

--- a/packages/spruce-skill-server/models/User.ts
+++ b/packages/spruce-skill-server/models/User.ts
@@ -136,7 +136,7 @@ export class User extends SpruceCoreModel<User> {
 				sizes.forEach(size => {
 					profileImages['profile' + size] =
 						'https://s3.amazonaws.com/' +
-						config.get('S3_BUCKET') +
+						config.S3_BUCKET +
 						'/default-profile--X' +
 						size +
 						'.jpg'

--- a/packages/spruce-skill-server/models/User.ts
+++ b/packages/spruce-skill-server/models/User.ts
@@ -116,7 +116,7 @@ export class User extends SpruceCoreModel<User> {
 					sizes.forEach(size => {
 						profileImages['profile' + size] =
 							'https://s3.amazonaws.com/' +
-							config.get<string>('S3_BUCKET') +
+							config.S3_BUCKET +
 							'/userProfileImages/' +
 							this.profileImageUUID +
 							'--X' +

--- a/packages/spruce-skill-server/package.json
+++ b/packages/spruce-skill-server/package.json
@@ -65,7 +65,7 @@
 		"umzug": "^2.1.0"
 	},
 	"peerDependencies": {
-		"config": "sprucelabsai/node-config#master",
+		"config": "sprucelabsai/node-config",
 		"graphql": "^14.5.4",
 		"sqlite3": "^4.0.4",
 		"supertest": "^3.0.0",

--- a/packages/spruce-skill-server/package.json
+++ b/packages/spruce-skill-server/package.json
@@ -65,7 +65,7 @@
 		"umzug": "^2.1.0"
 	},
 	"peerDependencies": {
-		"config": "^3",
+		"config": "sprucelabsai/node-config#master",
 		"graphql": "^14.5.4",
 		"sqlite3": "^4.0.4",
 		"supertest": "^3.0.0",

--- a/packages/spruce-skill-server/services/cache/Memory.ts
+++ b/packages/spruce-skill-server/services/cache/Memory.ts
@@ -20,7 +20,7 @@ export default class Memory implements AbstractSpruceSkillCacheAdapter {
 		keyPrefix?: string
 	}): void {
 		log.debug('Memory cache init', { options })
-		if (!config.get<boolean>('TESTING')) {
+		if (!config.TESTING) {
 			throw new Error('Memory cache should only be used for testing')
 		}
 	}

--- a/packages/spruce-skill-server/tests/ACLTests.ts
+++ b/packages/spruce-skill-server/tests/ACLTests.ts
@@ -4,6 +4,7 @@ import { assert } from 'chai'
 import SpruceTest from './lib/SpruceTest'
 import config from 'config'
 import { ISpruceContext } from '../interfaces/ctx'
+import { IAclsResult } from '../services/Acl'
 
 class ACLTests extends SpruceTest<ISpruceContext> {
 	public setup(): void {
@@ -83,7 +84,7 @@ class ACLTests extends SpruceTest<ISpruceContext> {
 		const isAuthorized = await this.ctx.services.acl.userIsAuthorizedForAcls({
 			userId,
 			permissions: {
-				[config.get<string>('SLUG')]: ['can_do_example_location']
+				[config.SLUG]: ['can_do_example_location']
 			},
 			locationId: this.location.id,
 			organizationId: this.organization.id
@@ -125,7 +126,7 @@ class ACLTests extends SpruceTest<ISpruceContext> {
 		const isAuthorized = await this.ctx.services.acl.userIsAuthorizedForAcls({
 			userId,
 			permissions: {
-				[config.get<string>('SLUG')]: ['can_do_example_organization']
+				[config.SLUG]: ['can_do_example_organization']
 			},
 			organizationId: this.organization.id
 		})
@@ -166,7 +167,7 @@ class ACLTests extends SpruceTest<ISpruceContext> {
 		const isAuthorized = await this.ctx.services.acl.userIsAuthorizedForAcls({
 			userId,
 			permissions: {
-				[config.get<string>('SLUG')]: [
+				[config.SLUG]: [
 					'can_do_example_organization',
 					'can_do_example_location_owner_only'
 				]
@@ -181,7 +182,7 @@ class ACLTests extends SpruceTest<ISpruceContext> {
 		const isAuthorized = await this.ctx.services.acl.userIsAuthorizedForAcls({
 			userId: this.organization.owner[0].id,
 			permissions: {
-				[config.get<string>('SLUG')]: ['not_a_real_permission']
+				[config.SLUG]: ['not_a_real_permission']
 			},
 			locationId: this.location.id,
 			organizationId: this.organization.id
@@ -209,7 +210,7 @@ class ACLTests extends SpruceTest<ISpruceContext> {
 			// @ts-ignore: Missing parameter error
 			await this.ctx.services.acl.userIsAuthorizedForAcls({
 				permissions: {
-					[config.get<string>('SLUG')]: ['can_do_example_location']
+					[config.SLUG]: ['can_do_example_location']
 				},
 				locationId: this.location.id,
 				organizationId: this.organization.id
@@ -227,7 +228,7 @@ class ACLTests extends SpruceTest<ISpruceContext> {
 			await this.ctx.services.acl.userIsAuthorizedForAcls({
 				userId: 'taco-bravo',
 				permissions: {
-					[config.get<string>('SLUG')]: ['can_do_example_location']
+					[config.SLUG]: ['can_do_example_location']
 				},
 				locationId: this.location.id
 			})
@@ -255,7 +256,7 @@ class ACLTests extends SpruceTest<ISpruceContext> {
 	public async checkIndividualOrgAcls(): Promise<void> {
 		const acls = await this.ctx.services.acl.getAcls({
 			permissions: {
-				[config.get<string>('SLUG')]: [
+				[config.SLUG]: [
 					'can_do_example_organization',
 					'can_do_example_organization_owner_only'
 				]
@@ -267,7 +268,7 @@ class ACLTests extends SpruceTest<ISpruceContext> {
 		const {
 			can_do_example_organization,
 			can_do_example_organization_owner_only
-		} = get(acls, acl => acl[config.get<string>('SLUG')], {
+		} = get(acls, (acl: IAclsResult) => acl[config.SLUG], {
 			can_do_example_organization: false,
 			can_do_example_organization_owner_only: false
 		})
@@ -279,7 +280,7 @@ class ACLTests extends SpruceTest<ISpruceContext> {
 	public async checkIndividualLocationAcls(): Promise<void> {
 		const acls = await this.ctx.services.acl.getAcls({
 			permissions: {
-				[config.get<string>('SLUG')]: [
+				[config.SLUG]: [
 					'can_do_example_location',
 					'can_do_example_location_owner_only'
 				]
@@ -291,7 +292,7 @@ class ACLTests extends SpruceTest<ISpruceContext> {
 
 		const { can_do_example_location, can_do_example_location_owner_only } = get(
 			acls,
-			acl => acl[config.get<string>('SLUG')],
+			(acl: IAclsResult) => acl[config.SLUG],
 			{
 				can_do_example_location: false,
 				can_do_example_location_owner_only: false

--- a/packages/spruce-skill-server/tests/EmitTests.ts
+++ b/packages/spruce-skill-server/tests/EmitTests.ts
@@ -15,7 +15,7 @@ class EmitTests extends SpruceTest<ISpruceContext> {
 
 	public async locationEmitWithEventId(): Promise<void> {
 		const eventId = uuid.v4()
-		const eventName = `${config.get('SLUG')}:test-event`
+		const eventName = `${config.SLUG}:test-event`
 
 		global.testEmitResponse[eventName] = {
 			callback: ({ data, method, path }) => {
@@ -37,7 +37,7 @@ class EmitTests extends SpruceTest<ISpruceContext> {
 
 	public async organizationEmitWithEventId(): Promise<void> {
 		const eventId = uuid.v4()
-		const eventName = `${config.get('SLUG')}:test-event`
+		const eventName = `${config.SLUG}:test-event`
 
 		global.testEmitResponse[eventName] = {
 			callback: ({ data, method, path }) => {

--- a/packages/spruce-skill-server/tests/mocks/SandboxMock.ts
+++ b/packages/spruce-skill-server/tests/mocks/SandboxMock.ts
@@ -121,7 +121,7 @@ export default class SandboxMock {
 			icon: ''
 		})
 
-		skill.apiKey = config.get('API_KEY')
+		skill.apiKey = config.API_KEY
 
 		return skill
 	}

--- a/packages/spruce-skill-server/tests/mocks/apiMocks.ts
+++ b/packages/spruce-skill-server/tests/mocks/apiMocks.ts
@@ -2,6 +2,7 @@ import { ISpruceContext } from '../../interfaces/ctx'
 import Debug from 'debug'
 import config from 'config'
 import { Source } from 'graphql'
+import { ISpruceAcls } from '../../interfaces/acls'
 
 const debug = Debug('spruce-skill-server')
 export default (ctx: ISpruceContext) => ({
@@ -101,20 +102,20 @@ export default (ctx: ISpruceContext) => ({
 						permissions: []
 					}
 
+					const configAcls = config.acl as ISpruceAcls
+
 					for (let j = 0; j < permissions.length; j += 1) {
 						const permission = permissions[j]
 						if (slug === config.SLUG) {
 							if (
-								config.get<Record<string, any>>('acl').publishes[permission] &&
-								config.get<Record<string, any>>('acl').publishes[permission]
-									.defaults
+								configAcls.publishes[permission] &&
+								configAcls.publishes[permission].defaults
 							) {
 								slugResponse.permissions.push({
 									name: permission,
 									value:
 										userRole === 'owner' ||
-										config.get<Record<string, any>>('acl').publishes[permission]
-											.defaults[userRole] === true
+										configAcls.publishes[permission].defaults[userRole] === true
 								})
 							}
 						} else {

--- a/packages/spruce-skill-server/tests/mocks/apiMocks.ts
+++ b/packages/spruce-skill-server/tests/mocks/apiMocks.ts
@@ -103,7 +103,7 @@ export default (ctx: ISpruceContext) => ({
 
 					for (let j = 0; j < permissions.length; j += 1) {
 						const permission = permissions[j]
-						if (slug === config.get('SLUG')) {
+						if (slug === config.SLUG) {
 							if (
 								config.get<Record<string, any>>('acl').publishes[permission] &&
 								config.get<Record<string, any>>('acl').publishes[permission]

--- a/packages/spruce-skill/bin/buildConfigs.js
+++ b/packages/spruce-skill/bin/buildConfigs.js
@@ -1,6 +1,6 @@
 // Used when building for production. Creates the interface/client.json file from the current config
 const config = require('config')
 const fs = require('fs')
-const clientConfig = config.default.sanitizeClientConfig({ ...config.default })
+const clientConfig = config.sanitizeClientConfig({ ...config })
 const jsonPath = `${__dirname}/../interface/client.json`
 fs.writeFileSync(jsonPath, JSON.stringify(clientConfig))

--- a/packages/spruce-skill/interface/__mocks__/client.js
+++ b/packages/spruce-skill/interface/__mocks__/client.js
@@ -3,7 +3,7 @@ import nock from 'nock'
 
 export default () => {
 	nock.disableNetConnect()
-	return nock(config.get('SERVER_HOST')).defaultReplyHeaders({
+	return nock(config.SERVER_HOST).defaultReplyHeaders({
 		'Access-Control-Allow-Origin': '*'
 	})
 }

--- a/packages/spruce-skill/package.json
+++ b/packages/spruce-skill/package.json
@@ -54,7 +54,7 @@
 		"apollo-link-ws": "^1.0.12",
 		"babel-core": "7.0.0-bridge.0",
 		"babel-plugin-transform-flow-strip-types": "^6.22.0",
-		"config": "^3",
+		"config": "sprucelabsai/node-config#f937717",
 		"dotenv": "^5.0.1",
 		"enzyme": "^3.3.0",
 		"enzyme-adapter-react-16": "^1.1.1",

--- a/packages/spruce-skill/server/interfaces/config.ts
+++ b/packages/spruce-skill/server/interfaces/config.ts
@@ -8,5 +8,7 @@ import defaultConfig from '../../config/default'
 type configType = typeof defaultConfig
 
 declare module 'config' {
-	interface IConfig extends configType {}
+	interface IConfig extends configType {
+		[key: string]: any
+	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7823,10 +7823,9 @@ config-chain@^1.1.11, config-chain@^1.1.12, config-chain@~1.1.5:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
-config@^3:
+config@sprucelabsai/node-config#f937717:
   version "3.2.2"
-  resolved "https://registry.yarnpkg.com/config/-/config-3.2.2.tgz#c7d31bb2a9d30013a905ff420101e3b1ba58eead"
-  integrity sha512-rOsfIOAcG82AWouK4/vBS/OKz3UPl2T/kP0irExmXJJOoWg2CmdfPLdx56bCoMUMFNh+7soQkQWCUC8DyemiwQ==
+  resolved "https://codeload.github.com/sprucelabsai/node-config/tar.gz/f937717300125b6c5cd41813bd1a7be1d54e6ce9"
   dependencies:
     json5 "^1.0.1"
 


### PR DESCRIPTION
## What does this PR do?

* Switches to forked version of `node-config` module to fix issue w/ typescript compilation where on a production build `config` keys were nested under `config.default.default` and unable to be found, causing an authentication redirect loop

  * https://github.com/sprucelabsai/node-config/pull/1/files

* Removes `config.get(...)` references in favor of strongly typed `config.KEY`

## Type

- [ ] Feature
- [X] Bug
- [X] Tech debt

## What are the relevant tickets?

- [SDEV3-2361](https://sprucelabsai.atlassian.net/browse/SDEV3-2361)