### PR TITLE
padding on text in a card_section in eventdetails

### DIFF
--- a/packages/heartwood-components/components/event-details/event-details.scss
+++ b/packages/heartwood-components/components/event-details/event-details.scss
@@ -39,6 +39,9 @@
 		padding-right: 0;
 		padding-bottom: 0;
 		padding-left: 0;
+		p.text {
+			padding: 1rem;
+		}
 	}
 
 	// TODO: Fix the root cause, which is double-nesting when the list item has actions


### PR DESCRIPTION
## What does this PR do?

Adds padding needed for event details to look right in RR.

## Type

- [ ] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-#](https://sprucelabsai.atlassian.net/browse/SDEV3-#)

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

## Screenshots (if appropriate)

## What gif best describes this PR or how it makes you feel?