### PR TITLE
[SDEV3-2814] IModal updates for authentication needs

### DIFF
--- a/packages/spruce-next-helpers/src/index.ts
+++ b/packages/spruce-next-helpers/src/index.ts
@@ -11,6 +11,7 @@ export {
 	ICalendar,
 	IConfirmationDialog,
 	IModal,
+	IModalOpenOptions,
 	ISupportingMessage,
 	IBlockingMessage
 } from './skillskit'

--- a/packages/spruce-next-helpers/src/skillskit/index.ts
+++ b/packages/spruce-next-helpers/src/skillskit/index.ts
@@ -148,13 +148,13 @@ export interface IModalOpenOptions {
 	isPaged?: boolean
 
 	/** The size of the modal */
-	size: IHWModalSize
+	size?: IHWModalSize
 
 	/** Whether the modal should be full-height */
-	isFullHeight: boolean
+	isFullHeight?: boolean
 
 	/** DEPRECATED: use size and isFullHeight instead */
-	contentHeight: string
+	contentHeight?: string
 }
 
 export interface IModal {

--- a/packages/spruce-next-helpers/src/skillskit/index.ts
+++ b/packages/spruce-next-helpers/src/skillskit/index.ts
@@ -99,45 +99,47 @@ export interface IConfirmationDialog {
 	setCancelButtonIsDisabled(isDisabled: boolean): void
 }
 
+export interface IModalOpenOptions {
+	/** The modal title */
+	title?: string
+
+	/** DEPRECATED: Use "route" instead */
+	src?: string
+
+	// TODO: Standardize around route/routeParams and ensure this matches final decision (https://sprucelabsai.atlassian.net/browse/SDEV3-2362)
+	/** The route to load within the modal */
+	route?: {
+		/** The path to the view to load. Either "host" or "slug" should also be set */
+		path: string
+
+		/** If you're opening a non-skill url, set the host. i.e. https://my-skill.example.com */
+		host?: string
+
+		/** If you're opening a skill view, providing the slug will set the proper host and include the JWT token for authentication */
+		slug?: string
+
+		/** If opening a skill view and "slug" is set, authentication will be tied to this organization */
+		organizationId?: string
+
+		/** If opening a skill view and "slug" is set, authentication will be tied to this location */
+		locationId?: string
+
+		/** Additional query parameters */
+		params?: Record<string, string>
+	}
+
+	footerPrimaryActionText?: string
+	footerSecondaryActionText?: string
+	isPaged?: boolean
+	isDialogFooterPrimaryActionDisabled?: boolean
+	isDialogFooterSecondaryActionDisabled?: boolean
+	size: 'small' | 'medium' | 'full-width'
+	contentHeight: string
+}
+
 export interface IModal {
 	/** open a modal dialog */
-	open(options: {
-		/** The modal title */
-		title?: string
-
-		/** DEPRECATED: Use "route" instead */
-		src?: string
-
-		// TODO: Standardize around route/routeParams and ensure this matches final decision (https://sprucelabsai.atlassian.net/browse/SDEV3-2362)
-		/** The route to load within the modal */
-		route?: {
-			/** The path to the view to load. Either "host" or "slug" should also be set */
-			path: string
-
-			/** If you're opening a non-skill url, set the host. i.e. https://my-skill.example.com */
-			host?: string
-
-			/** If you're opening a skill view, providing the slug will set the proper host and include the JWT token for authentication */
-			slug?: string
-
-			/** If opening a skill view and "slug" is set, authentication will be tied to this organization */
-			organizationId?: string
-
-			/** If opening a skill view and "slug" is set, authentication will be tied to this location */
-			locationId?: string
-
-			/** Additional query parameters */
-			params?: Record<string, string>
-		}
-
-		footerPrimaryActionText?: string
-		footerSecondaryActionText?: string
-		isPaged?: boolean
-		isDialogFooterPrimaryActionDisabled?: boolean
-		isDialogFooterSecondaryActionDisabled?: boolean
-		size: 'small' | 'medium' | 'full-width'
-		contentHeight: string
-	}): void
+	open(options: IModalOpenOptions): void
 	/** close modal dialog , data is passed through to onClosed */
 	close(data?: Record<string, any>): void
 	/** invoked when the "back" error is clicked */

--- a/packages/spruce-next-helpers/src/skillskit/index.ts
+++ b/packages/spruce-next-helpers/src/skillskit/index.ts
@@ -1,5 +1,9 @@
 import Iframes from '@sprucelabs/spruce-utils/iframes'
-import { ICoreUserLocation, ICoreCalendarEvent } from '@sprucelabs/spruce-types'
+import {
+	ICoreUserLocation,
+	ICoreCalendarEvent,
+	IHWModalSize
+} from '@sprucelabs/spruce-types'
 
 function postMessage(message: Record<string, any>): void {
 	return window.parent.postMessage(JSON.stringify(message), '*')
@@ -128,12 +132,28 @@ export interface IModalOpenOptions {
 		params?: Record<string, string>
 	}
 
+	/** The primary action text */
 	footerPrimaryActionText?: string
+
+	/** The secondary action text */
 	footerSecondaryActionText?: string
-	isPaged?: boolean
+
+	/** Whether to disable the primary action */
 	isDialogFooterPrimaryActionDisabled?: boolean
+
+	/** Whether to disable the secondary action */
 	isDialogFooterSecondaryActionDisabled?: boolean
-	size: 'small' | 'medium' | 'full-width'
+
+	/** PLACEHOLDER: Future paginated modal functionality */
+	isPaged?: boolean
+
+	/** The size of the modal */
+	size: IHWModalSize
+
+	/** Whether the modal should be full-height */
+	isFullHeight: boolean
+
+	/** DEPRECATED: use size and isFullHeight instead */
 	contentHeight: string
 }
 

--- a/packages/spruce-next-helpers/src/skillskit/index.ts
+++ b/packages/spruce-next-helpers/src/skillskit/index.ts
@@ -102,8 +102,16 @@ export interface IConfirmationDialog {
 export interface IModal {
 	/** open a modal dialog */
 	open(options: {
+		/** The modal title */
 		title?: string
+
+		// TODO: Standardize around route/routeParams (https://sprucelabsai.atlassian.net/browse/SDEV3-2362)
+		/** The full path to the view */
 		src?: string
+
+		/** If opening a skill view, providing the slug will include the JWT token for authentication */
+		slug?: string
+
 		footerPrimaryActionText?: string
 		footerSecondaryActionText?: string
 		isPaged?: boolean

--- a/packages/spruce-next-helpers/src/skillskit/index.ts
+++ b/packages/spruce-next-helpers/src/skillskit/index.ts
@@ -105,12 +105,27 @@ export interface IModal {
 		/** The modal title */
 		title?: string
 
-		// TODO: Standardize around route/routeParams (https://sprucelabsai.atlassian.net/browse/SDEV3-2362)
-		/** The full path to the view */
+		/** DEPRECATED: Use "route" instead */
 		src?: string
 
-		/** If opening a skill view, providing the slug will include the JWT token for authentication */
-		slug?: string
+		// TODO: Standardize around route/routeParams and ensure this matches final decision (https://sprucelabsai.atlassian.net/browse/SDEV3-2362)
+		/** The route to load within the modal */
+		route?: {
+			/** The path to the view to load. If "slug" is omitted this should be a full URL. If "slug" is provided this should not include the host */
+			path: string
+
+			/** If opening a skill view, providing the slug will include the JWT token for authentication */
+			slug?: string
+
+			/** If opening a skill view and "slug" is set, authentication will be tied to this organization */
+			organizationId?: string
+
+			/** If opening a skill view and "slug" is set, authentication will be tied to this location */
+			locationId?: string
+
+			/** Additional query parameters */
+			params?: Record<string, string>
+		}
 
 		footerPrimaryActionText?: string
 		footerSecondaryActionText?: string

--- a/packages/spruce-next-helpers/src/skillskit/index.ts
+++ b/packages/spruce-next-helpers/src/skillskit/index.ts
@@ -111,10 +111,13 @@ export interface IModal {
 		// TODO: Standardize around route/routeParams and ensure this matches final decision (https://sprucelabsai.atlassian.net/browse/SDEV3-2362)
 		/** The route to load within the modal */
 		route?: {
-			/** The path to the view to load. If "slug" is omitted this should be a full URL. If "slug" is provided this should not include the host */
+			/** The path to the view to load. Either "host" or "slug" should also be set */
 			path: string
 
-			/** If opening a skill view, providing the slug will include the JWT token for authentication */
+			/** If you're opening a non-skill url, set the host. i.e. https://my-skill.example.com */
+			host?: string
+
+			/** If you're opening a skill view, providing the slug will set the proper host and include the JWT token for authentication */
 			slug?: string
 
 			/** If opening a skill view and "slug" is set, authentication will be tied to this organization */

--- a/packages/spruce-types/src/gql/queries/UIEnhancements.ts
+++ b/packages/spruce-types/src/gql/queries/UIEnhancements.ts
@@ -355,6 +355,9 @@ export default gql`
 		... on ActionShowModal {
 			type
 			payload {
+				slug
+				route
+				routeParams
 				modalTitle: title
 				footerPrimaryActionText
 				footerSecondaryActionText


### PR DESCRIPTION
## What does this PR do?

* Define `route` on `IModal` which accepts a `slug` for authentication purposes when loading a view in a modal
* Add missing fields to `getUIEnhancements` query

## Type

- [ ] Feature
- [ ] Bug
- [X] Tech debt

## What are the relevant tickets?

- [SDEV3-2814](https://sprucelabsai.atlassian.net/browse/SDEV3-2814)