### PR TITLE
feat(EventDetails): Add action executor arch to components [SDEV3-2355]

### DIFF
--- a/packages/react-heartwood-components/src/components/Button/Button.tsx
+++ b/packages/react-heartwood-components/src/components/Button/Button.tsx
@@ -1,7 +1,8 @@
 import {
 	IHWButton,
 	IHWButtonTypes as ButtonTypes,
-	IHWButtonKinds as ButtonKinds
+	IHWButtonKinds as ButtonKinds,
+	IHWAction
 } from '@sprucelabs/spruce-types'
 import cx from 'classnames'
 import React, { Fragment } from 'react'
@@ -44,23 +45,28 @@ export interface IButtonProps extends Omit<IHWButton, 'id' | 'icon'> {
 
 	/** optional payload to be sent with onclick (different than the payload attached to action.) */
 	payload?: Record<string, any>
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 
 const Button = (props: IButtonProps): React.ReactElement => {
 	const {
-		className,
-		kind,
-		isSmall,
-		isFullWidth,
-		isLoading,
-		isIconOnly,
-		text,
-		href,
-		icon,
-		type,
-		onClick,
+		action,
 		AnchorComponent = BasicAnchor,
 		children,
+		className,
+		href,
+		icon,
+		isFullWidth,
+		isIconOnly,
+		isLoading,
+		isSmall,
+		kind,
+		onAction,
+		onClick,
+		text,
+		type,
 		...rest
 	} = props
 
@@ -81,6 +87,11 @@ const Button = (props: IButtonProps): React.ReactElement => {
 
 	const handleClick = (e: any): any => {
 		e.currentTarget.blur()
+
+		if (onAction && action) {
+			onAction(action)
+		}
+
 		if (onClick) {
 			onClick(e, props.payload)
 		}

--- a/packages/react-heartwood-components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-heartwood-components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,15 +1,18 @@
-import React from 'react'
+import { IHWAction, IHWButtonGroup } from '@sprucelabs/spruce-types'
 import cx from 'classnames'
-import Button, { IButtonProps, ButtonKinds } from '../Button/Button'
-import { IHWButtonGroup } from '@sprucelabs/spruce-types'
+import React from 'react'
+import Button, { ButtonKinds, IButtonProps } from '../Button/Button'
 
 export interface IButtonGroupProps extends Omit<IHWButtonGroup, 'actions'> {
 	/** Array of actions to render the group's buttons. */
 	actions: IButtonProps[]
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 
 const ButtonGroup = (props: IButtonGroupProps): React.ReactElement => {
-	const { actions, kind, isFullWidth, highlightedIndex } = props
+	const { actions, kind, isFullWidth, highlightedIndex, onAction } = props
 	const parentClass = cx('button-group', {
 		'button-group-segmented': kind === 'segmented',
 		'button-group-floating': kind === 'floating',
@@ -35,6 +38,7 @@ const ButtonGroup = (props: IButtonGroupProps): React.ReactElement => {
 									? ButtonKinds.Secondary
 									: action.kind
 							}
+							onAction={onAction}
 						/>
 					</li>
 				)

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.tsx
@@ -1,12 +1,15 @@
-import React, { Component } from 'react'
-import { createPortal } from 'react-dom'
+import {
+	IHWAction,
+	IHWButtonGroupKind,
+	IHWContextMenu
+} from '@sprucelabs/spruce-types'
 import cx from 'classnames'
 import { debounce } from 'lodash'
-import Button, { IButtonProps, ButtonKinds } from '../Button/Button'
-import ButtonGroup from '../ButtonGroup/ButtonGroup'
-
+import React, { Component } from 'react'
+import { createPortal } from 'react-dom'
 import MoreIcon from '../../../static/assets/icons/Interface-Essential/Menu/navigation-menu-horizontal.svg'
-import { IHWContextMenu, IHWButtonGroupKind } from '@sprucelabs/spruce-types'
+import Button, { ButtonKinds, IButtonProps } from '../Button/Button'
+import ButtonGroup from '../ButtonGroup/ButtonGroup'
 import { IIconProps } from '../Icon/Icon'
 
 export interface IContextMenuProps
@@ -30,6 +33,9 @@ export interface IContextMenuProps
 	className?: string
 
 	onToggleContextMenuVisible?: Function
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 
 interface IContextMenuState {
@@ -254,15 +260,16 @@ export default class ContextMenu extends Component<
 		const { isVisible, overflowBottom, overflowLeft, menuPosition } = this.state
 		const {
 			actions,
-			isRightAligned,
+			className,
+			icon,
 			isBottomAligned,
+			isRightAligned,
 			isSimple,
 			isSmall,
-			size,
-			icon,
-			text,
 			isTextOnly,
-			className
+			onAction,
+			size,
+			text
 		} = this.props
 		const buttonClass = cx('context-menu', className, {
 			'context-menu--is-visible': isVisible
@@ -316,6 +323,7 @@ export default class ContextMenu extends Component<
 									btnAction.className = 'context-menu__item-btn'
 									return btnAction
 								})}
+								onAction={onAction}
 							/>
 						</div>,
 						this.portalEl

--- a/packages/react-heartwood-components/src/components/EventDetails/EventDetails-story.tsx
+++ b/packages/react-heartwood-components/src/components/EventDetails/EventDetails-story.tsx
@@ -28,7 +28,13 @@ stories
 	.add('Booking: Appointment', () => (
 		<Sidebar side="right" isCollapsible={false} isLarge>
 			<SidebarHeader title="Appointment details" onClose={() => null} />
-			<EventDetails isLoading={boolean('isLoading', false)} {...appointment} />
+			<EventDetails
+				isLoading={boolean('isLoading', false)}
+				{...appointment}
+				onAction={action => {
+					console.log(JSON.stringify(action.payload))
+				}}
+			/>
 		</Sidebar>
 	))
 	.add('Booking: Appointment has warning', () => (
@@ -37,6 +43,9 @@ stories
 			<EventDetails
 				isLoading={boolean('isLoading', false)}
 				{...warningAppointment}
+				onAction={action => {
+					console.log(JSON.stringify(action.payload))
+				}}
 			/>
 		</Sidebar>
 	))
@@ -46,19 +55,34 @@ stories
 			<EventDetails
 				isLoading={boolean('isLoading', false)}
 				{...pastAppointment}
+				onAction={action => {
+					console.log(JSON.stringify(action.payload))
+				}}
 			/>
 		</Sidebar>
 	))
 	.add('Scheduling: Lunch Break', () => (
 		<Sidebar side="right" isCollapsible={false} isLarge>
 			<SidebarHeader title="Lunch break" onClose={() => null} />
-			<EventDetails isLoading={boolean('isLoading', false)} {...lunchBreak} />
+			<EventDetails
+				isLoading={boolean('isLoading', false)}
+				{...lunchBreak}
+				onAction={action => {
+					console.log(JSON.stringify(action.payload))
+				}}
+			/>
 		</Sidebar>
 	))
 
 	.add('Scheduling: PTO', () => (
 		<Sidebar side="right" isCollapsible={false} isLarge>
 			<SidebarHeader title="PTO" onClose={() => null} />
-			<EventDetails isLoading={boolean('isLoading', false)} {...ptoBlock} />
+			<EventDetails
+				isLoading={boolean('isLoading', false)}
+				{...ptoBlock}
+				onAction={action => {
+					console.log(JSON.stringify(action.payload))
+				}}
+			/>
 		</Sidebar>
 	))

--- a/packages/react-heartwood-components/src/components/EventDetails/EventDetails.tsx
+++ b/packages/react-heartwood-components/src/components/EventDetails/EventDetails.tsx
@@ -4,7 +4,8 @@ import cx from 'classnames'
 import {
 	IHWCalendarEventDetails,
 	IHWCalendarEventDetailsItemType,
-	IHWCalendarEventDetailsItem
+	IHWCalendarEventDetailsItem,
+	IHWAction
 } from '@sprucelabs/spruce-types'
 
 import EventDetailsItem from './components/EventDetailsItem/EventDetailsItem'
@@ -35,6 +36,9 @@ export interface IEventDetailsProps
 
 	/** all the items that make up this event details component */
 	items: IEventDetailsItemProps[]
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 
 interface IEventDetailsState {}
@@ -44,7 +48,7 @@ export default class EventDetails extends Component<
 	IEventDetailsState
 > {
 	public render(): React.ReactElement {
-		const { items, isLoading } = this.props
+		const { items, isLoading, onAction } = this.props
 
 		const className = cx('event-details', {
 			'loading-placeholder': isLoading
@@ -65,7 +69,11 @@ export default class EventDetails extends Component<
 								item.type === IHWCalendarEventDetailsItemType.CardBuilder
 						})}
 					>
-						<EventDetailsItem type={item.type} viewModel={item.viewModel} />
+						<EventDetailsItem
+							type={item.type}
+							viewModel={item.viewModel}
+							onAction={onAction}
+						/>
 					</div>
 				))}
 			</div>

--- a/packages/react-heartwood-components/src/components/EventDetails/components/EventDetailsItem/EventDetailsItem.tsx
+++ b/packages/react-heartwood-components/src/components/EventDetails/components/EventDetailsItem/EventDetailsItem.tsx
@@ -10,7 +10,10 @@ import SplitButton, {
 } from '../../../SplitButton/SplitButton'
 import Text, { ITextProps } from '../../../Text/Text'
 import Toast, { IToastProps } from '../../../Toast/Toast'
-import { IHWCalendarEventDetailsItem } from '@sprucelabs/spruce-types'
+import {
+	IHWCalendarEventDetailsItem,
+	IHWAction
+} from '@sprucelabs/spruce-types'
 
 const MDTextContainer = (props: IMarkdownProps): React.ReactElement => (
 	<div className="event-details__markdown">
@@ -38,12 +41,15 @@ export interface IEventDetailsItemProps
 		| ITextProps
 		| IMarkdownProps
 		| ISplitButtonProps
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 
 const EventDetailsItem = (
 	props: IEventDetailsItemProps
 ): React.ReactElement => {
-	const { type, viewModel } = props
+	const { type, viewModel, onAction } = props
 
 	if (!type || !components[type]) {
 		// TODO: Use logger library for warning
@@ -54,7 +60,7 @@ const EventDetailsItem = (
 	}
 
 	const Handler = components[type]
-	return <Handler {...viewModel} />
+	return <Handler {...viewModel} onAction={onAction} />
 }
 
 export default EventDetailsItem

--- a/packages/react-heartwood-components/src/components/EventDetails/eventDetailsMock.ts
+++ b/packages/react-heartwood-components/src/components/EventDetails/eventDetailsMock.ts
@@ -1,11 +1,12 @@
 import { IEventDetailsItemProps } from './components/EventDetailsItem/EventDetailsItem'
 import { IEventDetailsProps } from './EventDetails'
-import { IListProps } from '../List'
+import { IListProps, IWrappedItemProps } from '../List'
 import {
 	IHWCalendarEventDetailsItemType,
 	IHWListItemSelectableType,
 	IHWContextMenuSize,
-	IHWCardBuilderBodyItemType
+	IHWCardBuilderBodyItemType,
+	IHWActionTypes
 } from '@sprucelabs/spruce-types'
 import { ButtonKinds } from '../Button/Button'
 
@@ -30,10 +31,22 @@ const services: IEventDetailsItemProps = {
 					size: IHWContextMenuSize.Large,
 					actions: [
 						{
-							text: 'Change teammate'
+							text: 'Change teammate',
+							action: {
+								type: IHWActionTypes.EmitEvent,
+								payload: {
+									eventName: 'change-teammate'
+								}
+							}
 						},
 						{
-							text: 'Remove from appointment'
+							text: 'Remove from appointment',
+							action: {
+								type: IHWActionTypes.EmitEvent,
+								payload: {
+									eventName: 'remove-from-appointment'
+								}
+							}
 						}
 					]
 				}
@@ -52,10 +65,22 @@ const services: IEventDetailsItemProps = {
 					size: IHWContextMenuSize.Large,
 					actions: [
 						{
-							text: 'Change teammate'
+							text: 'Change teammate',
+							action: {
+								type: IHWActionTypes.EmitEvent,
+								payload: {
+									eventName: 'change-teammate'
+								}
+							}
 						},
 						{
-							text: 'Remove from appointment'
+							text: 'Remove from appointment',
+							action: {
+								type: IHWActionTypes.EmitEvent,
+								payload: {
+									eventName: 'remove-from-appointment'
+								}
+							}
 						}
 					]
 				}
@@ -66,20 +91,32 @@ const services: IEventDetailsItemProps = {
 				icon: { name: 'add' },
 				primaryAction: {
 					icon: { name: 'add' },
-					kind: ButtonKinds.Simple
+					kind: ButtonKinds.Simple,
+					action: {
+						type: IHWActionTypes.EmitEvent,
+						payload: {
+							eventName: 'add-service'
+						}
+					}
 				}
 			}
 		]
 	}
 }
 
-const inclusiveStatuses = [
+const inclusiveStatuses: IWrappedItemProps[] = [
 	{
 		id: 'status',
 		title: 'Confirmed',
 		selectableId: 'confirmed',
 		selectableProps: {
-			name: 'checkbox'
+			name: 'checkbox',
+			action: {
+				type: IHWActionTypes.EmitEvent,
+				payload: {
+					eventName: 'checkbox-checked'
+				}
+			}
 		}
 	},
 	{
@@ -87,17 +124,29 @@ const inclusiveStatuses = [
 		title: 'Checked in',
 		selectableId: 'checkedIn',
 		selectableProps: {
-			name: 'checkbox'
+			name: 'checkbox',
+			action: {
+				type: IHWActionTypes.EmitEvent,
+				payload: {
+					eventName: 'checkbox-checked'
+				}
+			}
 		}
 	}
 ]
-const exclusiveStatuses = [
+const exclusiveStatuses: IWrappedItemProps[] = [
 	{
 		id: 'on-time',
 		title: 'On time',
 		selectableId: 'onTime',
 		selectableProps: {
-			name: 'radio'
+			name: 'radio',
+			action: {
+				type: IHWActionTypes.EmitEvent,
+				payload: {
+					eventName: 'radio-checked'
+				}
+			}
 		}
 	},
 	{
@@ -105,7 +154,13 @@ const exclusiveStatuses = [
 		title: 'Late',
 		selectableId: 'late',
 		selectableProps: {
-			name: 'radio'
+			name: 'radio',
+			action: {
+				type: IHWActionTypes.EmitEvent,
+				payload: {
+					eventName: 'radio-checked'
+				}
+			}
 		}
 	},
 	{
@@ -113,7 +168,13 @@ const exclusiveStatuses = [
 		title: 'Ghosted 👻',
 		selectableId: 'noShow',
 		selectableProps: {
-			name: 'radio'
+			name: 'radio',
+			action: {
+				type: IHWActionTypes.EmitEvent,
+				payload: {
+					eventName: 'radio-checked'
+				}
+			}
 		}
 	}
 ]
@@ -163,10 +224,22 @@ export const appointment: { items: IEventDetailsItemProps[] } = {
 							size: IHWContextMenuSize.Large,
 							actions: [
 								{
-									text: 'Edit guest'
+									text: 'Edit guest',
+									action: {
+										type: IHWActionTypes.EmitEvent,
+										payload: {
+											eventName: 'edit-guest'
+										}
+									}
 								},
 								{
-									text: 'Book for someone else'
+									text: 'Book for someone else',
+									action: {
+										type: IHWActionTypes.EmitEvent,
+										payload: {
+											eventName: 'book-for-someone-else'
+										}
+									}
 								}
 							]
 						}
@@ -179,7 +252,13 @@ export const appointment: { items: IEventDetailsItemProps[] } = {
 						actions: [
 							{
 								icon: { name: 'edit' },
-								kind: ButtonKinds.Simple
+								kind: ButtonKinds.Simple,
+								action: {
+									type: IHWActionTypes.EmitEvent,
+									payload: {
+										eventName: 'edit-note'
+									}
+								}
 							}
 						]
 					}
@@ -200,7 +279,13 @@ export const appointment: { items: IEventDetailsItemProps[] } = {
 							{
 								id: 'first',
 								icon: { name: 'edit' },
-								kind: ButtonKinds.Simple
+								kind: ButtonKinds.Simple,
+								action: {
+									type: IHWActionTypes.EmitEvent,
+									payload: {
+										eventName: 'edit-date'
+									}
+								}
 							}
 						]
 					}
@@ -239,23 +324,59 @@ export const appointment: { items: IEventDetailsItemProps[] } = {
 				isFullWidth: true,
 				defaultAction: {
 					text: 'Check guest in',
-					isFullWidth: true
+					isFullWidth: true,
+					action: {
+						type: IHWActionTypes.EmitEvent,
+						payload: {
+							eventName: 'guest-check-in'
+						}
+					}
 				},
 				actions: [
 					{
-						text: 'Unconfirm appointment'
+						text: 'Unconfirm appointment',
+						action: {
+							type: IHWActionTypes.EmitEvent,
+							payload: {
+								eventName: 'unconfirm'
+							}
+						}
 					},
 					{
-						text: 'Mark guest as late'
+						text: 'Mark guest as late',
+						action: {
+							type: IHWActionTypes.EmitEvent,
+							payload: {
+								eventName: 'mark-late'
+							}
+						}
 					},
 					{
-						text: 'Mark as no show'
+						text: 'Mark as no show',
+						action: {
+							type: IHWActionTypes.EmitEvent,
+							payload: {
+								eventName: 'mark-no-show'
+							}
+						}
 					},
 					{
-						text: 'Book again'
+						text: 'Book again',
+						action: {
+							type: IHWActionTypes.EmitEvent,
+							payload: {
+								eventName: 'book-again'
+							}
+						}
 					},
 					{
-						text: 'Cancel appointment'
+						text: 'Cancel appointment',
+						action: {
+							type: IHWActionTypes.EmitEvent,
+							payload: {
+								eventName: 'cancel-appointment'
+							}
+						}
 					}
 				]
 			}
@@ -282,10 +403,22 @@ export const warningAppointment: IEventDetailsProps = {
 							size: IHWContextMenuSize.Large,
 							actions: [
 								{
-									text: 'Edit guest'
+									text: 'Edit guest',
+									action: {
+										type: IHWActionTypes.EmitEvent,
+										payload: {
+											eventName: 'edit-guest'
+										}
+									}
 								},
 								{
-									text: 'Book for someone else'
+									text: 'Book for someone else',
+									action: {
+										type: IHWActionTypes.EmitEvent,
+										payload: {
+											eventName: 'book-for-someone-else'
+										}
+									}
 								}
 							]
 						}
@@ -298,7 +431,13 @@ export const warningAppointment: IEventDetailsProps = {
 						actions: [
 							{
 								icon: { name: 'edit' },
-								kind: ButtonKinds.Simple
+								kind: ButtonKinds.Simple,
+								action: {
+									type: IHWActionTypes.EmitEvent,
+									payload: {
+										eventName: 'edit-note'
+									}
+								}
 							}
 						]
 					}
@@ -324,7 +463,13 @@ export const warningAppointment: IEventDetailsProps = {
 										actions: [
 											{
 												icon: { name: 'edit' },
-												kind: ButtonKinds.Simple
+												kind: ButtonKinds.Simple,
+												action: {
+													type: IHWActionTypes.EmitEvent,
+													payload: {
+														eventName: 'edit-date'
+													}
+												}
 											}
 										],
 										warnings: {
@@ -353,13 +498,25 @@ export const warningAppointment: IEventDetailsProps = {
 								text: 'Dismiss',
 								kind: ButtonKinds.Simple,
 								isSmall: true,
-								id: 'foo'
+								id: 'foo',
+								action: {
+									type: IHWActionTypes.EmitEvent,
+									payload: {
+										eventName: 'dismiss'
+									}
+								}
 							},
 							{
 								text: 'Find a different time',
 								kind: ButtonKinds.Secondary,
 								isSmall: true,
-								id: 'bar'
+								id: 'bar',
+								action: {
+									type: IHWActionTypes.EmitEvent,
+									payload: {
+										eventName: 'find-different-time'
+									}
+								}
 							}
 						]
 					}
@@ -404,23 +561,59 @@ export const warningAppointment: IEventDetailsProps = {
 				isFullWidth: true,
 				defaultAction: {
 					text: 'Check guest in',
-					isFullWidth: true
+					isFullWidth: true,
+					action: {
+						type: IHWActionTypes.EmitEvent,
+						payload: {
+							eventName: 'check-in'
+						}
+					}
 				},
 				actions: [
 					{
-						text: 'Unconfirm appointment'
+						text: 'Unconfirm appointment',
+						action: {
+							type: IHWActionTypes.EmitEvent,
+							payload: {
+								eventName: 'unconfirm'
+							}
+						}
 					},
 					{
-						text: 'Mark guest as late'
+						text: 'Mark guest as late',
+						action: {
+							type: IHWActionTypes.EmitEvent,
+							payload: {
+								eventName: 'mark-late'
+							}
+						}
 					},
 					{
-						text: 'Mark as no show'
+						text: 'Mark as no show',
+						action: {
+							type: IHWActionTypes.EmitEvent,
+							payload: {
+								eventName: 'mark-no-show'
+							}
+						}
 					},
 					{
-						text: 'Book again'
+						text: 'Book again',
+						action: {
+							type: IHWActionTypes.EmitEvent,
+							payload: {
+								eventName: 'book-again'
+							}
+						}
 					},
 					{
-						text: 'Cancel appointment'
+						text: 'Cancel appointment',
+						action: {
+							type: IHWActionTypes.EmitEvent,
+							payload: {
+								eventName: 'cancel-appointment'
+							}
+						}
 					}
 				]
 			}
@@ -443,7 +636,13 @@ export const pastAppointment: IEventDetailsProps = {
 						actions: [
 							{
 								icon: { name: 'edit' },
-								kind: ButtonKinds.Simple
+								kind: ButtonKinds.Simple,
+								action: {
+									type: IHWActionTypes.EmitEvent,
+									payload: {
+										eventName: 'edit-guest'
+									}
+								}
 							}
 						]
 					},
@@ -455,7 +654,13 @@ export const pastAppointment: IEventDetailsProps = {
 						actions: [
 							{
 								icon: { name: 'edit' },
-								kind: ButtonKinds.Simple
+								kind: ButtonKinds.Simple,
+								action: {
+									type: IHWActionTypes.EmitEvent,
+									payload: {
+										eventName: 'edit-note'
+									}
+								}
 							}
 						]
 					}
@@ -528,11 +733,23 @@ export const pastAppointment: IEventDetailsProps = {
 				isFullWidth: true,
 				defaultAction: {
 					text: 'Book again',
-					isFullWidth: true
+					isFullWidth: true,
+					action: {
+						type: IHWActionTypes.EmitEvent,
+						payload: {
+							eventName: 'book-again'
+						}
+					}
 				},
 				actions: [
 					{
-						text: 'Edit past appointment'
+						text: 'Edit past appointment',
+						action: {
+							type: IHWActionTypes.EmitEvent,
+							payload: {
+								eventName: 'edit-past-appointment'
+							}
+						}
 					}
 				]
 			}
@@ -591,7 +808,13 @@ export const lunchBreak: IEventDetailsProps = {
 				id: 'actions',
 				text: 'Reschedule',
 				kind: ButtonKinds.Secondary,
-				isFullWidth: true
+				isFullWidth: true,
+				action: {
+					type: IHWActionTypes.EmitEvent,
+					payload: {
+						eventName: 'reschedule'
+					}
+				}
 			}
 		}
 	]
@@ -648,7 +871,13 @@ export const ptoBlock: IEventDetailsProps = {
 				id: 'actions',
 				text: 'Edit PTO Block',
 				kind: ButtonKinds.Secondary,
-				isFullWidth: true
+				isFullWidth: true,
+				action: {
+					type: IHWActionTypes.EmitEvent,
+					payload: {
+						eventName: 'edit-pto-block'
+					}
+				}
 			}
 		}
 	]

--- a/packages/react-heartwood-components/src/components/Forms/components/Checkbox/Checkbox.tsx
+++ b/packages/react-heartwood-components/src/components/Forms/components/Checkbox/Checkbox.tsx
@@ -1,10 +1,9 @@
-import React, { Component, ChangeEvent } from 'react'
+import { IHWAction, IHWCheckbox } from '@sprucelabs/spruce-types'
 import cx from 'classnames'
-
+import React, { ChangeEvent, Component } from 'react'
 import CheckIconYes from '../../../../../static/assets/icons/ic_check_box.svg'
 import CheckIconNo from '../../../../../static/assets/icons/ic_check_box_outline_blank.svg'
 import CheckIconMaybe from '../../../../../static/assets/icons/ic_indeterminate_check_box.svg'
-import { IHWCheckbox } from '@sprucelabs/spruce-types'
 
 export interface ICheckboxProps extends Omit<IHWCheckbox, 'isIndeterminate'> {
 	/** Class for the checkbox wrapper */
@@ -15,6 +14,9 @@ export interface ICheckboxProps extends Omit<IHWCheckbox, 'isIndeterminate'> {
 
 	/** Is this 3 states, on, off, or half */
 	isIndeterminate?: boolean
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 
 interface ICheckboxState {}
@@ -50,13 +52,15 @@ export default class Checkbox extends Component<
 
 	public render(): React.ReactElement {
 		const {
-			id,
-			label,
-			postText,
+			action,
 			className,
-			name,
+			id,
 			isChecked,
-			isDisabled
+			isDisabled,
+			label,
+			name,
+			onAction,
+			postText
 		} = this.props
 		const parentClass = cx('checkbox-item', className)
 
@@ -72,7 +76,13 @@ export default class Checkbox extends Component<
 						disabled={isDisabled || false}
 						id={id}
 						// Always use internal change handler
-						onChange={this.handleChange}
+						onChange={(...args) => {
+							this.handleChange(...args)
+
+							if (onAction && action) {
+								onAction(action)
+							}
+						}}
 						type="checkbox"
 					/>
 					<label className="checkbox-item__label" htmlFor={id}>

--- a/packages/react-heartwood-components/src/components/Forms/components/Radio/Radio.tsx
+++ b/packages/react-heartwood-components/src/components/Forms/components/Radio/Radio.tsx
@@ -1,4 +1,4 @@
-import { IHWRadio } from '@sprucelabs/spruce-types'
+import { IHWAction, IHWRadio } from '@sprucelabs/spruce-types'
 import cx from 'classnames'
 import React from 'react'
 import RadioIconYes from '../../../../../static/assets/icons/ic_radio_button_checked.svg'
@@ -13,16 +13,21 @@ export interface IRadioProps extends Omit<IHWRadio, 'id'> {
 
 	/** Change handler */
 	onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 
 const Radio = (props: IRadioProps): React.ReactElement => {
 	const {
-		isChecked,
+		action,
 		className,
-		isDisabled,
 		id,
+		isChecked,
+		isDisabled,
 		label,
 		name,
+		onAction,
 		onChange,
 		postText
 	} = props
@@ -36,7 +41,15 @@ const Radio = (props: IRadioProps): React.ReactElement => {
 					disabled={isDisabled || false}
 					id={id}
 					name={name || undefined}
-					onChange={onChange}
+					onChange={(...args) => {
+						if (onChange) {
+							onChange(...args)
+						}
+
+						if (onAction && action) {
+							onAction(action)
+						}
+					}}
 					type="radio"
 				/>
 				<label className="checkbox-item__label" htmlFor={id}>

--- a/packages/react-heartwood-components/src/components/List/List.tsx
+++ b/packages/react-heartwood-components/src/components/List/List.tsx
@@ -1,17 +1,13 @@
-import React, { Fragment } from 'react'
+import { IHWAction, IHWList } from '@sprucelabs/spruce-types'
 import cx from 'classnames'
+import React, { Fragment } from 'react'
+import ExpandableListItem, {
+	IExpandableListItemProps
+} from './components/ExpandableListItem/ExpandableListItem'
 import ListHeader, {
 	IListHeaderProps
 } from './components/ListHeader/ListHeader'
 import ListItem, { IListItemProps } from './components/ListItem/ListItem'
-import ExpandableListItem, {
-	IExpandableListItemProps
-} from './components/ExpandableListItem/ExpandableListItem'
-import { IHWList } from '@sprucelabs/spruce-types'
-
-export const ListWrapper = (props): React.ReactElement => (
-	<div className="list-wrapper">{props.children}</div>
-)
 
 export type IWrappedItemProps = IListItemProps | IExpandableListItemProps
 
@@ -33,6 +29,9 @@ export interface IListProps extends Omit<IHWList, 'id' | 'header' | 'items'> {
 
 	/** Is this whole list in a loading state? Sets all list items to loading only if true. */
 	isLoading?: boolean
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 
 const List = (props: IListProps): React.ReactElement => {
@@ -44,7 +43,8 @@ const List = (props: IListProps): React.ReactElement => {
 		areSeparatorsVisible: areSeparatorsVisibleProp,
 		children,
 		selectableType,
-		isLoading
+		isLoading,
+		onAction
 	} = props
 
 	// seperators a true by default
@@ -83,10 +83,17 @@ const List = (props: IListProps): React.ReactElement => {
 											? listItem.isSeparatorVisible
 											: areSeparatorsVisible
 									}
+									onAction={onAction}
 								/>
 							)
 						}
-						return <ExpandableListItem key={idx} {...expandablListItem} />
+						return (
+							<ExpandableListItem
+								key={idx}
+								{...expandablListItem}
+								onAction={onAction}
+							/>
+						)
 					})}
 				{children && children}
 			</ul>

--- a/packages/react-heartwood-components/src/components/List/List.tsx
+++ b/packages/react-heartwood-components/src/components/List/List.tsx
@@ -34,6 +34,10 @@ export interface IListProps extends Omit<IHWList, 'id' | 'header' | 'items'> {
 	onAction?: (action: IHWAction) => any
 }
 
+export const ListWrapper = (props): React.ReactElement => (
+	<div className="list-wrapper">{props.children}</div>
+)
+
 const List = (props: IListProps): React.ReactElement => {
 	const {
 		header,

--- a/packages/react-heartwood-components/src/components/List/components/ExpandableListItem/ExpandableListItem.tsx
+++ b/packages/react-heartwood-components/src/components/List/components/ExpandableListItem/ExpandableListItem.tsx
@@ -1,8 +1,8 @@
+import { IHWAction, IHWExpandableListItem } from '@sprucelabs/spruce-types'
 import React, { Component } from 'react'
+import { ButtonKinds } from '../../../Button/Button'
 import { IListProps } from '../../List'
 import ListItem, { IListItemProps } from '../ListItem/ListItem'
-import { IHWExpandableListItem } from '@sprucelabs/spruce-types'
-import { ButtonKinds } from '../../../Button/Button'
 
 export interface IExpandableListItemProps
 	extends Omit<IHWExpandableListItem, 'item' | 'list' | 'lists'> {
@@ -14,6 +14,9 @@ export interface IExpandableListItemProps
 
 	/** Optional; adds multiple lists nested at the same level */
 	lists?: IListProps[]
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 interface IExpandableListItemState {
 	/** Is the list item expanded */
@@ -40,7 +43,8 @@ export default class ExpandableListItem extends Component<
 			list,
 			lists,
 			collapsedIconName,
-			expandedIconName
+			expandedIconName,
+			onAction
 		} = this.props
 		const { isExpanded } = this.state
 		return (
@@ -59,6 +63,7 @@ export default class ExpandableListItem extends Component<
 						onClick: this.toggleExpanded
 					}
 				]}
+				onAction={onAction}
 			/>
 		)
 	}

--- a/packages/react-heartwood-components/src/components/List/components/ListItem/ListItem.tsx
+++ b/packages/react-heartwood-components/src/components/List/components/ListItem/ListItem.tsx
@@ -1,21 +1,22 @@
+import {
+	IHWAction,
+	IHWListItem,
+	IHWListItemSelectableType
+} from '@sprucelabs/spruce-types'
 import cx from 'classnames'
-import React, { Fragment } from 'react'
 import cloneDeep from 'lodash/cloneDeep'
+import React, { Fragment } from 'react'
 import Avatar from '../../../Avatar/Avatar'
 import Button, { IButtonProps } from '../../../Button/Button'
 import ContextMenu, {
 	IContextMenuProps
 } from '../../../ContextMenu/ContextMenu'
 import { Checkbox, Radio, Toggle } from '../../../Forms'
-import Icon, { IIconProps } from '../../../Icon/Icon'
-import List, { IListProps } from '../../List'
-import {
-	IHWListItem,
-	IHWListItemSelectableType
-} from '@sprucelabs/spruce-types'
-import { IToggleProps } from '../../../Forms/components/Toggle/Toggle'
 import { ICheckboxProps } from '../../../Forms/components/Checkbox/Checkbox'
 import { IRadioProps } from '../../../Forms/components/Radio/Radio'
+import { IToggleProps } from '../../../Forms/components/Toggle/Toggle'
+import Icon, { IIconProps } from '../../../Icon/Icon'
+import List, { IListProps } from '../../List'
 
 export interface IListItemProps
 	extends Omit<
@@ -65,33 +66,37 @@ export interface IListItemProps
 
 	/** In a loading state, loading placeholders will be dropped in */
 	isLoading?: boolean
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 
 const ListItem = (props: IListItemProps): React.ReactElement => {
 	const {
-		title,
-		subtitle,
-		note,
-		avatar,
-		image,
-		icon,
-		isIconHidden,
-		isDraggable,
-		isDisabled,
-		toggleId,
-		primaryAction,
 		actions,
-		contextMenu,
-		toggleProps,
-		isSeparatorVisible,
+		avatar,
 		className,
+		contextMenu,
+		icon,
+		image,
+		isDisabled,
+		isDraggable,
+		isIconHidden,
+		isLoading,
+		isSeparatorVisible,
+		list,
+		lists,
+		note,
+		onAction,
+		primaryAction,
 		selectableId: selectableIdProp,
 		selectableProps,
 		selectableType,
-		warnings,
-		list,
-		lists,
-		isLoading
+		subtitle,
+		title,
+		toggleId,
+		toggleProps,
+		warnings
 	} = props
 
 	let checkboxProps: ICheckboxProps | undefined
@@ -153,6 +158,7 @@ const ListItem = (props: IListItemProps): React.ReactElement => {
 										id={selectableId}
 										{...(isDisabled ? { disabled: true } : {})}
 										{...checkboxProps}
+										onAction={onAction}
 									/>
 								)}
 							{selectableType === IHWListItemSelectableType.Radio &&
@@ -161,6 +167,7 @@ const ListItem = (props: IListItemProps): React.ReactElement => {
 										id={selectableId}
 										{...(isDisabled ? { disabled: true } : {})}
 										{...radioProps}
+										onAction={onAction}
 									/>
 								)}
 						</Fragment>
@@ -232,30 +239,33 @@ const ListItem = (props: IListItemProps): React.ReactElement => {
 									isSmall
 									className="list-item__action"
 									{...action}
+									onAction={onAction}
 								/>
 							))}
 						</div>
 					)}
 					{contextMenu && (
 						<div className="list-item__actions-wrapper">
-							<ContextMenu {...contextMenu} />
+							<ContextMenu {...contextMenu} onAction={onAction} />
 						</div>
 					)}
 				</Fragment>
 			)}
 			{toggleId && <Toggle id={toggleId} {...toggleProps} />}
 
