### PR TITLE
[SDEV3-2185] fixed ts library reference, triggerEvent types

### DIFF
--- a/packages/spruce-skill-server/tests/lib/SpruceTest.ts
+++ b/packages/spruce-skill-server/tests/lib/SpruceTest.ts
@@ -20,6 +20,7 @@ import {
 } from '../mocks/SandboxMock'
 import { Server } from 'http'
 import { IGQLTag } from '@sprucelabs/spruce-node'
+import request from 'superagent'
 
 // The base test model that all others will extend
 export default class Base<Context> {
@@ -179,14 +180,14 @@ export default class Base<Context> {
 		return response && response.body
 	}
 
-	protected async triggerEvent(options: {
+	protected async triggerEvent<IEventResponseBody = any>(options: {
 		eventName: string
 		payload: Record<string, any>
 		skill: IMockSkill
 		location: Location
 		organization: Organization
 		user: User
-	}): Promise<any> {
+	}): Promise<request.Response & { body: IEventResponseBody }> {
 		const { eventName, payload, skill, location, organization, user } = options
 		const token = generateSkillJWT({
 			skill,

--- a/sprucebot-skill-kit.code-workspace
+++ b/sprucebot-skill-kit.code-workspace
@@ -74,7 +74,7 @@
 		"eslint.options": {
 			"extensions": [".js", ".jsx", ".ts", ".tsx"]
 		},
-		"typescript.tsdk": "node_modules/typescript/lib",
+		"typescript.tsdk": "Workspace/node_modules/typescript/lib",
 		"atlascode.jira.workingSite": {
 			"baseUrlSuffix": "atlassian.net"
 		}


### PR DESCRIPTION
## What does this PR do?

Fixes a reference to the right version of typescript when working in the Workspace. Also, types `triggerEvent`

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2185](https://sprucelabsai.atlassian.net/browse/SDEV3-2185)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

NA

## Screenshots (if appropriate)

NA

## What gif best describes this PR or how it makes you feel?

NA