### PR TITLE
Fix .tsx imports not working without extension

### DIFF
--- a/packages/spruce-skill/interface/next.config.js
+++ b/packages/spruce-skill/interface/next.config.js
@@ -22,6 +22,7 @@ function client(webpack) {
 	})
 
 	webpack.resolve = {
+		...webpack.resolve,
 		alias: {
 			config: jsonPath
 			// Might be necessary to uncomment below if 'yarn link'-ing @sprucelabs/react-heartwood-components, @sprucelabs/spruce-skill-server or @sprucelabs/log


### PR DESCRIPTION
## What does this PR do?

Updates the `next.config.js` to extend the `resolve` config which fixes `.tsx` files not getting resolved properly

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt