### PR TITLE
HW components can take both generated props and standard props

### DIFF
--- a/packages/react-heartwood-components/src/components/Button/Button.tsx
+++ b/packages/react-heartwood-components/src/components/Button/Button.tsx
@@ -50,7 +50,9 @@ export interface IButtonProps extends Omit<IHWButton, 'id' | 'icon'> {
 	onAction?: (action: IHWAction) => any
 }
 
-const Button = (props: IButtonProps): React.ReactElement => {
+export type Action = IButtonProps | IHWButton
+
+const Button = (props: IButtonProps | IHWButton): React.ReactElement => {
 	const {
 		action,
 		AnchorComponent = BasicAnchor,
@@ -67,8 +69,9 @@ const Button = (props: IButtonProps): React.ReactElement => {
 		onClick,
 		text,
 		type,
+		payload,
 		...rest
-	} = props
+	} = props as IButtonProps
 
 	const btnClass = cx(className, {
 		btn: true,
@@ -93,7 +96,7 @@ const Button = (props: IButtonProps): React.ReactElement => {
 		}
 
 		if (onClick) {
-			onClick(e, props.payload)
+			onClick(e, payload)
 		}
 	}
 

--- a/packages/react-heartwood-components/src/components/Button/Button.tsx
+++ b/packages/react-heartwood-components/src/components/Button/Button.tsx
@@ -53,6 +53,8 @@ export interface IButtonProps extends Omit<IHWButton, 'id' | 'icon'> {
 export type Action = IButtonProps | IHWButton
 
 const Button = (props: IButtonProps | IHWButton): React.ReactElement => {
+	const reactHeartwoodProps = props as IButtonProps
+
 	const {
 		action,
 		AnchorComponent = BasicAnchor,
@@ -71,7 +73,7 @@ const Button = (props: IButtonProps | IHWButton): React.ReactElement => {
 		type,
 		payload,
 		...rest
-	} = props as IButtonProps
+	} = reactHeartwoodProps
 
 	const btnClass = cx(className, {
 		btn: true,

--- a/packages/react-heartwood-components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-heartwood-components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -15,8 +15,11 @@ export interface IButtonGroupProps extends Omit<IHWButtonGroup, 'actions'> {
 const ButtonGroup = (
 	props: IButtonGroupProps | IHWButtonGroup
 ): React.ReactElement => {
-	const { actions, kind, isFullWidth, highlightedIndex } = props
-	const { onAction } = props as IButtonGroupProps
+	const reactHeartwoodProps = props as IButtonGroupProps
+	const commonProps = props as IHWButtonGroup
+
+	const { actions, kind, isFullWidth, highlightedIndex } = commonProps
+	const { onAction } = reactHeartwoodProps
 
 	const parentClass = cx('button-group', {
 		'button-group-segmented': kind === 'segmented',

--- a/packages/react-heartwood-components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-heartwood-components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,18 +1,23 @@
 import { IHWAction, IHWButtonGroup } from '@sprucelabs/spruce-types'
 import cx from 'classnames'
 import React from 'react'
-import Button, { ButtonKinds, IButtonProps } from '../Button/Button'
+import Button, { ButtonKinds, Action } from '../Button/Button'
+import { unionArray } from '../..'
 
 export interface IButtonGroupProps extends Omit<IHWButtonGroup, 'actions'> {
 	/** Array of actions to render the group's buttons. */
-	actions: IButtonProps[]
+	actions: Action[]
 
 	/** optional, provide a handler for Actions */
 	onAction?: (action: IHWAction) => any
 }
 
-const ButtonGroup = (props: IButtonGroupProps): React.ReactElement => {
-	const { actions, kind, isFullWidth, highlightedIndex, onAction } = props
+const ButtonGroup = (
+	props: IButtonGroupProps | IHWButtonGroup
+): React.ReactElement => {
+	const { actions, kind, isFullWidth, highlightedIndex } = props
+	const { onAction } = props as IButtonGroupProps
+
 	const parentClass = cx('button-group', {
 		'button-group-segmented': kind === 'segmented',
 		'button-group-floating': kind === 'floating',
@@ -20,7 +25,7 @@ const ButtonGroup = (props: IButtonGroupProps): React.ReactElement => {
 	})
 	return (
 		<ul className={parentClass}>
-			{actions.map((action, idx) => {
+			{unionArray(actions).map((action, idx) => {
 				return (
 					<li
 						key={action.id}

--- a/packages/react-heartwood-components/src/components/Card/components/CardBuilder.tsx
+++ b/packages/react-heartwood-components/src/components/Card/components/CardBuilder.tsx
@@ -21,11 +21,12 @@ import CardFooter from './CardFooter'
 import CardHeader, { ICardHeaderProps } from './CardHeader'
 import OnboardingCard, { IOnboardingCardProps } from './OnboardingCard'
 import Scores from './Scores'
+import { unionArray } from '../../..'
 
 export interface ICardBuilderFooter
 	extends Omit<IHWCardBuilderFooter, 'buttonGroup'> {
 	/** Render buttons in the Card Footer */
-	buttonGroup?: IButtonGroupProps
+	buttonGroup?: IButtonGroupProps | null
 }
 
 export type CardBuilderBodyItemViewModel =
@@ -60,22 +61,27 @@ export interface ICardBuilderProps
 	id?: string
 
 	/** Card Header props */
-	header?: ICardHeaderProps
+	header?: ICardHeaderProps | null
 
 	/** Image rendered as header */
-	headerImage?: IImageProps
+	headerImage?: IImageProps | null
 
 	/** all onboarding props */
-	onboarding?: IOnboardingCardProps
+	onboarding?: IOnboardingCardProps | null
 
 	/** Card Body props */
-	body?: ICardBuilderBodyProps
+	body?: ICardBuilderBodyProps | null
 
 	/** Card Footer props */
-	footer?: ICardBuilderFooter
+	footer?: ICardBuilderFooter | null
+
+	/** so we can use directly and set our own children */
+	children?: any
 }
 
-const renderItem = (item: ICardBuilderBodyItem): React.ReactElement => {
+const renderItem = (
+	item: ICardBuilderBodyItem | IHWCardBuilderBodyItem
+): React.ReactElement => {
 	const CardBuilderKey = {
 		CardBodyButton: Button,
 		CardBodyImage: Image,
@@ -111,7 +117,9 @@ const renderItem = (item: ICardBuilderBodyItem): React.ReactElement => {
 	)
 }
 
-const CardBuilder = (props: ICardBuilderProps): React.ReactElement => {
+const CardBuilder = (
+	props: ICardBuilderProps | IHWCardBuilder
+): React.ReactElement => {
 	const { header, headerImage, body, footer, onboarding } = props
 	if (onboarding) {
 		return <OnboardingCard {...onboarding} />
@@ -124,10 +132,8 @@ const CardBuilder = (props: ICardBuilderProps): React.ReactElement => {
 		isFullBleed = false,
 		areSectionSeparatorsVisible = false,
 		hasTopPadding = true,
-		hasBottomPadding = true,
-		children
+		hasBottomPadding = true
 	} = body || {
-		children: undefined,
 		items: undefined,
 		isSectioned: true,
 		isFullBleed: false,
@@ -135,6 +141,8 @@ const CardBuilder = (props: ICardBuilderProps): React.ReactElement => {
 		hasTopPadding: true,
 		hasBottomPadding: true
 	}
+
+	const { children } = (body as ICardBuilderProps) || { children: undefined }
 
 	return (
 		<Card>
@@ -153,7 +161,7 @@ const CardBuilder = (props: ICardBuilderProps): React.ReactElement => {
 					isFullBleed={!!isFullBleed}
 				>
 					{children}
-					{Array.isArray(items) ? items.map(renderItem) : items}
+					{Array.isArray(items) ? unionArray(items).map(renderItem) : items}
 				</CardBody>
 			)}
 			{footer && (

--- a/packages/react-heartwood-components/src/components/Card/components/CardHeader.tsx
+++ b/packages/react-heartwood-components/src/components/Card/components/CardHeader.tsx
@@ -20,8 +20,15 @@ export interface ICardHeaderProps
 	contextMenu?: IContextMenuProps | null
 }
 
-const CardHeader = (props: ICardHeaderProps): React.ReactElement => {
-	const { title, labelText, labelIcon, actions, contextMenu } = props
+const CardHeader = (
+	props: ICardHeaderProps | IHWCardHeader
+): React.ReactElement => {
+	const propsComp = props as ICardHeaderProps
+	const propsGql = props as IHWCardHeader
+
+	const { title, labelText, actions, contextMenu } = propsGql
+	const { labelIcon } = propsComp
+
 	return (
 		<div className="card__header">
 			{(title || labelText || labelIcon) && (
@@ -30,7 +37,9 @@ const CardHeader = (props: ICardHeaderProps): React.ReactElement => {
 						<div className="card__header-label">
 							{labelIcon && (
 								<Icon
-									customIcon={labelIcon.customIcon}
+									customIcon={
+										labelIcon.customIcon ? labelIcon.customIcon : undefined
+									}
 									name={labelIcon.name}
 									isLineIcon={labelIcon.isLineIcon}
 									className={cx('card__header-label-icon', labelIcon.className)}

--- a/packages/react-heartwood-components/src/components/Card/components/CardHeader.tsx
+++ b/packages/react-heartwood-components/src/components/Card/components/CardHeader.tsx
@@ -23,11 +23,11 @@ export interface ICardHeaderProps
 const CardHeader = (
 	props: ICardHeaderProps | IHWCardHeader
 ): React.ReactElement => {
-	const propsComp = props as ICardHeaderProps
-	const propsGql = props as IHWCardHeader
+	const reactHeartwoodProps = props as ICardHeaderProps
+	const commonProps = props as IHWCardHeader
 
-	const { title, labelText, actions, contextMenu } = propsGql
-	const { labelIcon } = propsComp
+	const { title, labelText, actions, contextMenu } = commonProps
+	const { labelIcon } = reactHeartwoodProps
 
 	return (
 		<div className="card__header">

--- a/packages/react-heartwood-components/src/components/Card/components/OnboardingCard.tsx
+++ b/packages/react-heartwood-components/src/components/Card/components/OnboardingCard.tsx
@@ -10,13 +10,14 @@ import {
 	IHWOnboardingCardStep
 } from '@sprucelabs/spruce-types'
 import { IIconProps } from '../../Icon/Icon'
+import { unionArray } from '../../..'
 
 export interface IStep
 	extends Omit<IHWOnboardingCardStep, 'panelCTA' | 'tabIcon'> {
 	/** Primary CTA of this step */
-	panelCTA?: IButtonProps
+	panelCTA?: IButtonProps | null
 
-	tabIcon?: IIconProps
+	tabIcon?: IIconProps | null
 }
 
 export interface IOnboardingCardProps extends Omit<IHWOnboardingCard, 'steps'> {
@@ -31,7 +32,7 @@ interface IOnboardingCardState {
 	currentStep: number
 }
 
-const getCurrentStep = (steps: IStep[]): number => {
+const getCurrentStep = (steps: IStep[] | IHWOnboardingCardStep[]): number => {
 	// Find the first step that is not complete
 	if (steps && steps.length > 0) {
 		for (let i = 0; i < steps.length; i++) {
@@ -44,7 +45,7 @@ const getCurrentStep = (steps: IStep[]): number => {
 }
 
 export default class OnboardingCard extends Component<
-	IOnboardingCardProps,
+	IOnboardingCardProps | IHWOnboardingCard,
 	IOnboardingCardState
 > {
 	public state = {
@@ -60,7 +61,7 @@ export default class OnboardingCard extends Component<
 	public render(): React.ReactElement {
 		const { currentStep } = this.state
 		const { title, steps } = this.props
-		const tabs = steps.map((step, idx) => ({
+		const tabs = unionArray(steps).map((step, idx) => ({
 			text: step.tabTitle,
 			icon: step.tabIcon,
 			isCurrent: idx === currentStep,
@@ -78,9 +79,14 @@ export default class OnboardingCard extends Component<
 				<CardBody isSectioned isFullBleed={false}>
 					{steps[currentStep].panelCopy}
 				</CardBody>
-				<CardFooter>
-					<Button kind={ButtonKinds.Primary} {...steps[currentStep].panelCTA} />
-				</CardFooter>
+				{steps[currentStep].panelCTA && (
+					<CardFooter>
+						<Button
+							kind={ButtonKinds.Primary}
+							{...steps[currentStep].panelCTA}
+						/>
+					</CardFooter>
+				)}
 			</Card>
 		)
 	}

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.tsx
@@ -124,7 +124,9 @@ export default class ContextMenu extends Component<
 	}
 
 	public getMenuPlacement = () => {
-		const { isRightAligned, isBottomAligned } = this.props as IContextMenuProps
+		const reactHeartwoodProps = this.props as IContextMenuProps
+		const { isRightAligned, isBottomAligned } = reactHeartwoodProps
+
 		const triggerPosition = this.getTriggerPlacement()
 
 		if (!triggerPosition) {
@@ -259,20 +261,19 @@ export default class ContextMenu extends Component<
 	}
 
 	public render(): React.ReactElement {
+		const reactHeartwoodProps = this.props as IContextMenuProps
+		const commonProps = this.props as IHWContextMenu
+
 		const { isVisible, overflowBottom, overflowLeft, menuPosition } = this.state
+		const { icon, isSimple, isSmall, isTextOnly, size, text } = commonProps
+
 		const {
 			actions,
-			icon,
-			isSimple,
-			isSmall,
-			isTextOnly,
-			size,
-			text,
 			className,
 			isBottomAligned,
 			isRightAligned,
 			onAction
-		} = this.props as IContextMenuProps
+		} = reactHeartwoodProps
 
 		const buttonClass = cx('context-menu', className, {
 			'context-menu--is-visible': isVisible

--- a/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/react-heartwood-components/src/components/ContextMenu/ContextMenu.tsx
@@ -27,7 +27,7 @@ export interface IContextMenuProps
 	isBottomAligned?: boolean
 
 	/** Overrides the default icon */
-	icon?: IIconProps
+	icon?: IIconProps | null
 
 	/** Optional classname that applies to the button */
 	className?: string
@@ -53,7 +53,7 @@ interface IContextMenuState {
 }
 
 export default class ContextMenu extends Component<
-	IContextMenuProps,
+	IContextMenuProps | IHWContextMenu,
 	IContextMenuState
 > {
 	public static defaultProps = {
@@ -124,7 +124,7 @@ export default class ContextMenu extends Component<
 	}
 
 	public getMenuPlacement = () => {
-		const { isRightAligned, isBottomAligned } = this.props
+		const { isRightAligned, isBottomAligned } = this.props as IContextMenuProps
 		const triggerPosition = this.getTriggerPlacement()
 
 		if (!triggerPosition) {
@@ -219,6 +219,8 @@ export default class ContextMenu extends Component<
 	}
 
 	public handleToggle = (): void => {
+		const { onToggleContextMenuVisible } = this.props as IContextMenuProps
+
 		this.setState(
 			prevState => ({
 				isVisible: !prevState.isVisible
@@ -226,8 +228,8 @@ export default class ContextMenu extends Component<
 			() => {
 				this.manageListeners()
 
-				if (this.props.onToggleContextMenuVisible) {
-					this.props.onToggleContextMenuVisible(this.state.isVisible)
+				if (onToggleContextMenuVisible) {
+					onToggleContextMenuVisible(this.state.isVisible)
 				}
 
 				if (this.state.isVisible) {
@@ -260,17 +262,18 @@ export default class ContextMenu extends Component<
 		const { isVisible, overflowBottom, overflowLeft, menuPosition } = this.state
 		const {
 			actions,
-			className,
 			icon,
-			isBottomAligned,
-			isRightAligned,
 			isSimple,
 			isSmall,
 			isTextOnly,
-			onAction,
 			size,
-			text
-		} = this.props
+			text,
+			className,
+			isBottomAligned,
+			isRightAligned,
+			onAction
+		} = this.props as IContextMenuProps
+
 		const buttonClass = cx('context-menu', className, {
 			'context-menu--is-visible': isVisible
 		})

--- a/packages/react-heartwood-components/src/components/EventDetails/EventDetails.tsx
+++ b/packages/react-heartwood-components/src/components/EventDetails/EventDetails.tsx
@@ -51,7 +51,11 @@ export default class EventDetails extends Component<
 	IEventDetailsState
 > {
 	public render(): React.ReactElement {
-		const { items, isLoading, onAction } = this.props as IEventDetailsProps
+		const reactHeartwoodProps = this.props as IEventDetailsProps
+		const commonProps = this.props as IHWCalendarEventDetails
+
+		const { items } = commonProps
+		const { isLoading, onAction } = reactHeartwoodProps
 
 		const className = cx('event-details', {
 			'loading-placeholder': isLoading

--- a/packages/react-heartwood-components/src/components/EventDetails/EventDetails.tsx
+++ b/packages/react-heartwood-components/src/components/EventDetails/EventDetails.tsx
@@ -5,7 +5,8 @@ import {
 	IHWCalendarEventDetails,
 	IHWCalendarEventDetailsItemType,
 	IHWCalendarEventDetailsItem,
-	IHWAction
+	IHWAction,
+	IHWCalendarEventDetailsItemViewModel
 } from '@sprucelabs/spruce-types'
 
 import EventDetailsItem from './components/EventDetailsItem/EventDetailsItem'
@@ -16,6 +17,7 @@ import { ITextProps } from '../Text/Text'
 import { IMarkdownProps } from '../MarkdownText/MarkdownText'
 import { ISplitButtonProps } from '../SplitButton/SplitButton'
 import { IListProps } from '../List'
+import { unionArray } from '../..'
 
 export interface IEventDetailsItemProps
 	extends Omit<IHWCalendarEventDetailsItem, 'viewModel'> {
@@ -27,6 +29,7 @@ export interface IEventDetailsItemProps
 		| ITextProps
 		| IMarkdownProps
 		| ISplitButtonProps
+		| IHWCalendarEventDetailsItemViewModel
 }
 
 export interface IEventDetailsProps
@@ -35,7 +38,7 @@ export interface IEventDetailsProps
 	isLoading?: boolean
 
 	/** all the items that make up this event details component */
-	items: IEventDetailsItemProps[]
+	items: (IEventDetailsItemProps | IHWCalendarEventDetailsItem)[]
 
 	/** optional, provide a handler for Actions */
 	onAction?: (action: IHWAction) => any
@@ -44,11 +47,11 @@ export interface IEventDetailsProps
 interface IEventDetailsState {}
 
 export default class EventDetails extends Component<
-	IEventDetailsProps,
+	IEventDetailsProps | IHWCalendarEventDetails,
 	IEventDetailsState
 > {
 	public render(): React.ReactElement {
-		const { items, isLoading, onAction } = this.props
+		const { items, isLoading, onAction } = this.props as IEventDetailsProps
 
 		const className = cx('event-details', {
 			'loading-placeholder': isLoading
@@ -56,7 +59,7 @@ export default class EventDetails extends Component<
 
 		return (
 			<div className={className}>
-				{items.map(item => (
+				{unionArray(items).map(item => (
 					<div
 						key={item.viewModel.id}
 						className={cx('event-details__section', {

--- a/packages/react-heartwood-components/src/components/EventDetails/components/EventDetailsItem/EventDetailsItem.tsx
+++ b/packages/react-heartwood-components/src/components/EventDetails/components/EventDetailsItem/EventDetailsItem.tsx
@@ -12,7 +12,8 @@ import Text, { ITextProps } from '../../../Text/Text'
 import Toast, { IToastProps } from '../../../Toast/Toast'
 import {
 	IHWCalendarEventDetailsItem,
-	IHWAction
+	IHWAction,
+	IHWCalendarEventDetailsItemViewModel
 } from '@sprucelabs/spruce-types'
 
 const MDTextContainer = (props: IMarkdownProps): React.ReactElement => (
@@ -31,16 +32,19 @@ const components = {
 	markdown: MDTextContainer
 }
 
+type ViewModel =
+	| IListProps
+	| IButtonProps
+	| ICardBuilderProps
+	| IToastProps
+	| ITextProps
+	| IMarkdownProps
+	| ISplitButtonProps
+	| IHWCalendarEventDetailsItemViewModel
+
 export interface IEventDetailsItemProps
 	extends Omit<IHWCalendarEventDetailsItem, 'viewModel'> {
-	viewModel:
-		| IListProps
-		| IButtonProps
-		| ICardBuilderProps
-		| IToastProps
-		| ITextProps
-		| IMarkdownProps
-		| ISplitButtonProps
+	viewModel: ViewModel
 
 	/** optional, provide a handler for Actions */
 	onAction?: (action: IHWAction) => any

--- a/packages/react-heartwood-components/src/components/EventDetails/eventDetailsMock.ts
+++ b/packages/react-heartwood-components/src/components/EventDetails/eventDetailsMock.ts
@@ -20,17 +20,18 @@ const services: IEventDetailsItemProps = {
 		items: [
 			{
 				id: 'first',
-				icon: { name: 'unordered_list', isLineIcon: true },
+				icon: { name: 'unordered_list', isLineIcon: true, id: 'unordered' },
 				title: 'Accent Highlight',
 				subtitle: '$65 | 1hr',
 				note: 'Vicenta Maggio',
 				contextMenu: {
-					icon: { name: 'edit', isLineIcon: true },
+					icon: { id: 'edit', name: 'edit', isLineIcon: true },
 					isSimple: true,
 					isSmall: true,
 					size: IHWContextMenuSize.Large,
 					actions: [
 						{
+							id: 'save-teammate',
 							text: 'Change teammate',
 							action: {
 								type: IHWActionTypes.EmitEvent,
@@ -40,6 +41,7 @@ const services: IEventDetailsItemProps = {
 							}
 						},
 						{
+							id: 'remove-appointment',
 							text: 'Remove from appointment',
 							action: {
 								type: IHWActionTypes.EmitEvent,
@@ -53,18 +55,19 @@ const services: IEventDetailsItemProps = {
 			},
 			{
 				id: 'second',
-				icon: { name: 'unordered_list', isLineIcon: true },
+				icon: { id: 'second-icon', name: 'unordered_list', isLineIcon: true },
 				isIconHidden: true,
 				title: 'Haircut',
 				subtitle: '$40 | 1hr',
 				note: 'Vicenta Maggio',
 				contextMenu: {
-					icon: { name: 'edit', isLineIcon: true },
+					icon: { id: 'edit', name: 'edit', isLineIcon: true },
 					isSimple: true,
 					isSmall: true,
 					size: IHWContextMenuSize.Large,
 					actions: [
 						{
+							id: 'change-teammate',
 							text: 'Change teammate',
 							action: {
 								type: IHWActionTypes.EmitEvent,
@@ -74,6 +77,7 @@ const services: IEventDetailsItemProps = {
 							}
 						},
 						{
+							id: 'remove',
 							text: 'Remove from appointment',
 							action: {
 								type: IHWActionTypes.EmitEvent,
@@ -88,9 +92,10 @@ const services: IEventDetailsItemProps = {
 			{
 				id: 'last',
 				title: 'Add service',
-				icon: { name: 'add' },
+				icon: { id: 'add', name: 'add' },
 				primaryAction: {
-					icon: { name: 'add' },
+					id: 'add',
+					icon: { id: 'add', name: 'add' },
 					kind: ButtonKinds.Simple,
 					action: {
 						type: IHWActionTypes.EmitEvent,
@@ -523,7 +528,7 @@ export const warningAppointment: IEventDetailsProps = {
 				}
 			}
 		},
-		{ ...services },
+		services,
 		{
 			type: IHWCalendarEventDetailsItemType.List,
 			viewModel: {

--- a/packages/react-heartwood-components/src/components/Image/Image.tsx
+++ b/packages/react-heartwood-components/src/components/Image/Image.tsx
@@ -12,7 +12,11 @@ export interface IImageProps extends Omit<IHWImage, 'id'> {
 }
 
 const Image = (props: IImageProps | IHWImage): React.ReactElement => {
-	const { id, alt, width, height, src } = props as IImageProps
+	const reactHeartwoodProps = props as IImageProps
+	const commonProps = props as IHWImage
+
+	const { id, alt, src } = commonProps
+	const { width, height } = reactHeartwoodProps
 
 	const imageProps = {
 		id: id || undefined,

--- a/packages/react-heartwood-components/src/components/Image/Image.tsx
+++ b/packages/react-heartwood-components/src/components/Image/Image.tsx
@@ -4,13 +4,25 @@ import { IHWImage } from '@sprucelabs/spruce-types'
 export interface IImageProps extends Omit<IHWImage, 'id'> {
 	id?: string
 
-	alt?: string
+	alt?: string | null
 
 	width?: number
 
 	height?: number
 }
 
-const Image = (props: IImageProps): React.ReactElement => <img {...props} />
+const Image = (props: IImageProps | IHWImage): React.ReactElement => {
+	const { id, alt, width, height, src } = props as IImageProps
+
+	const imageProps = {
+		id: id || undefined,
+		alt: alt || undefined,
+		width: width || undefined,
+		height: height || undefined,
+		src: src || undefined
+	}
+
+	return <img {...imageProps} />
+}
 
 export default Image

--- a/packages/react-heartwood-components/src/components/List/List.tsx
+++ b/packages/react-heartwood-components/src/components/List/List.tsx
@@ -1,4 +1,9 @@
-import { IHWAction, IHWList } from '@sprucelabs/spruce-types'
+import {
+	IHWAction,
+	IHWList,
+	IHWListHeader,
+	IHWListItemTypes
+} from '@sprucelabs/spruce-types'
 import cx from 'classnames'
 import React, { Fragment } from 'react'
 import ExpandableListItem, {
@@ -16,10 +21,10 @@ export interface IListProps extends Omit<IHWList, 'id' | 'header' | 'items'> {
 	id?: string
 
 	/** List Header */
-	header?: IListHeaderProps
+	header?: IListHeaderProps | IHWListHeader | null
 
 	/** List items */
-	items?: IWrappedItemProps[]
+	items?: Array<IWrappedItemProps | IHWListItemTypes> | null
 
 	/** Class for the list */
 	className?: string

--- a/packages/react-heartwood-components/src/components/List/components/ListHeader/ListHeader.tsx
+++ b/packages/react-heartwood-components/src/components/List/components/ListHeader/ListHeader.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
 import cx from 'classnames'
-import Button, { IButtonProps } from '../../../Button/Button'
+import Button, { Action } from '../../../Button/Button'
 import { IHWListHeader } from '@sprucelabs/spruce-types'
+import { unionArray } from '../../../..'
 
 export interface IListHeaderProps extends Omit<IHWListHeader, 'actions'> {
-	actions?: IButtonProps[]
+	actions?: Action[]
 }
 
-const ListHeader = (props: IListHeaderProps): React.ReactElement => {
+const ListHeader = (
+	props: IListHeaderProps | IHWListHeader
+): React.ReactElement => {
 	const { title, subtitle, isSmall, actions } = props
 	const parentClass = cx('list-header', { 'list-header-small': isSmall })
 
@@ -17,9 +20,9 @@ const ListHeader = (props: IListHeaderProps): React.ReactElement => {
 				<h3 className="list-header__title">{title}</h3>
 				{subtitle && <p className="list-header__subtitle">{subtitle}</p>}
 			</div>
-			{actions && actions.length > 0 && (
+			{Array.isArray(actions) && actions.length > 0 && (
 				<ul className="list-header__actions">
-					{actions.map((action, idx) => (
+					{unionArray(actions).map((action, idx) => (
 						<li key={idx} className="list-header__action-wrapper">
 							<Button {...action} />
 						</li>

--- a/packages/react-heartwood-components/src/components/Toast/Toast-story.tsx
+++ b/packages/react-heartwood-components/src/components/Toast/Toast-story.tsx
@@ -133,7 +133,7 @@ stories
 			headline={text('headline', 'Neat')}
 			text={text('text', 'Something just happened and it was fine.')}
 			onRemove={() => null}
-			followupAction={() => null}
+			onAction={() => null}
 			followupText={boolean('followupAction', false) ? 'Undo' : undefined}
 		/>
 	))
@@ -147,7 +147,7 @@ stories
 						headline={text('headline', 'Neat') + ' ' + kind + ' toast'}
 						text={text('text', 'Something just happened and it was fine.')}
 						onRemove={() => null}
-						followupAction={() => null}
+						onAction={() => null}
 						followupText={boolean('followupAction', false) ? 'Undo' : undefined}
 					/>
 				</div>

--- a/packages/react-heartwood-components/src/components/Toast/Toast.tsx
+++ b/packages/react-heartwood-components/src/components/Toast/Toast.tsx
@@ -1,14 +1,20 @@
 import React from 'react'
 import cx from 'classnames'
 import Button from '../Button/Button'
-import { IHWToast } from '@sprucelabs/spruce-types'
+import { IHWToast, IHWAction } from '@sprucelabs/spruce-types'
 
-interface IToastHeaderProps extends Omit<IHWToast, 'id'> {
+interface IToastHeaderProps {
 	/**  Optional id for view caching */
 	id?: string
 
 	/** Function to remove the toast */
 	onRemove?: Function
+
+	/** headline */
+	headline?: string
+
+	/** is this toast removable */
+	canRemove?: boolean
 }
 
 const ToastHeader = (props: IToastHeaderProps): React.ReactElement => {
@@ -23,37 +29,30 @@ const ToastHeader = (props: IToastHeaderProps): React.ReactElement => {
 	)
 }
 
-export interface IToastProps {
+export interface IToastProps extends Omit<IHWToast, 'id'> {
 	/** Unique ID for the toast */
 	id: string | number
-
-	/** Headline text */
-	headline: string
-
-	/** Optional; Text after the headline */
-	text?: string
 
 	/** Handle toast removal */
 	onRemove?: Function
 
-	/** Optional; controls whether the toast can be removed. Defaults to true */
-	canRemove?: boolean
-
-	/** Sets the variation of toast */
-	kind?: string
-
-	/** Handle a followup action */
-	followupAction?: Function
-
-	/** Text for the followup action */
-	followupText?: string
-
 	/** override how long before the toast goes away, in milis */
 	timeout?: number | 'never'
+
+	/** optional, provide a handler for Actions */
+	onAction?: (action: IHWAction) => any
 }
 
-const Toast = (props: IToastProps): React.ReactElement => {
-	const { headline, kind, text, followupAction, followupText, onRemove } = props
+const Toast = (props: IToastProps | IHWToast): React.ReactElement => {
+	const {
+		headline,
+		kind,
+		text,
+		followupAction,
+		followupText,
+		onAction,
+		onRemove
+	} = props as IToastProps
 	const toastClass = cx('toast', {
 		'toast-positive': kind === 'positive',
 		'toast-negative': kind === 'negative',
@@ -68,8 +67,8 @@ const Toast = (props: IToastProps): React.ReactElement => {
 					<p>{text}</p>
 				</div>
 			)}
-			{followupAction && (
-				<Button text={followupText} onClick={followupAction} />
+			{followupAction && onAction && (
+				<Button text={followupText} onAction={() => onAction(followupAction)} />
 			)}
 		</div>
 	)

--- a/packages/react-heartwood-components/src/components/Toast/Toast.tsx
+++ b/packages/react-heartwood-components/src/components/Toast/Toast.tsx
@@ -44,15 +44,12 @@ export interface IToastProps extends Omit<IHWToast, 'id'> {
 }
 
 const Toast = (props: IToastProps | IHWToast): React.ReactElement => {
-	const {
-		headline,
-		kind,
-		text,
-		followupAction,
-		followupText,
-		onAction,
-		onRemove
-	} = props as IToastProps
+	const commonProps = props as IHWToast
+	const reactHeartwoodProps = props as IToastProps
+
+	const { headline, kind, text, followupAction, followupText } = commonProps
+	const { onAction, onRemove } = reactHeartwoodProps
+
 	const toastClass = cx('toast', {
 		'toast-positive': kind === 'positive',
 		'toast-negative': kind === 'negative',

--- a/packages/react-heartwood-components/src/index.tsx
+++ b/packages/react-heartwood-components/src/index.tsx
@@ -114,3 +114,9 @@ export { default as SplitButton } from './components/SplitButton/SplitButton'
 export {
 	default as TruncatedList
 } from './components/TruncatedList/TruncatedList'
+
+export type ArrayElem<A> = A extends Array<infer Elem> ? Elem : never
+
+export function unionArray<T>(array: T): Array<ArrayElem<T>> {
+	return array as any
+}

--- a/packages/spruce-types/src/generated/api-gql.ts
+++ b/packages/spruce-types/src/generated/api-gql.ts
@@ -222,6 +222,8 @@ export type ICoreGQLActionCoreRedirect = {
 	__typename?: 'ActionCoreRedirect'
 	type?: Maybe<ICoreGQLActionTypes>
 	payload: ICoreGQLActionCoreRedirectPayload
+	onComplete?: Maybe<ICoreGQLAction>
+	onCancel?: Maybe<ICoreGQLAction>
 }
 
 /** payload used for core redirect */
@@ -265,6 +267,7 @@ export type ICoreGQLActionEmitEventPayload = {
 
 export type ICoreGQLActionExecutor = {
 	action?: Maybe<ICoreGQLAction>
+	id: Scalars['ID']
 }
 
 /** Pop up dialog to edit the user */
@@ -752,7 +755,14 @@ export enum ICoreGQLCalendarEventKind {
 
 export type ICoreGQLCalendarEventStreamResponse = {
 	__typename?: 'CalendarEventStreamResponse'
+	type?: Maybe<ICoreGQLCalendarEventStreamType>
 	CalendarEvent?: Maybe<ICoreGQLCalendarEvent>
+}
+
+export enum ICoreGQLCalendarEventStreamType {
+	Create = 'Create',
+	Update = 'Update',
+	Delete = 'Delete'
 }
 
 /** The builder for all things cards */
@@ -1342,7 +1352,7 @@ export type ICoreGQLExpandableListItem = {
 	/** Optional; adds a nested list */
 	list?: Maybe<ICoreGQLList>
 	/** Optional; adds multiple lists nested at the same level */
-	lists?: Maybe<Array<Maybe<ICoreGQLList>>>
+	lists?: Maybe<Array<ICoreGQLList>>
 	/** Optional icon for collapsed state */
 	collapsedIconName?: Maybe<Scalars['String']>
 	/** Optional icon for expanded state */
@@ -1712,7 +1722,7 @@ export type ICoreGQLGroupHasManyUserGroupsEdge = {
 export type ICoreGQLHeading = {
 	__typename?: 'Heading'
 	/** Id for view caching */
-	id: Scalars['String']
+	id: Scalars['ID']
 	/** HTML rendered directly */
 	html?: Maybe<Scalars['String']>
 	/** Text rendered in the header */
@@ -2012,7 +2022,7 @@ export type ICoreGQLList = {
 	/** List Header */
 	header?: Maybe<ICoreGQLListHeader>
 	/** List items */
-	items?: Maybe<Array<Maybe<ICoreGQLListItemTypes>>>
+	items?: Maybe<Array<ICoreGQLListItemTypes>>
 	/** Set true to make the list smaller */
 	isSmall?: Maybe<Scalars['Boolean']>
 	/** Set to true to show separators between list items */
@@ -2083,7 +2093,7 @@ export type ICoreGQLListItem = {
 	/** Optional; adds a nested list */
 	list?: Maybe<ICoreGQLList>
 	/** Optional; adds multiple lists nested at the same level */
-	lists?: Maybe<Array<Maybe<ICoreGQLList>>>
+	lists?: Maybe<Array<ICoreGQLList>>
 }
 
 export type ICoreGQLListItemSelectablePropsType =
@@ -2571,6 +2581,25 @@ export type ICoreGQLLocationScheduleDetailsTimes = {
 	startTime: Scalars['String']
 	/** The end of the open time for a location schedule */
 	endTime: Scalars['String']
+}
+
+/** A connection to a list of items. */
+export type ICoreGQLLocationsForUserLocationConnectionConnection = {
+	__typename?: 'LocationsForUserLocationConnectionConnection'
+	/** Information to aid in pagination. */
+	pageInfo: ICoreGQLPageInfo
+	/** A list of edges. */
+	edges?: Maybe<Array<Maybe<ICoreGQLLocationsForUserLocationConnectionEdge>>>
+	totalCount?: Maybe<Scalars['Int']>
+}
+
+/** An edge in a connection. */
+export type ICoreGQLLocationsForUserLocationConnectionEdge = {
+	__typename?: 'LocationsForUserLocationConnectionEdge'
+	/** The item at the end of the edge */
+	node?: Maybe<ICoreGQLLocation>
+	/** A cursor for use in pagination */
+	cursor: Scalars['String']
 }
 
 /** A location skill mapping */
@@ -3768,6 +3797,8 @@ export type ICoreGQLQuery = {
 	Location?: Maybe<ICoreGQLLocation>
 	/** Get public information about locations. Max/default limit 50. */
 	Locations?: Maybe<ICoreGQLLocationConnection>
+	/** Get Locations the current user is connected to as a teammate (or above). Max/default limit 50. */
+	LocationsForUser?: Maybe<ICoreGQLLocationsForUserLocationConnectionConnection>
 	/** Check if a location slug is available. */
 	checkLocationSlug?: Maybe<ICoreGQLCheckSlugResponse>
 	/** Check if a store num is available. */
@@ -3968,6 +3999,19 @@ export type ICoreGQLQueryLocationArgs = {
 
 export type ICoreGQLQueryLocationsArgs = {
 	organizationId: Scalars['ID']
+	notInGroupIds?: Maybe<Array<Maybe<Scalars['ID']>>>
+	search?: Maybe<Scalars['String']>
+	limit?: Maybe<Scalars['Int']>
+	order?: Maybe<Scalars['String']>
+	where?: Maybe<Scalars['SequelizeJSON']>
+	offset?: Maybe<Scalars['Int']>
+	after?: Maybe<Scalars['String']>
+	first?: Maybe<Scalars['Int']>
+	before?: Maybe<Scalars['String']>
+	last?: Maybe<Scalars['Int']>
+}
+
+export type ICoreGQLQueryLocationsForUserArgs = {
 	notInGroupIds?: Maybe<Array<Maybe<Scalars['ID']>>>
 	search?: Maybe<Scalars['String']>
 	limit?: Maybe<Scalars['Int']>

--- a/packages/spruce-types/src/generated/hw-gql.ts
+++ b/packages/spruce-types/src/generated/hw-gql.ts
@@ -551,7 +551,7 @@ export type IHWExpandableListItem = {
   /** Optional; adds a nested list */
   list?: Maybe<IHWList>,
   /** Optional; adds multiple lists nested at the same level */
-  lists?: Maybe<Array<Maybe<IHWList>>>,
+  lists?: Maybe<Array<IHWList>>,
   /** Optional icon for collapsed state */
   collapsedIconName?: Maybe<Scalars['String']>,
   /** Optional icon for expanded state */
@@ -611,7 +611,7 @@ export type IHWList = {
   /** List Header */
   header?: Maybe<IHWListHeader>,
   /** List items */
-  items?: Maybe<Array<Maybe<IHWListItemTypes>>>,
+  items?: Maybe<Array<IHWListItemTypes>>,
   /** Set true to make the list smaller */
   isSmall?: Maybe<Scalars['Boolean']>,
   /** Set to true to show separators between list items */
@@ -682,7 +682,7 @@ export type IHWListItem = {
   /** Optional; adds a nested list */
   list?: Maybe<IHWList>,
   /** Optional; adds multiple lists nested at the same level */
-  lists?: Maybe<Array<Maybe<IHWList>>>,
+  lists?: Maybe<Array<IHWList>>,
 };
 
 export type IHWListItemSelectablePropsType = IHWCheckbox | IHWRadio;
@@ -723,7 +723,7 @@ export type IHWOnboardingCard = {
   /** Title of the entire card */
   title?: Maybe<Scalars['String']>,
   /** Steps for onboarding */
-  steps?: Maybe<Array<Maybe<IHWOnboardingCardStep>>>,
+  steps: Array<IHWOnboardingCardStep>,
 };
 
 /** One step in the onboarding process */
@@ -767,7 +767,7 @@ export type IHWRadio = IHWActionExecutor & {
 /** A score card! */
 export type IHWScoreCard = {
   __typename?: 'ScoreCard',
-  scores?: Maybe<Array<Maybe<IHWScoreCardPanel>>>,
+  scores?: Maybe<Array<IHWScoreCardPanel>>,
 };
 
 /** Panels make up the score card */
@@ -838,6 +838,8 @@ export type IHWToast = {
   kind?: Maybe<Scalars['String']>,
   /** Text for the followup action */
   followupText?: Maybe<Scalars['String']>,
+  /** Action to be invoked when hitting the followup CTA */
+  followupAction?: Maybe<IHWAction>,
 };
 
 export type IHWToggle = IHWActionExecutor & {

--- a/packages/spruce-types/src/gql/CardBuilder.gql
+++ b/packages/spruce-types/src/gql/CardBuilder.gql
@@ -39,7 +39,7 @@ type ScoreCardPanel {
 
 "A score card!"
 type ScoreCard {
-	scores: [ScoreCardPanel]
+	scores: [ScoreCardPanel!]
 }
 
 union CardBuilderBodyItemViewModel =
@@ -120,7 +120,7 @@ type OnboardingCard {
 	title: String
 
 	"Steps for onboarding"
-	steps: [OnboardingCardStep]
+	steps: [OnboardingCardStep!]!
 }
 
 "The footer component of a card"

--- a/packages/spruce-types/src/gql/List.gql
+++ b/packages/spruce-types/src/gql/List.gql
@@ -98,7 +98,7 @@ type ListItem {
 	list: List
 
 	"Optional; adds multiple lists nested at the same level"
-	lists: [List]
+	lists: [List!]
 }
 
 "Wraps a standard list or list item and makes it collapsable"
@@ -113,7 +113,7 @@ type ExpandableListItem {
 	list: List
 
 	"Optional; adds multiple lists nested at the same level"
-	lists: [List]
+	lists: [List!]
 
 	"Optional icon for collapsed state"
 	collapsedIconName: String
@@ -133,7 +133,7 @@ type List {
 	header: ListHeader
 
 	"List items"
-	items: [ListItemTypes]
+	items: [ListItemTypes!]
 
 	"Set true to make the list smaller"
 	isSmall: Boolean

--- a/packages/spruce-types/src/gql/Toast.gql
+++ b/packages/spruce-types/src/gql/Toast.gql
@@ -17,4 +17,7 @@ type Toast {
 
 	"Text for the followup action"
 	followupText: String
+
+	"Action to be invoked when hitting the followup CTA"
+	followupAction: Action
 }


### PR DESCRIPTION
## What does this PR do?

Lets you use heartwood components manually and through gql endpoints without warnings/errors.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-#](https://sprucelabsai.atlassian.net/browse/SDEV3-#)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

## Screenshots (if appropriate)

## What gif best describes this PR or how it makes you feel?