### PR TITLE
Only run build on canary branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ workflows:
             branches:
               ignore:
                 - master
+                - canary
       - pre_release:
           requires:
             - test
@@ -141,8 +142,6 @@ workflows:
               only:
                 - /prerelease\/.*/
       - canary:
-          requires:
-            - test
           filters:
             branches:
               only:


### PR DESCRIPTION
## What does this PR do?

Set up CI to only run build on merge to `canary` since test will have already passed on the branch we're merging

## Type

- [ ] Feature
- [ ] Bug
- [X] Tech debt