### PR TITLE
[SDEV3-3041] Add no nav prev button prop

### DIFF
--- a/packages/react-sprucebot/src/components/DateSelect/DateSelect.js
+++ b/packages/react-sprucebot/src/components/DateSelect/DateSelect.js
@@ -102,7 +102,8 @@ class DateSelect extends Component {
 			initialVisibleMonth,
 			onPrevMonthClick,
 			onNextMonthClick,
-			loading
+			loading,
+			noNavPrevButton
 		} = this.props
 
 		return (
@@ -140,6 +141,7 @@ class DateSelect extends Component {
 							chevron_right
 						</Icon>
 					}
+					noNavPrevButton={noNavPrevButton}
 					keepOpenOnDateSelect
 					hideKeyboardShortcutsPanel
 					noBorder
@@ -162,11 +164,13 @@ DateSelect.propTypes = {
 	onPrevMonthClick: PropTypes.func,
 	loading: PropTypes.bool,
 	highlightDates: PropTypes.array,
-	canDeselectDate: PropTypes.bool
+	canDeselectDate: PropTypes.bool,
+	noNavPrevButton: PropTypes.bool
 }
 
 DateSelect.defaultProps = {
 	allowPastDates: false,
 	loading: false,
-	canDeselectDate: true
+	canDeselectDate: true,
+	noNavPrevButton: false
 }


### PR DESCRIPTION
## What does this PR do?

Pass in prop to hide prev nav button

Looks like this is possible based off the source code here:
(https://github.com/airbnb/react-dates/blob/master/src/components/DayPickerSingleDateController.jsx)

## What are the relevant tickets?

- [SDEV3-3041](https://sprucelabsai.atlassian.net/browse/SDEV3-3041)

