### PR TITLE
Safari / iOS sidebar scroll issue

### DIFF
--- a/packages/heartwood-components/components/03-structure/page.scss
+++ b/packages/heartwood-components/components/03-structure/page.scss
@@ -171,6 +171,7 @@
 	flex: 1;
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;
+	position: relative;
 }
 
 body.render-location-modal {

--- a/packages/heartwood-components/components/99-web/sidebar.scss
+++ b/packages/heartwood-components/components/99-web/sidebar.scss
@@ -23,7 +23,7 @@ html.skill .sidebar {
 	@include lte('medium') {
 		// NOTE: This classname may change
 		&.sidebar--is-mobile-expanded {
-			position: fixed;
+			position: absolute;
 			top: rem(48);
 			bottom: 0;
 			left: 0;

--- a/packages/heartwood-components/components/99-web/sidebar.scss
+++ b/packages/heartwood-components/components/99-web/sidebar.scss
@@ -47,7 +47,7 @@ html.skill .sidebar {
 	@include lte(990px) {
 		// NOTE: This classname may change
 		&.sidebar--is-mobile-expanded {
-			position: fixed;
+			position: absolute;
 			top: rem(48);
 			bottom: 0;
 			right: 0;

--- a/packages/heartwood-components/components/99-web/sidebar.scss
+++ b/packages/heartwood-components/components/99-web/sidebar.scss
@@ -6,8 +6,12 @@
 	background-color: $c-grey-00;
 
 	&.sidebar--large {
-		width: 100%;
-		max-width: rem(360);
+		width: rem(360);
+		// should we make this a breakpoint?
+		@include lte(360px) {
+			width: 100%;
+			max-width: rem(360);
+		}
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

There seems to be an issue with scrolling on position:fixed overlays in Safari and iOS. The background scrolls when the user attempts to scroll the sidebar. Here is a popular [SO thread](https://stackoverflow.com/questions/41594997/ios-10-safari-prevent-scrolling-behind-a-fixed-overlay-and-maintain-scroll-posi) on it.

There are a slew of workarounds for it, many include adding  javascript to components or using npm packages. I've found that changing the mobile sidebars from position:fixed to position:absolute resolves this issue in Safari (on desktop) and hopefully fixes the issue in iOS as well (need to test).

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2756](https://sprucelabsai.atlassian.net/browse/SDEV3-2756)