### PR TITLE
feat(Typescript): Upgrade to 3.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"pm2": "^2.10.1",
 		"prettier": "^1.16.4",
 		"sqlite3": "^4.0.4",
-		"typescript": "~3.4.5"
+		"typescript": "3.6.3"
 	},
 	"devDependencies": {
 		"commitizen": "^3.0.7",

--- a/packages/eslint-config-spruce/index.js
+++ b/packages/eslint-config-spruce/index.js
@@ -37,6 +37,11 @@ module.exports = {
 					{ allow: ['^(can_|skill_can_)'] }
 				],
 				'@typescript-eslint/no-empty-interface': 0,
+				// TODO: Remove this if we can; it isn't a good rule to squash.
+				// Sometimes this is fine, but sometimes it masks a compile error.
+				'@typescript-eslint/ban-ts-ignore': 0,
+				'@typescript-eslint/no-empty-function': 0,
+				'@typescript-eslint/explicit-function-return-type': 0,
 				'@typescript-eslint/interface-name-prefix': [2, 'always'],
 				'@typescript-eslint/no-explicit-any': 0,
 				'@typescript-eslint/member-delimiter-style': [
@@ -50,12 +55,6 @@ module.exports = {
 							delimiter: 'semi',
 							requireLast: false
 						}
-					}
-				],
-				'@typescript-eslint/explicit-function-return-type': [
-					'error',
-					{
-						allowExpressions: true
 					}
 				],
 				'@typescript-eslint/member-ordering': [

--- a/packages/eslint-config-spruce/package.json
+++ b/packages/eslint-config-spruce/package.json
@@ -18,8 +18,8 @@
 		"url": "https://github.com/sprucelabsai/workspace.sprucebot-skills-kit/issues"
 	},
 	"dependencies": {
-		"@typescript-eslint/eslint-plugin": "1.13.0",
-		"@typescript-eslint/parser": "1.13.0",
+		"@typescript-eslint/eslint-plugin": "2.3.1",
+		"@typescript-eslint/parser": "2.3.1",
 		"babel-eslint": "10.0.1",
 		"eslint-config-prettier": "4.1.0",
 		"eslint-plugin-flowtype": "3.4.2",
@@ -32,6 +32,6 @@
 	"peerDependencies": {
 		"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0",
 		"prettier": "^1.16.4",
-		"typescript": "~3.4.5"
+		"typescript": "3.6.3"
 	}
 }

--- a/packages/react-heartwood-components/package.json
+++ b/packages/react-heartwood-components/package.json
@@ -85,7 +85,7 @@
 		"storybook-addon-jsx": "^7.1.6",
 		"storybook-addon-react-docgen": "^1.2.18",
 		"storybook-readme": "^5.0.8",
-		"typescript": "~3.4.5",
+		"typescript": "3.6.3",
 		"uuid": "^3.3.2",
 		"webpack": "^4.29.6"
 	},

--- a/packages/react-heartwood-components/src/components/Card/components/CardBuilder.tsx
+++ b/packages/react-heartwood-components/src/components/Card/components/CardBuilder.tsx
@@ -22,7 +22,8 @@ import CardHeader, { ICardHeaderProps } from './CardHeader'
 import OnboardingCard, { IOnboardingCardProps } from './OnboardingCard'
 import Scores from './Scores'
 
