### PR TITLE
Remove action for toast

### DIFF
--- a/packages/react-heartwood-components/src/components/Toast/Toast.tsx
+++ b/packages/react-heartwood-components/src/components/Toast/Toast.tsx
@@ -47,7 +47,14 @@ const Toast = (props: IToastProps | IHWToast): React.ReactElement => {
 	const commonProps = props as IHWToast
 	const reactHeartwoodProps = props as IToastProps
 
-	const { headline, kind, text, followupAction, followupText } = commonProps
+	const {
+		headline,
+		kind,
+		text,
+		followupAction,
+		followupText,
+		removeAction
+	} = commonProps
 	const { canRemove, onAction, onRemove } = reactHeartwoodProps
 
 	const toastClass = cx('toast', {
@@ -60,7 +67,10 @@ const Toast = (props: IToastProps | IHWToast): React.ReactElement => {
 		<div className={toastClass}>
 			<ToastHeader
 				headline={headline}
-				onRemove={onRemove}
+				onRemove={() => {
+					removeAction && onAction && onAction(removeAction)
+					onRemove && onRemove()
+				}}
 				canRemove={canRemove || false}
 			/>
 			{text && (

--- a/packages/spruce-types/src/generated/api-gql.ts
+++ b/packages/spruce-types/src/generated/api-gql.ts
@@ -766,6 +766,8 @@ export type ICoreGQLCalendarEventDetails = {
 /** Control the rendering of the list item */
 export type ICoreGQLCalendarEventDetailsItem = {
 	__typename?: 'CalendarEventDetailsItem'
+	/** An optional ID for this item; used to allow association with UI Enhancements */
+	id?: Maybe<Scalars['String']>
 	/** How the view should be rendered */
 	type: ICoreGQLCalendarEventDetailsItemType
 	/** The data fed into the view to configure it. */
@@ -5345,6 +5347,8 @@ export type ICoreGQLToast = {
 	text?: Maybe<Scalars['String']>
 	/** Optional; controls whether the toast can be removed. Defaults to true */
 	canRemove?: Maybe<Scalars['Boolean']>
+	/** Action to be invoked when hitting the dismiss button */
+	removeAction?: Maybe<ICoreGQLAction>
 	/** Sets the variation of toast */
 	kind?: Maybe<Scalars['String']>
 	/** Text for the followup action */
@@ -5371,6 +5375,8 @@ export type ICoreGQLUiEnhancementSection = {
 	calendarEventDetailsItems?: Maybe<Array<ICoreGQLCalendarEventDetailsItem>>
 	/** [PLACEHOLDER] Card builder items to add as enhancements */
 	cardBuilderBodyItems?: Maybe<Array<ICoreGQLCardBuilderBodyItem>>
+	/** Context menu items to add as enhancements */
+	contextMenuItems?: Maybe<Array<ICoreGQLButton>>
 	/** Items to add as actions in the section context menu */
 	actions?: Maybe<Array<ICoreGQLAction>>
 }

--- a/packages/spruce-types/src/generated/hw-gql.ts
+++ b/packages/spruce-types/src/generated/hw-gql.ts
@@ -889,6 +889,8 @@ export type IHWToast = {
   text?: Maybe<Scalars['String']>,
   /** Optional; controls whether the toast can be removed. Defaults to true */
   canRemove?: Maybe<Scalars['Boolean']>,
+  /** Action to be invoked when hitting the dismiss button */
+  removeAction?: Maybe<IHWAction>,
   /** Sets the variation of toast */
   kind?: Maybe<Scalars['String']>,
   /** Text for the followup action */

--- a/packages/spruce-types/src/gql/types/Toast.gql
+++ b/packages/spruce-types/src/gql/types/Toast.gql
@@ -12,6 +12,9 @@ type Toast {
 	"Optional; controls whether the toast can be removed. Defaults to true"
 	canRemove: Boolean
 
+	"Action to be invoked when hitting the dismiss button"
+	removeAction: Action
+
 	"Sets the variation of toast"
 	kind: String
 


### PR DESCRIPTION
## What does this PR do?

Gives toast a `removeAction` so we can do things when the dismiss button is hit.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

NA

## Does this add new dependencies? Is there an installation procedure? (yarn, bower, npm, etc)

NA

## Screenshots (if appropriate)

NA

## What gif best describes this PR or how it makes you feel?

NA