### PR TITLE
[SDEV3-2849] Update user profile image from url

### DIFF
--- a/packages/spruce-node/https/index.ts
+++ b/packages/spruce-node/https/index.ts
@@ -93,7 +93,8 @@ export default class Https implements AbstractSprucebotAdapter {
 		path: string,
 		data?: Record<string, any>,
 		query?: Record<string, any>,
-		method = 'POST'
+		method = 'POST',
+		version?: string
 	): Promise<any> {
 		return new Promise((resolve, reject) => {
 			// API Key must go with each request
@@ -108,7 +109,7 @@ export default class Https implements AbstractSprucebotAdapter {
 					host: this.host,
 					headers,
 					rejectUnauthorized: !this.allowSelfSignedCerts,
-					path: url.build(path, query, this.version, this.id)
+					path: url.build(path, query, version || this.version, this.id)
 				},
 				response => {
 					this.handleResponse(request, response, resolve, reject, method)
@@ -133,6 +134,23 @@ export default class Https implements AbstractSprucebotAdapter {
 		query?: Record<string, any>
 	): Promise<Record<string, any>> {
 		return this.post(path, data, query, 'PATCH')
+	}
+
+	/**
+	 * Make an update through the API
+	 *
+	 * @param {String} path
+	 * @param {Object} data
+	 * @param {Object} query
+	 * @returns {Promise}
+	 */
+	public async put(
+		path: string,
+		data?: Record<string, any>,
+		query?: Record<string, any>,
+		version?: string
+	): Promise<Record<string, any>> {
+		return this.post(path, data, query, 'PUT', version)
 	}
 
 	/**

--- a/packages/spruce-node/index.ts
+++ b/packages/spruce-node/index.ts
@@ -47,12 +47,19 @@ export abstract class AbstractSprucebotAdapter {
 		path: string,
 		data?: Record<string, any>,
 		queryParams?: Record<string, any>,
-		method?: string
+		method?: string,
+		version?: string
 	): Promise<any>
 	public abstract patch(
 		path: string,
 		data?: Record<string, any>,
 		queryParams?: Record<string, any>
+	): Promise<any>
+	public abstract put(
+		path: string,
+		data?: Record<string, any>,
+		queryParams?: Record<string, any>,
+		version?: string
 	): Promise<any>
 	public abstract delete(
 		path: string,
@@ -938,6 +945,22 @@ export default class Sprucebot {
 				eventName,
 				payload
 			}
+		)
+
+		return result
+	}
+
+	public async setUserImageFromUrl(options: {
+		userId: string
+		organizationId: string
+		url: string
+	}) {
+		const { userId, organizationId, url } = options
+		const result = await this.adapter.put(
+			`/organizations/${organizationId}/guests/${userId}/profileImageUrl`,
+			{ url },
+			{},
+			'2.0'
 		)
 
 		return result

--- a/packages/spruce-skill-server/tests/lib/HttpsMock.ts
+++ b/packages/spruce-skill-server/tests/lib/HttpsMock.ts
@@ -147,6 +147,14 @@ export default class HttpsMock extends AbstractSprucebotAdapter {
 		console.log('MOCK PATCH', data, path, query)
 		return Promise.resolve({})
 	}
+	public async put(
+		path: string,
+		data?: Record<string, any>,
+		query?: Record<string, any>
+	): Promise<any> {
+		console.log('MOCK PUT', data, path, query)
+		return Promise.resolve({})
+	}
 	public async delete(path: string, query?: Record<string, any>): Promise<any> {
 		console.log('MOCK DELETE', path, query)
 		return Promise.resolve({})


### PR DESCRIPTION
## What does this PR do?

Adds `spruce-node` method for updating a user profile image from a url

## Type

- [X] Feature
- [ ] Bug
- [ ] Tech debt

## What are the relevant tickets?

- [SDEV3-2849](https://sprucelabsai.atlassian.net/browse/SDEV3-2849)