-export interface ICardBuilderFooter extends IHWCardBuilderFooter {
+export interface ICardBuilderFooter
+	extends Omit<IHWCardBuilderFooter, 'buttonGroup'> {
 	/** Render buttons in the Card Footer */
 	buttonGroup?: IButtonGroupProps
 }

--- a/packages/react-heartwood-components/src/components/Card/components/CardBuilder.tsx
+++ b/packages/react-heartwood-components/src/components/Card/components/CardBuilder.tsx
@@ -1,34 +1,28 @@
-import React from 'react'
-
-import Card from '../Card'
-import CardHeader from './CardHeader'
-import CardBody from './CardBody'
-import CardFooter from './CardFooter'
-
-// COMPONENTS THAT CAN GO INTO THIS COMPONENT, KEEP MINIMAL
-import Button from '../../Button/Button'
-import Heading from '../../Heading/Heading'
-import Text, { ITextProps } from '../../Text/Text'
-import Image, { IImageProps } from '../../Image/Image'
-import List, { IListProps } from '../../List/List'
-import Scores from './Scores'
-import OnboardingCard from './OnboardingCard'
-import ButtonGroup, { IButtonGroupProps } from '../../ButtonGroup/ButtonGroup'
-import Toast, { IToastProps } from '../../Toast/Toast'
-
-import { IButtonProps } from '../../Button/Button'
-import { ICardHeaderProps } from './CardHeader'
-import { IOnboardingCardProps } from './OnboardingCard'
 import {
 	IHWCardBuilder,
 	IHWCardBuilderBody,
 	IHWCardBuilderBodyItem,
+	IHWCardBuilderFooter,
 	IHWHeading,
 	IHWScoreCard
 } from '@sprucelabs/spruce-types'
-import { IHWCardFooter } from '@sprucelabs/spruce-types'
+import React from 'react'
+// COMPONENTS THAT CAN GO INTO THIS COMPONENT, KEEP MINIMAL
+import Button, { IButtonProps } from '../../Button/Button'
+import ButtonGroup, { IButtonGroupProps } from '../../ButtonGroup/ButtonGroup'
+import Heading from '../../Heading/Heading'
+import Image, { IImageProps } from '../../Image/Image'
+import List, { IListProps } from '../../List/List'
+import Text, { ITextProps } from '../../Text/Text'
+import Toast, { IToastProps } from '../../Toast/Toast'
+import Card from '../Card'
+import CardBody from './CardBody'
+import CardFooter from './CardFooter'
+import CardHeader, { ICardHeaderProps } from './CardHeader'
+import OnboardingCard, { IOnboardingCardProps } from './OnboardingCard'
+import Scores from './Scores'
 
-export interface ICardBuilderFooter extends Omit<IHWCardFooter, 'buttonGroup'> {
+export interface ICardBuilderFooter extends IHWCardBuilderFooter {
 	/** Render buttons in the Card Footer */
 	buttonGroup?: IButtonGroupProps
 }

--- a/packages/react-heartwood-components/src/components/EventDetails/eventDetailsMock.ts
+++ b/packages/react-heartwood-components/src/components/EventDetails/eventDetailsMock.ts
@@ -347,20 +347,22 @@ export const warningAppointment: IEventDetailsProps = {
 					]
 				},
 				footer: {
-					actions: [
-						{
-							text: 'Dismiss',
-							kind: ButtonKinds.Simple,
-							isSmall: true,
-							id: 'foo'
-						},
-						{
-							text: 'Find a different time',
-							kind: ButtonKinds.Secondary,
-							isSmall: true,
-							id: 'bar'
-						}
-					]
+					buttonGroup: {
+						actions: [
+							{
+								text: 'Dismiss',
+								kind: ButtonKinds.Simple,
+								isSmall: true,
+								id: 'foo'
+							},
+							{
+								text: 'Find a different time',
+								kind: ButtonKinds.Secondary,
+								isSmall: true,
+								id: 'bar'
+							}
+						]
+					}
 				}
 			}
 		},

--- a/packages/react-heartwood-components/src/components/EventDetails/eventDetailsMock.ts
+++ b/packages/react-heartwood-components/src/components/EventDetails/eventDetailsMock.ts
@@ -351,12 +351,14 @@ export const warningAppointment: IEventDetailsProps = {
 						{
 							text: 'Dismiss',
 							kind: ButtonKinds.Simple,
-							isSmall: true
+							isSmall: true,
+							id: 'foo'
 						},
 						{
 							text: 'Find a different time',
 							kind: ButtonKinds.Secondary,
-							isSmall: true
+							isSmall: true,
+							id: 'bar'
 						}
 					]
 				}

