### PR TITLE
[SDEV3-2798] Only show search placeholder text after md screen size breakpoint

### DIFF
--- a/packages/heartwood-components/components/99-web/header-primary.scss
+++ b/packages/heartwood-components/components/99-web/header-primary.scss
@@ -215,9 +215,6 @@
 			height: rem(20);
 			width: rem(20);
 		}
-		.btn__text {
-			display: block;
-		}
 	}
 }
 
@@ -225,6 +222,12 @@
 	.header-primary {
 		.hamburger {
 			display: none;
+		}
+
+		.header-primary__search-btn {
+			.btn__text {
+				display: block;
+			}
 		}
 
 		.text-input {


### PR DESCRIPTION
## What does this PR do?

Only show search placeholder text after md screen size breakpoint

Fixes issue in screenshot:
<img width="537" alt="Screen Shot 2020-01-23 at 10 53 36 AM" src="https://user-images.githubusercontent.com/5225766/73020199-608d5600-3de2-11ea-899e-33389ed8c466.png">


## Type

- [ ] Feature
- [x] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2798](https://sprucelabsai.atlassian.net/browse/SDEV3-2798)