### PR TITLE
Prevent double save formatters

### DIFF
--- a/packages/spruce-skill/.vscode/settings.json
+++ b/packages/spruce-skill/.vscode/settings.json
@@ -32,6 +32,18 @@
 	"eslint.options": {
 		"extensions": [".js", ".jsx", ".ts", ".tsx"]
 	},
+	"[javascript]": {
+		"editor.formatOnSave": false
+	},
+	"[javascriptreact]": {
+		"editor.formatOnSave": false
+	},
+	"[typescript]": {
+		"editor.formatOnSave": false
+	},
+	"[typescriptreact]": {
+		"editor.formatOnSave": false
+	},
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"atlascode.jira.workingSite": {
 		"baseUrlSuffix": "atlassian.net"


### PR DESCRIPTION
## What does this PR do?

* Fix vscode config so only eslint fix formatter runs

## Type

- [ ] Feature
- [ ] Bug
- [X] Tech debt