### PR TITLE
feat: skill modal match other interfaces

### DIFF
--- a/packages/spruce-types/src/generated/hw-gql.ts
+++ b/packages/spruce-types/src/generated/hw-gql.ts
@@ -115,7 +115,7 @@ export type IHWActionEmitEventPayload = {
   /** Name of the event, like 'booking:update-appointment' */
   eventName?: Maybe<Scalars['String']>,
   /** Arbitrary payload sent with the event */
-  Payload?: Maybe<Scalars['JSON']>,
+  payload?: Maybe<Scalars['JSON']>,
 };
 
 export type IHWActionExecuter = {

--- a/packages/spruce-types/src/generated/hw-gql.ts
+++ b/packages/spruce-types/src/generated/hw-gql.ts
@@ -153,8 +153,10 @@ export type IHWActionShowModal = {
 /** Props passed to a modal you want to pop up when invoking this action */
 export type IHWActionShowModalPayload = {
   __typename?: 'ActionShowModalPayload',
-  /** Fully qualified url to destination */
-  src: Scalars['String'],
+  /** Host and protocol to destination (usually config.INTERFACE_HOST) */
+  host: Scalars['String'],
+  /** Path to your skill view */
+  path?: Maybe<Scalars['String']>,
   /** Title of the dialog */
   title: Scalars['String'],
   /** Drop a primary action button into the footer */

--- a/packages/spruce-types/src/gql/ActionExecuter.gql
+++ b/packages/spruce-types/src/gql/ActionExecuter.gql
@@ -65,8 +65,11 @@ enum ModalSize {
 
 "Props passed to a modal you want to pop up when invoking this action"
 type ActionShowModalPayload {
-	"Fully qualified url to destination"
-	src: String!
+	"Host and protocol to destination (usually config.INTERFACE_HOST)"
+	host: String!
+
+	"Path to your skill view"
+	path: String
 
 	"Title of the dialog"
 	title: String!

--- a/packages/spruce-types/src/gql/ActionExecuter.gql
+++ b/packages/spruce-types/src/gql/ActionExecuter.gql
@@ -105,7 +105,7 @@ type ActionEmitEventPayload {
 	eventName: String
 
 	"Arbitrary payload sent with the event"
-	Payload: JSON
+	payload: JSON
 }
 
 "Emit an event to your skill"


### PR DESCRIPTION
## What does this PR do?

Makes the skill view modal signature match other instances of loading skill view.

## Type

- [ ] Feature
- [ ] Bug
- [x] Tech debt

## What are the relevant tickets?

NA

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

NA

## Screenshots (if appropriate)

NA

## What gif best describes this PR or how it makes you feel?

NA