-			{list && <List {...list} />}
+			{list && <List {...list} onAction={onAction} />}
 			{lists &&
 				lists.length > 0 &&
-				lists.map((list, idx) => <List key={idx} {...list} />)}
+				lists.map((list, idx) => (
+					<List key={idx} {...list} onAction={onAction} />
+				))}
 		</Fragment>
 	)
 
 	return (
 		<li className={parentClass}>
 			{primaryAction ? (
-				<Button {...primaryAction}>
+				<Button {...primaryAction} onAction={onAction}>
 					<ListItemInner />
 				</Button>
 			) : (

--- a/packages/react-heartwood-components/src/components/SplitButton/SplitButton.tsx
+++ b/packages/react-heartwood-components/src/components/SplitButton/SplitButton.tsx
@@ -1,9 +1,13 @@
+import {
+	IHWAction,
+	IHWButtonGroupKind,
+	IHWSplitButton
+} from '@sprucelabs/spruce-types'
+import cx from 'classnames'
 import React, { Component, Fragment } from 'react'
 import { createPortal } from 'react-dom'
-import cx from 'classnames'
 import Button, { IButtonProps } from '../Button/Button'
 import ButtonGroup from '../ButtonGroup/ButtonGroup'
-import { IHWSplitButton, IHWButtonGroupKind } from '@sprucelabs/spruce-types'
 
 export interface ISplitButtonProps
 	extends Omit<IHWSplitButton, 'actions' | 'defaultAction'> {
@@ -11,6 +15,9 @@ export interface ISplitButtonProps
 
 	/** All the secondary nested actions */
 	actions: IButtonProps[]
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 
 interface ISplitButtonState {
@@ -189,7 +196,8 @@ export default class SplitButton extends Component<
 			kind,
 			isFullWidth,
 			isSmall,
-			usePortal
+			usePortal,
+			onAction
 		} = this.props
 		const { isVisible, menuPosition, highlightedActionIndex } = this.state
 
@@ -201,6 +209,7 @@ export default class SplitButton extends Component<
 					isSmall={isSmall}
 					{...defaultAction}
 					kind={defaultAction.kind || kind}
+					onAction={onAction}
 				/>
 			)
 		}
@@ -219,6 +228,7 @@ export default class SplitButton extends Component<
 						{...defaultAction}
 						kind={defaultAction.kind || kind}
 						isFullWidth={false}
+						onAction={onAction}
 					/>
 					<Button
 						isSmall={isSmall}
@@ -226,6 +236,7 @@ export default class SplitButton extends Component<
 						icon={{ name: 'keyboard_arrow_down' }}
 						kind={kind}
 						onClick={this.toggleActionsVisibility}
+						onAction={onAction}
 					/>
 				</div>
 				{isVisible && (
@@ -246,6 +257,7 @@ export default class SplitButton extends Component<
 										isFullWidth
 										actions={actions}
 										highlightedIndex={highlightedActionIndex}
+										onAction={onAction}
 									/>
 								</div>,
 								document.body
@@ -265,6 +277,7 @@ export default class SplitButton extends Component<
 									isFullWidth
 									actions={actions}
 									highlightedIndex={highlightedActionIndex}
+									onAction={onAction}
 								/>
 							</div>
 						)}

--- a/packages/spruce-types/src/generated/hw-gql.ts
+++ b/packages/spruce-types/src/generated/hw-gql.ts
@@ -77,6 +77,8 @@ export type IHWActionCoreRedirect = {
   __typename?: 'ActionCoreRedirect',
   type?: Maybe<IHWActionTypes>,
   payload: IHWActionCoreRedirectPayload,
+  onComplete?: Maybe<IHWAction>,
+  onCancel?: Maybe<IHWAction>,
 };
 
 /** payload used for core redirect */

--- a/packages/spruce-types/src/gql/ActionExecutor.gql
+++ b/packages/spruce-types/src/gql/ActionExecutor.gql
@@ -34,6 +34,8 @@ type ActionCoreRedirectPayload {
 type ActionCoreRedirect {
 	type: ActionTypes
 	payload: ActionCoreRedirectPayload!
+	onComplete: Action
+	onCancel: Action
 }
 
 "payload used when redirecting a skill view"


### PR DESCRIPTION
## What does this PR do?
- Applies action executors to EventDetails as specified in https://github.com/sprucelabsai/spruce-rfcs/tree/master/text/0000-action-executors
- Adds onComplete and onCancel actions to GQL for ActionExecutors
- Adds actions to all elements in EventDetails storybook (logs to console)

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2355](https://sprucelabsai.atlassian.net/browse/SDEV3-2355)