### PR TITLE
[SDEV3-2767] Default modal height to 100% on screens 500px or less

### DIFF
--- a/packages/heartwood-components/components/06-modal/modal.scss
+++ b/packages/heartwood-components/components/06-modal/modal.scss
@@ -94,6 +94,7 @@
 		top: 0;
 		left: 0;
 		width: 100%;
+		height: 100%;
 		max-height: 100%;
 		overflow-y: auto;
 
@@ -117,6 +118,7 @@
 			top: spacing('base');
 			left: spacing('base');
 			width: calc(100% - #{rem(32)});
+			height: auto;
 			max-height: calc(100% - #{rem(32)});
 		}
 


### PR DESCRIPTION
## What does this PR do?

Default modal height to 100% on screens 500px or less

## What are the relevant tickets?

- [SDEV3-2767](https://sprucelabsai.atlassian.net/browse/SDEV3-2767)