### PR TITLE
Add max width for large sidebar

### DIFF
--- a/packages/heartwood-components/components/99-web/sidebar.scss
+++ b/packages/heartwood-components/components/99-web/sidebar.scss
@@ -6,7 +6,8 @@
 	background-color: $c-grey-00;
 
 	&.sidebar--large {
-		width: rem(360);
+		width: 100%;
+		max-width: rem(360);
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Sidebars with the prop isLarge will now have a max-width of 360px rather than a hardcoded width of 360px.

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2786](https://sprucelabsai.atlassian.net/browse/SDEV3-2786)
