### PR TITLE
VScode should exclude build/ directory from watch

### DIFF
--- a/packages/spruce-skill/.vscode/settings.json
+++ b/packages/spruce-skill/.vscode/settings.json
@@ -7,10 +7,12 @@
 	"files.watcherExclude": {
 		"**/.git/objects/**": true,
 		"**/.git/subtree-cache/**": true,
+		"**/build/**": true,
 		"**/node_modules/**": true,
 		"**/.next/**": true
 	},
 	"search.exclude": {
+		"**/build/**": true,
 		"**/node_modules/**": true,
 		"**/.next/**": true
 	},


### PR DESCRIPTION
## What does this PR do?

Excludes `build` directories from search / watch in vscode which should help performance and prevent us from accidentally editing a built file

## Type

- [ ] Feature
- [ ] Bug
- [X] Tech debt