--- a/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.tsx
+++ b/packages/react-heartwood-components/src/components/Forms/components/Autosuggest/Autosuggest.tsx
@@ -242,7 +242,7 @@ export default class Autosuggest extends Component<
 		}
 
 		// For scrollX and scrollY cross-browser compatibility
-		let docEl = document.scrollingElement || document.documentElement
+		const docEl = document.scrollingElement || document.documentElement
 
 		const scrollX = (typeof docEl.scrollLeft === 'number'
 			? docEl
@@ -329,7 +329,7 @@ export default class Autosuggest extends Component<
 			const suggestionsBox = suggestionsContainer.getBoundingClientRect()
 			const suggestionsBottom = suggestionsBox.top + suggestionsBox.height
 
-			let isSmoothScrollSupported =
+			const isSmoothScrollSupported =
 				'scrollBehavior' in document.documentElement.style
 
 			if (suggestionsBottom > overflowBoxBottom) {

--- a/packages/react-heartwood-components/src/components/Icon/Icon.tsx
+++ b/packages/react-heartwood-components/src/components/Icon/Icon.tsx
@@ -30,7 +30,7 @@ const Icon = (props: IIconProps): React.ReactElement => {
 		return <Fragment />
 	}
 
-	let isFillIcon = !customIcon && icons[iconKey] && !icons[iconKey].isLineIcon
+	const isFillIcon = !customIcon && icons[iconKey] && !icons[iconKey].isLineIcon
 
 	const Handler = customIcon || icons[iconKey].icon
 

--- a/packages/react-heartwood-components/src/components/Text/Text.tsx
+++ b/packages/react-heartwood-components/src/components/Text/Text.tsx
@@ -26,11 +26,12 @@ const renderText = (child): ReactNode => {
 
 // Allows basic templating functionality on text strings
 const TemplateEngine = (text = '', context = {}): ReactNode[] => {
-	let re = /{{([^}}]+)?}}/g,
-		children: Record<string, any>[] = [],
-		cursor = 0
+	const re = /{{([^}}]+)?}}/g,
+		children: Record<string, any>[] = []
 
