### PR TITLE
[SDEV3-2976] Fix updateUser mutation

### DIFF
--- a/packages/spruce-node/index.ts
+++ b/packages/spruce-node/index.ts
@@ -422,18 +422,22 @@ export default class Sprucebot {
 		return this.adapter.get(`/organizations/${organizationId}/users/`, options)
 	}
 
-	//Update for user who have been to this location
-	public async updateUser(
+	// Update a user who has been to this location
+	public async updateGuest(
 		id: string,
 		values: Record<string, any>
 	): Promise<Record<string, any>> {
 		return this.mutation(
 			`
-				mutation($input: updateUserInput!) {
-					id
-					firstName
-					lastName
-					phoneNumber
+				mutation($input: updateGuestInput!) {
+					updateGuest(input: $input) {
+						User {
+							id
+							firstName
+							lastName
+							phoneNumber
+						}
+					}
 				}
 			`,
 			{

--- a/packages/spruce-skill/server/gql/resolvers/Test/sdl.ts
+++ b/packages/spruce-skill/server/gql/resolvers/Test/sdl.ts
@@ -42,14 +42,14 @@ export default (ctx: ISkillContext) => {
 				loadUserOrLocation(type: String!): Model
 			}
 
-			input UpdateUserInput {
+			input UpdateGuestInput {
 				id: ID!
 				firstName: String!
 			}
 
 			extend type Mutation {
 				"Testing a user update"
-				updateUserTest(input: UpdateUserInput!): User
+				UpdateGuestTest(input: UpdateGuestInput!): User
 			}
 		`,
 		resolvers: {
@@ -136,7 +136,7 @@ export default (ctx: ISkillContext) => {
 			},
 			Mutation: {
 				// updating a model, honoring scope (see sr/config/scopes.ts)
-				updateUserTest: ctx.gql.helpers.buildSequelizeResolver({
+				UpdateGuestTest: ctx.gql.helpers.buildSequelizeResolver({
 					modelName: 'User',
 					before: async (_findOptions, args, context) => {
 						const { id, firstName } = args.input
@@ -148,11 +148,11 @@ export default (ctx: ISkillContext) => {
 						})
 
 						if (user) {
-							await ctx.sb.updateUser(id, { firstName })
+							await ctx.sb.UpdateGuest(id, { firstName })
 						}
 
 						// see /src/config/scopes.ts
-						context.scopes.updateUserTest = config.scopes.Mock.public()
+						context.scopes.UpdateGuestTest = config.scopes.Mock.public()
 
 						// let the resolver handle the loading of the model (along with relationships)
 						return {

--- a/packages/spruce-skill/server/gql/resolvers/Test/sdl.ts
+++ b/packages/spruce-skill/server/gql/resolvers/Test/sdl.ts
@@ -148,7 +148,7 @@ export default (ctx: ISkillContext) => {
 						})
 
 						if (user) {
-							await ctx.sb.UpdateGuest(id, { firstName })
+							await ctx.sb.updateGuest(id, { firstName })
 						}
 
 						// see /src/config/scopes.ts

--- a/packages/spruce-skill/server/interfaces/events-generated.ts
+++ b/packages/spruce-skill/server/interfaces/events-generated.ts
@@ -160,6 +160,43 @@ export namespace SpruceEvents.core.GetSettings {
 /**
  * The Spruce Core API. Visit https://developer.spruce.ai for more information.
  *
+ * This is an opportunity to enrich user data. Set the user name, profile image, create a note, etc.
+ */
+export namespace SpruceEvents.core.EnrichUser {
+	/** The event name  */
+	export const name = 'enrich-user'
+
+	/**
+	 * Event Payload
+	 *
+	 * The Spruce Core API listens for this event. You'll emit an event with this payload (ctx.sb.emit('SpruceEvents.core.EnrichUser.eventName', payload))
+	*/
+	export interface IPayload {
+		/**
+		 * The user id to enrich
+		 */
+		enrichUserId?: string
+	}
+
+	/**
+	 * Event Response
+	 *
+	 * The Spruce Core API Skill expects your skill to respond with this data in your event handler:
+	 * ctx.body: SpruceEvents.core.EnrichUser.IResponseBody = { ... }
+	 */
+	export interface IResponseBody {
+		/**
+		 * Respond with &quot;success&quot; to indicate you received the event.
+		 */
+		status: string
+	}
+
+
+}
+
+/**
+ * The Spruce Core API. Visit https://developer.spruce.ai for more information.
+ *
  * Core asks for settings validation
  */
 export namespace SpruceEvents.core.ValidateSettings {

--- a/packages/spruce-skill/server/tests/ExampleGQLTests.ts
+++ b/packages/spruce-skill/server/tests/ExampleGQLTests.ts
@@ -192,8 +192,8 @@ class ExampleTests extends SpruceTest<ISkillContext> {
 
 		const results = await this.gql(
 			gql`
-				mutation($input: updateUserInput!) {
-					updateUserTest(input: $input) {
+				mutation($input: updateGuestInput!) {
+					updateGuestTest(input: $input) {
 						id
 						firstName
 						phoneNumber
@@ -208,7 +208,7 @@ class ExampleTests extends SpruceTest<ISkillContext> {
 			}
 		)
 
-		const mutationUser = get(results, r => r.data.updateUserTest)
+		const mutationUser = get(results, r => r.data.updateGuestTest)
 		assert.isOk(mutationUser.id)
 		assert.isOk(mutationUser.firstName)
 		assert.isNull(mutationUser.phoneNumber) // scopes should block this


### PR DESCRIPTION
## What does this PR do?

The `updateUser` mutation never actually worked as written. This updates that method, changing it to use the `updateGuest` mutation

## Type

- [ ] Feature
- [X] Bug
- [X] Tech debt

## What are the relevant tickets?

- [SDEV3-2976](https://sprucelabsai.atlassian.net/browse/SDEV3-2976)