### PR TITLE
Update "@typescript-eslint/camelcase": Allow non-camel case for permissions

### DIFF
--- a/packages/eslint-config-spruce/index.js
+++ b/packages/eslint-config-spruce/index.js
@@ -31,6 +31,10 @@ module.exports = {
 			rules: {
 				...typescriptEslintRecommended.rules,
 				...typescriptEslintPrettier.rules,
+				'@typescript-eslint/camelcase': [
+					'error',
+					{ allow: ['^(can_|skill_can_)'] }
+				],
 				'@typescript-eslint/no-empty-interface': 0,
 				'@typescript-eslint/interface-name-prefix': [2, 'always'],
 				'@typescript-eslint/no-explicit-any': 0,


### PR DESCRIPTION
## What does this PR do?

Update `@typescript-eslint/camelcase` rule to allow variables to be non-camelcase when they begin with `can_` or `skill_can_`

## Type

- [ ] Feature
- [ ] Bug
- [X] Tech debt