### PR TITLE
fix(ButtonGroup): Handle actions and close dropdown [SDEV3-2927]

### DIFF
--- a/packages/react-heartwood-components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-heartwood-components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -38,6 +38,10 @@ const ButtonGroup = (
 					>
 						<Button
 							isFullWidth={kind === 'floating'}
+							// TODO: This is necessary since the older "action" interface
+							// (meaning a button) doesn't work with the newer IHWAction
+							// interface. We need to refactor the legacy case broadly to
+							// remove this.
 							action={(action as unknown) as IHWAction}
 							{...action}
 							kind={

--- a/packages/react-heartwood-components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-heartwood-components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -38,6 +38,7 @@ const ButtonGroup = (
 					>
 						<Button
 							isFullWidth={kind === 'floating'}
+							action={(action as unknown) as IHWAction}
 							{...action}
 							kind={
 								kind === 'floating'

--- a/packages/react-heartwood-components/src/components/SplitButton/SplitButton.tsx
+++ b/packages/react-heartwood-components/src/components/SplitButton/SplitButton.tsx
@@ -189,6 +189,18 @@ export default class SplitButton extends Component<
 		)
 	}
 
+	public handleAction(action: IHWAction) {
+		const { onAction } = this.props
+
+		this.setState(
+			{
+				isVisible: false,
+				highlightedActionIndex: -1
+			},
+			() => onAction && onAction(action)
+		)
+	}
+
 	public render(): React.ReactElement {
 		const {
 			defaultAction,
@@ -196,8 +208,7 @@ export default class SplitButton extends Component<
 			kind,
 			isFullWidth,
 			isSmall,
-			usePortal,
-			onAction
+			usePortal
 		} = this.props
 		const { isVisible, menuPosition, highlightedActionIndex } = this.state
 
@@ -209,7 +220,7 @@ export default class SplitButton extends Component<
 					isSmall={isSmall}
 					{...defaultAction}
 					kind={defaultAction.kind || kind}
-					onAction={onAction}
+					onAction={action => this.handleAction(action)}
 				/>
 			)
 		}
@@ -228,7 +239,7 @@ export default class SplitButton extends Component<
 						{...defaultAction}
 						kind={defaultAction.kind || kind}
 						isFullWidth={false}
-						onAction={onAction}
+						onAction={action => this.handleAction(action)}
 					/>
 					<Button
 						isSmall={isSmall}
@@ -236,7 +247,7 @@ export default class SplitButton extends Component<
 						icon={{ name: 'keyboard_arrow_down' }}
 						kind={kind}
 						onClick={this.toggleActionsVisibility}
-						onAction={onAction}
+						onAction={action => this.handleAction(action)}
 					/>
 				</div>
 				{isVisible && (
@@ -257,7 +268,7 @@ export default class SplitButton extends Component<
 										isFullWidth
 										actions={actions}
 										highlightedIndex={highlightedActionIndex}
-										onAction={onAction}
+										onAction={action => this.handleAction(action)}
 									/>
 								</div>,
 								document.body
@@ -277,7 +288,7 @@ export default class SplitButton extends Component<
 									isFullWidth
 									actions={actions}
 									highlightedIndex={highlightedActionIndex}
-									onAction={onAction}
+									onAction={action => this.handleAction(action)}
 								/>
 							</div>
 						)}


### PR DESCRIPTION
- Add temp fix for passing `action` to button by cooercing it into an 
IHWAction; looking at a followup fix
- Took a quick look at fixing "actions" (meaning buttons in the old context) but that's not easy at all. Needs a deeper dive...

## What does this PR do?

## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2927](https://sprucelabsai.atlassian.net/browse/SDEV3-2927)