### PR TITLE
fix: Procfile path, force node to node 10

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: sh -c 'cd ./packages/spruce-skill/ && node --optimize_for_size --max_old_space_size=460 --gc_interval=100 build/server.js'
+web: sh -c 'cd ./packages/spruce-skill/ && NODE_CONFIG_DIR=./build/config node --optimize_for_size --max_old_space_size=460 --gc_interval=100 build/server/server.js'

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
 		"packages/spruce-utils",
 		"packages/spruce-types"
 	],
+        "engines": {
+                "node": "^10",
+                "npm": "^6"
+        },
 	"scripts": {
 		"local": "pm2 start ecosystem.config.js && echo 'run `yarn run log` to tail the logs'",
 		"log": "pm2 log 'SB Skillskit'",


### PR DESCRIPTION
## What does this PR do?

Fixes a build issue on Heroku.  This also sets the workspace node version to 10, the build has been failing since Heroku updated to node 12.  

Details on node 12 issue: The version of sqlite3 we are using (4.0.6) fails to compile in node 12. NaN package -  https://github.com/nodejs/nan/issues/849 -  this says the fix is included in 4.07 - https://github.com/mapbox/node-sqlite3/pull/1093

## Type

- [ ] Feature
- [ ] Bug
- [x] Tech debt