-	let add = function(line: string, templateVar?: string): void {
+	let cursor = 0
+
+	const add = function(line: string, templateVar?: string): void {
 		if (line !== '') {
 			children.push({
 				props: { element: 'span', children: line.replace(/"/g, '\\"') }
@@ -87,7 +88,7 @@ const Text: React.StatelessComponent<ITextProps> = (
 		isInline,
 		...rest
 	} = props
-	let Element: any = isInline ? 'span' : 'p'
+	const Element: any = isInline ? 'span' : 'p'
 	let children = originalChildren
 
 	const text = children || textProps || context

--- a/packages/react-heartwood-components/src/components/Toast/Toast.tsx
+++ b/packages/react-heartwood-components/src/components/Toast/Toast.tsx
@@ -8,7 +8,7 @@ interface IToastHeaderProps extends Omit<IHWToast, 'id'> {
 	id?: string
 
 	/** Function to remove the toast */
-	onRemove: Function
+	onRemove?: Function
 }
 
 const ToastHeader = (props: IToastHeaderProps): React.ReactElement => {
@@ -34,7 +34,7 @@ export interface IToastProps {
 	text?: string
 
 	/** Handle toast removal */
-	onRemove: Function
+	onRemove?: Function
 
 	/** Optional; controls whether the toast can be removed. Defaults to true */
 	canRemove?: boolean

--- a/packages/react-heartwood-components/src/components/Toast/components/ToastWrapper/ToastWrapper.tsx
+++ b/packages/react-heartwood-components/src/components/Toast/components/ToastWrapper/ToastWrapper.tsx
@@ -35,7 +35,7 @@ export default class ToastWrapper extends Component<
 		state: IToastWrapperState
 	): { toasts: IToastProps[]; timeouts: any[] } {
 		const uniqToasts = uniqBy(props.toasts, 'id')
-		let timeouts = { ...state.timeouts }
+		const timeouts = { ...state.timeouts }
 		uniqToasts.forEach(toast => {
 			if (toast.timeout !== 'never') {
 				timeouts[toast.id] = setTimeout(

--- a/packages/react-heartwood-components/src/custom-types.d.ts
+++ b/packages/react-heartwood-components/src/custom-types.d.ts
@@ -7,5 +7,3 @@ declare module '*.png' {
 	const content: any
 	export default content
 }
-
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>

--- a/packages/spruce-next-helpers/src/skillskit/index.ts
+++ b/packages/spruce-next-helpers/src/skillskit/index.ts
@@ -280,6 +280,8 @@ const skill: ISkill = {
 
 	// TODO: Use Iframes built in callback functionality
 	bigSearch() {
+		// TODO: Is this alias necessary?
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const _this = this
 
 		const bigSearch: IBigSearch = {

--- a/packages/spruce-node/index.ts
+++ b/packages/spruce-node/index.ts
@@ -652,7 +652,7 @@ export default class Sprucebot {
 
 		// not found, create it
 		if (!meta) {
-			meta = await this.createMeta(key, value, Array.from(arguments)[2])
+			meta = await this.createMeta(key, value, options)
 		}
 		return meta
 	}
@@ -670,7 +670,7 @@ export default class Sprucebot {
 
 		// not found, create it
 		if (!meta) {
-			meta = await this.createMeta(key, value, Array.from(arguments)[2])
+			meta = await this.createMeta(key, value, options)
 		} else if (JSON.stringify(meta.value) !== JSON.stringify(value)) {
 			//found, but value has changed
 			meta = await this.updateMeta(meta.id, { value })
@@ -875,10 +875,10 @@ export default class Sprucebot {
 			this._mutexes[key].promises.push(new Promise(resolve => resolve()))
 			this._mutexes[key].resolvers.push(() => {})
 		} else {
-			let resolver = (resolve: any): void => {
+			const resolver = (resolve: any): void => {
 				this._mutexes[key].resolvers.push(resolve)
 			}
-			let promise = new Promise(resolver)
+			const promise = new Promise(resolver)
 			this._mutexes[key].promises.push(promise)
 		}
 

--- a/packages/spruce-node/package.json
+++ b/packages/spruce-node/package.json
@@ -45,7 +45,7 @@
 	},
 	"peerDependencies": {
 		"graphql": "^14.5.4",
-		"typescript": "~3.4.5"
+		"typescript": "3.6.3"
 	},
 	"jest": {
 		"coverageDirectory": "./coverage/",

--- a/packages/spruce-node/utilities/url.ts
+++ b/packages/spruce-node/utilities/url.ts
@@ -4,7 +4,7 @@ export default {
 	 */
 	serialize(obj: Record<string, any>) {
 		const str: string[] = []
-		for (let p in obj) {
+		for (const p in obj) {
 			if (obj.hasOwnProperty(p)) {
 				str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]))
 			}

--- a/packages/spruce-skill-server/gql/Schema.ts
+++ b/packages/spruce-skill-server/gql/Schema.ts
@@ -161,7 +161,7 @@ export default class Schema {
 		}
 
 		// add in reslovers
-		let cleanedResolvers = { ...allResolvers }
+		const cleanedResolvers = { ...allResolvers }
 		if (Object.keys(cleanedResolvers.Query).length === 0) {
 			delete cleanedResolvers.Query
 		}

--- a/packages/spruce-skill-server/gql/helpers.ts
+++ b/packages/spruce-skill-server/gql/helpers.ts
@@ -339,7 +339,7 @@ export default (ctx: ISpruceContext) => {
 		const { model, type, associationName } = options
 		let connectionOptions = options.connectionOptions
 		let name = options.name || model.name
-		let modelName = name
+		const modelName = name
 		let target = model
 
 		if (model.associations[associationName]) {

--- a/packages/spruce-skill-server/index.ts
+++ b/packages/spruce-skill-server/index.ts
@@ -387,7 +387,7 @@ async function serve<ISkillContext extends ISpruceContext>(
 
 			// anything in the error thrown that matches these
 			// keys, lets set back to the error
-			for (let key of ['code', 'friendlyReason']) {
+			for (const key of ['code', 'friendlyReason']) {
 				if (err[key]) {
 					errorResponse[key] = err[key]
 				}

--- a/packages/spruce-skill-server/lib/GraphQLSubscriptionServer.ts
+++ b/packages/spruce-skill-server/lib/GraphQLSubscriptionServer.ts
@@ -102,6 +102,9 @@ export default class GQLSubscriptionServer {
 		const token = authorizationHeader.replace('JWT ', '')
 		const decoded = jwt.verify(
 			token,
+			// TODO: config's type doesn't describe this API correctly...
+			// try to remove at a later date.
+			// @ts-ignore
 			config
 				.get('API_KEY')
 				.toString()

--- a/packages/spruce-skill-server/lib/GraphQLSubscriptionServer.ts
+++ b/packages/spruce-skill-server/lib/GraphQLSubscriptionServer.ts
@@ -99,17 +99,12 @@ export default class GQLSubscriptionServer {
 		locationId?: string
 		organizationId?: string
 	} {
+		if (!config.API_KEY) {
+			throw new Error('GQLSubscriptionServer: API_KEY must be set in config.')
+		}
+
 		const token = authorizationHeader.replace('JWT ', '')
-		const decoded = jwt.verify(
-			token,
-			// TODO: config's type doesn't describe this API correctly...
-			// try to remove at a later date.
-			// @ts-ignore
-			config
-				.get('API_KEY')
-				.toString()
-				.toLowerCase()
-		)
+		const decoded = jwt.verify(token, config.API_KEY)
 
 		return decoded as {
 			userId?: string

--- a/packages/spruce-skill-server/middleware/auth.ts
+++ b/packages/spruce-skill-server/middleware/auth.ts
@@ -29,7 +29,7 @@ export default (
 			: (passedId as ISpruceContext)
 		const id: string | null = passedNext ? (passedId as string) : null
 
-		let token =
+		const token =
 			id ||
 			ctx.request.body.jwt ||
 			ctx.request.query.jwt ||
@@ -145,7 +145,7 @@ export default (
 			: (passedId as ISpruceContext)
 		const id: string | null = passedNext ? (passedId as string) : null
 
-		let token =
+		const token =
 			id ||
 			ctx.request.body.jwtV2 ||
 			ctx.request.query.jwtV2 ||
@@ -229,7 +229,7 @@ export default (
 	// router.use('/api/*/teammate/*', auth)
 	router.use('/api/1.0/teammate/*', async (ctx, next) => {
 		// @ts-ignore: legacy functionality
-		let role = ctx.auth && ctx.auth.role
+		const role = ctx.auth && ctx.auth.role
 		if (role !== 'teammate' && role !== 'owner') {
 			debug(`MIDDLEWARE/AUTH ACCESS DENIED: ${ctx.path} for role: '${role}' `)
 			ctx.throw('NOT_AUTHORIZED')
@@ -240,7 +240,7 @@ export default (
 	// router.use('/api/*/owner/*', auth)
 	router.use('/api/1.0/owner/*', async (ctx, next) => {
 		// @ts-ignore: legacy functionality
-		let role = ctx.auth && ctx.auth.role
+		const role = ctx.auth && ctx.auth.role
 		if (role !== 'owner') {
 			debug(`MIDDLEWARE/AUTH ACCESS DENIED: ${ctx.path} for role: '${role}' `)
 			ctx.throw('NOT_AUTHORIZED')
@@ -251,7 +251,7 @@ export default (
 	// router.use('/api/*/guest/*', auth)
 	router.use('/api/1.0/guest/*', async (ctx, next) => {
 		// @ts-ignore: legacy functionality
-		let role = ctx.auth && ctx.auth.role
+		const role = ctx.auth && ctx.auth.role
 		if (!role) {
 			debug(`MIDDLEWARE/AUTH ACCESS DENIED: ${ctx.path} for role: '${role}' `)
 			ctx.throw('NOT_AUTHORIZED')

--- a/packages/spruce-skill-server/package.json
+++ b/packages/spruce-skill-server/package.json
@@ -67,7 +67,7 @@
 		"graphql-type-json": "^0.3.0",
 		"sqlite3": "^4.0.4",
 		"supertest": "^3.0.0",
-		"typescript": "~3.4.5"
+		"typescript": "3.6.3"
 	},
 	"devDependencies": {
 		"@types/bluebird": "^3.5.27",

--- a/packages/spruce-skill-server/services/Acl.ts
+++ b/packages/spruce-skill-server/services/Acl.ts
@@ -173,7 +173,7 @@ export default class AclService extends SpruceSkillService<ISpruceContext> {
 		}
 		// Implements recursive object serialization according to JSON spec
 		// but without quotes around the keys.
-		let props = Object.keys(objFromJSON)
+		const props = Object.keys(objFromJSON)
 			.map(key => `${key}:${this.stringify(objFromJSON[key])}`)
 			.join(',')
 		return `{${props}}`

--- a/packages/spruce-skill-server/tests/lib/SpruceTest.ts
+++ b/packages/spruce-skill-server/tests/lib/SpruceTest.ts
@@ -150,7 +150,7 @@ export default class Base<Context> {
 	protected async afterBase(): Promise<void> {
 		try {
 			const promises = []
-			for (let k in this.mocks) {
+			for (const k in this.mocks) {
 				if (this.mocks[k].teardown) {
 					promises.push(this.mocks[k].teardown())
 				}

--- a/packages/spruce-skill/package.json
+++ b/packages/spruce-skill/package.json
@@ -92,7 +92,7 @@
 		"supertest": "^3.3.0",
 		"swagger-jsdoc": "^3.0.2",
 		"ts-get": "^1.0.5",
-		"typescript": "~3.4.5",
+		"typescript": "3.6.3",
 		"universal-cookie": "^2.1.0"
 	},
 	"devDependencies": {

--- a/packages/spruce-types/package.json
+++ b/packages/spruce-types/package.json
@@ -38,7 +38,7 @@
 		"@sprucelabs/spruce-skill-server": "^8.15.2",
 		"graphql-iso-date": "^3.6.1",
 		"graphql-type-json": "^0.3.0",
-		"typescript": "~3.4.5"
+		"typescript": "3.6.3"
 	},
 	"devDependencies": {
 		"@graphql-codegen/add": "^1.6.1",

--- a/packages/spruce-types/src/generated/hw-gql.ts
+++ b/packages/spruce-types/src/generated/hw-gql.ts
@@ -408,7 +408,7 @@ export type IHWCardBuilderBodyItemViewModel = IHWButton | IHWImage | IHWHeading 
 export type IHWCardBuilderFooter = {
   __typename?: 'CardBuilderFooter',
   /** Render buttons in the Card Footer */
-  actions?: Maybe<Array<IHWButton>>,
+  buttonGroup?: Maybe<IHWButtonGroup>,
   /** Helper for the footer */
   helper?: Maybe<Scalars['String']>,
 };

--- a/packages/spruce-types/src/gql/CardBuilder.gql
+++ b/packages/spruce-types/src/gql/CardBuilder.gql
@@ -19,7 +19,7 @@ type CardHeader {
 "The footer of the card"
 type CardBuilderFooter {
 	"Render buttons in the Card Footer"
-	actions: [Button!]
+	buttonGroup: ButtonGroup
 
 	"Helper for the footer"
 	helper: String

--- a/yarn.lock
+++ b/yarn.lock
@@ -4178,16 +4178,16 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@typescript-eslint/eslint-plugin@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz#22fed9b16ddfeb402fd7bcde56307820f6ebc49f"
-  integrity sha512-WQHCozMnuNADiqMtsNzp96FNox5sOVpU8Xt4meaT4em8lOG1SrOv92/mUbEHQVh90sldKSfcOc/I0FOb/14G1g==
+"@typescript-eslint/eslint-plugin@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.3.1.tgz#b0b1e6b9b3f84b3e1afbdd338f4194c8ab92db21"
+  integrity sha512-VqVNEsvemviajlaWm03kVMabc6S3xCHGYuY0fReTrIIOZg+3WzB+wfw6fD3KYKerw5lYxmzogmHOZ0i7YKnuwA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "1.13.0"
-    eslint-utils "^1.3.1"
+    "@typescript-eslint/experimental-utils" "2.3.1"
+    eslint-utils "^1.4.2"
     functional-red-black-tree "^1.0.1"
     regexpp "^2.0.1"
-    tsutils "^3.7.0"
+    tsutils "^3.17.1"
 
 "@typescript-eslint/experimental-utils@1.13.0":
   version "1.13.0"
@@ -4198,7 +4198,26 @@
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-scope "^4.0.0"
 
-"@typescript-eslint/parser@1.13.0", "@typescript-eslint/parser@^1.10.2":
+"@typescript-eslint/experimental-utils@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.3.1.tgz#92f2531d3e7c22e64a2cc10cfe89935deaf00f7c"
+  integrity sha512-FaZEj73o4h6Wd0Lg+R4pZiJGdR0ZYbJr+O2+RbQ1aZjX8bZcfkVDtD+qm74Dv77rfSKkDKE64UTziLBo9UYHQA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.3.1"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/parser@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.3.1.tgz#f2b93b614d9b338825c44e75552a433e2ebf8c33"
+  integrity sha512-ZlWdzhCJ2iZnSp/VBAJ/sowFbyHycIux8t0UEH0JsKgQvfSf7949hLYFMwTXdCMeEnpP1zRTHimrR+YHzs8LIw==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.3.1"
+    "@typescript-eslint/typescript-estree" "2.3.1"
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/parser@^1.10.2":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.13.0.tgz#61ac7811ea52791c47dc9fd4dd4a184fae9ac355"
   integrity sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==
@@ -4215,6 +4234,16 @@
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
+
+"@typescript-eslint/typescript-estree@2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.3.1.tgz#62c64f149948473d06a129dc33b4fc76e6c051f9"
+  integrity sha512-9SFhUgFuePJBB6jlLkOPPhMkZNiDCr+S8Ft7yAkkP2c5x5bxPhG3pe/exMiQaF8IGyVMDW6Ul0q4/cZ+uF3uog==
+  dependencies:
+    glob "^7.1.4"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
 
 "@webassemblyjs/ast@1.7.8":
   version "1.7.8"
@@ -10068,15 +10097,35 @@ eslint-scope@^4.0.0, eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
+  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-utils@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
   integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
 
+eslint-utils@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
+  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
+  dependencies:
+    eslint-visitor-keys "^1.0.0"
+
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+
+eslint-visitor-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
 eslint@^5, eslint@^5.0.0, eslint@^5.9.0:
   version "5.16.0"
@@ -23818,10 +23867,10 @@ tslib@^1.8.1, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tsutils@^3.7.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.10.0.tgz#6f1c95c94606e098592b0dff06590cf9659227d6"
-  integrity sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   dependencies:
     tslib "^1.8.1"
 
@@ -23895,15 +23944,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
+  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+
 typescript@^3.2.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
-
-typescript@~3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 ua-parser-js@0.7.17:
   version "0.7.17"


### PR DESCRIPTION
- Upgrades to TS 3.6.3, which necessitated an upgrade to our TS+eslint integration.
- Fixes mostly for `prefer-const`.
- Fix a few typing issues that 3.6.3 was able to flag that 3.4.x missed.