### PR TITLE
[SDEV3-2852] Fix linksToWebView option not getting passed through on ctx.sb.message

### DIFF
--- a/packages/spruce-node/index.ts
+++ b/packages/spruce-node/index.ts
@@ -489,8 +489,9 @@ export default class Sprucebot {
 		}
 
 		if (options) {
-			const { type, webViewQueryData } = options
+			const { type, webViewQueryData, linksToWebView } = options
 			data.type = type
+			data.linksToWebView = linksToWebView
 			if (webViewQueryData) {
 				data.webViewQueryData = JSON.stringify(webViewQueryData)
 			}


### PR DESCRIPTION
## What does this PR do?

`linksToWebView` option not respected by `ctx.sb.message()`

## Type

- [ ] Feature
- [X] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2852](https://sprucelabsai.atlassian.net/browse/SDEV3-2852)