### PR TITLE
Fix dependencies

### DIFF
--- a/packages/spruce-skill-server/package.json
+++ b/packages/spruce-skill-server/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@koa/cors": "2",
 		"@sprucelabs/log": "^2.2.1",
-		"@sprucelabs/spruce-types": "^8.17.8-pre-91dabded.0",
+		"@sprucelabs/spruce-types": "^8.18.0",
 		"apollo-link": "1.2.6",
 		"apollo-link-ws": "1.0.12",
 		"cookies": "^0.8.0",

--- a/packages/spruce-types/package.json
+++ b/packages/spruce-types/package.json
@@ -35,7 +35,6 @@
 		"url": "https://github.com/sprucelabsai/workspace.sprucebot-skills-kit/issues"
 	},
 	"dependencies": {
-		"@sprucelabs/spruce-skill-server": "^8.18.0",
 		"graphql-iso-date": "^3.6.1",
 		"graphql-type-json": "^0.3.0",
 		"typescript": "3.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3032,13 +3032,6 @@
   resolved "https://registry.yarnpkg.com/@sprucelabs/semantic-release/-/semantic-release-2.0.8.tgz#37fdc05bd447e69f60d5c26c0d51c629eef139d9"
   integrity sha512-E+l04vYuyeTKvNjY76jYdcj4gcTe1hVI/jIL332sPavZWaxa9K29i4yYTe7r0cSb8LiqmWarK9Tq6YZ6O3HPfw==
 
-"@sprucelabs/spruce-types@^8.17.8-pre-91dabded.0":
-  version "8.17.8-pre-91dabded.0"
-  resolved "https://registry.yarnpkg.com/@sprucelabs/spruce-types/-/spruce-types-8.17.8-pre-91dabded.0.tgz#e651d9afe0831e6aa7392d4d2c04f60a589c6670"
-  integrity sha512-PPD48bElF+LlNHoRuErcys4en4B+fCOQnHP0ASFaw5dKdkhGz5A9MIn/QN5P6QQ2yktV9aVzxoy/x8KoeF2SEw==
-  dependencies:
-    typescript "~3.4.5"
-
 "@storybook/addon-actions@5.2.1", "@storybook/addon-actions@^5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-5.2.1.tgz#2096e7f938b289be48af6f0adfd620997e7a420c"
@@ -24029,11 +24022,6 @@ typescript@^3.2.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
-
-typescript@~3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 ua-parser-js@0.7.17:
   version "0.7.17"


### PR DESCRIPTION
## What does this PR do?

* Fix circular dependency where `@sprucelabs/spruce-skill-server` was required by `@sprucelabs/spruce-types` which can cause issues w/ builds

* Fixes issue w/ `spruce-types` prerelease referenced instead of linked/current version

## Type

- [ ] Feature
- [ ] Bug
- [X] Tech debt