### PR TITLE
CardBuilder: Clean up types for better adherence to shared types

### DIFF
--- a/packages/react-heartwood-components/src/components/Button/Button.tsx
+++ b/packages/react-heartwood-components/src/components/Button/Button.tsx
@@ -72,7 +72,7 @@ const Button = (props: IButtonProps | IHWButton): React.ReactElement => {
 		text,
 		type,
 		payload,
-		HTMLAttributes,
+		htmlAttributes,
 		...rest
 	} = reactHeartwoodProps
 
@@ -150,7 +150,7 @@ const Button = (props: IButtonProps | IHWButton): React.ReactElement => {
 			type={type || 'button'}
 			onClick={handleClick}
 			disabled={isDisabled || false}
-			{...HTMLAttributes}
+			{...htmlAttributes}
 		>
 			<Inner />
 		</button>

--- a/packages/react-heartwood-components/src/components/Button/Button.tsx
+++ b/packages/react-heartwood-components/src/components/Button/Button.tsx
@@ -72,6 +72,7 @@ const Button = (props: IButtonProps | IHWButton): React.ReactElement => {
 		text,
 		type,
 		payload,
+		HTMLAttributes,
 		...rest
 	} = reactHeartwoodProps
 
@@ -149,6 +150,7 @@ const Button = (props: IButtonProps | IHWButton): React.ReactElement => {
 			type={type || 'button'}
 			onClick={handleClick}
 			disabled={isDisabled || false}
+			{...HTMLAttributes}
 		>
 			<Inner />
 		</button>

--- a/packages/react-heartwood-components/src/components/Card/Card-story.tsx
+++ b/packages/react-heartwood-components/src/components/Card/Card-story.tsx
@@ -34,7 +34,7 @@ const cardJSON: ICardBuilderProps = {
 				type: IHWButtonTypes.Button,
 				text: 'More Info',
 				href: '#',
-				HTMLAttributes: {
+				htmlAttributes: {
 					target: '_blank'
 				},
 				isSmall: true
@@ -59,7 +59,7 @@ const cardJSON: ICardBuilderProps = {
 					id: 'foo',
 					type: IHWButtonTypes.Button,
 					text: 'Fire a JS Callback!',
-					HTMLAttributes: {
+					htmlAttributes: {
 						onClick: () => window.alert('clicked!')
 					},
 					kind: ButtonKinds.Secondary,

--- a/packages/react-heartwood-components/src/components/Card/Card-story.tsx
+++ b/packages/react-heartwood-components/src/components/Card/Card-story.tsx
@@ -58,7 +58,10 @@ const cardJSON: ICardBuilderProps = {
 				{
 					id: 'foo',
 					type: IHWButtonTypes.Button,
-					text: 'Do things',
+					text: 'Fire a JS Callback!',
+					HTMLAttributes: {
+						onClick: () => window.alert('clicked!')
+					},
 					kind: ButtonKinds.Secondary,
 					isSmall: true
 				}

--- a/packages/react-heartwood-components/src/components/Card/Card-story.tsx
+++ b/packages/react-heartwood-components/src/components/Card/Card-story.tsx
@@ -24,15 +24,19 @@ import {
 } from '@sprucelabs/spruce-types'
 
 const cardJSON: ICardBuilderProps = {
+	id: 'foo',
 	header: {
 		title: 'Introducing the Card Builder! (Note: WIP)',
 		labelText: '',
 		actions: [
 			{
+				id: 'foo',
 				type: IHWButtonTypes.Button,
 				text: 'More Info',
 				href: '#',
-				target: '_blank',
+				HTMLAttributes: {
+					target: '_blank'
+				},
 				isSmall: true
 			}
 		]
@@ -52,6 +56,7 @@ const cardJSON: ICardBuilderProps = {
 		buttonGroup: {
 			actions: [
 				{
+					id: 'foo',
 					type: IHWButtonTypes.Button,
 					text: 'Do things',
 					kind: ButtonKinds.Secondary,
@@ -63,6 +68,7 @@ const cardJSON: ICardBuilderProps = {
 }
 
 const cardJSON2: ICardBuilderProps = {
+	id: 'foo',
 	header: {
 		title: 'Your sales for today!'
 	},
@@ -86,6 +92,7 @@ const cardJSON2: ICardBuilderProps = {
 	}
 }
 const cardJSON3: ICardBuilderProps = {
+	id: 'foo',
 	onboarding: {
 		title: 'Setup your first skill!',
 		steps: [
@@ -99,13 +106,13 @@ const cardJSON3: ICardBuilderProps = {
 			{
 				id: '2',
 				tabTitle: 'Set up your team',
-				tabIcon: { name: 'location', isLineIcon: true },
+				tabIcon: { id: 'foo', name: 'location', isLineIcon: true },
 				panelTitle: 'Team setup is the best',
 				panelCopy: 'Teammwork makes the dream work!'
 			},
 			{
 				id: '3',
-				tabIcon: { name: 'launch', isLineIcon: true },
+				tabIcon: { id: 'foo', name: 'launch', isLineIcon: true },
 				tabTitle: 'Go live',
 				panelTitle: "You're ready to go live!",
 				panelCopy: 'Do it! Do it!'
@@ -114,6 +121,7 @@ const cardJSON3: ICardBuilderProps = {
 	}
 }
 const cardJSON4: ICardBuilderProps = {
+	id: 'foo',
 	header: {
 		labelText: 'The last example!'
 	},
@@ -122,6 +130,7 @@ const cardJSON4: ICardBuilderProps = {
 			{
 				type: IHWCardBuilderBodyItemType.List,
 				viewModel: {
+					id: '',
 					header: {
 						title: 'This is a list!'
 					},
@@ -130,12 +139,12 @@ const cardJSON4: ICardBuilderProps = {
 							id: 'number_one',
 							title: 'This is so cool!',
 							subtitle: 'For sure!',
-							icon: { name: 'complete', isLineIcon: true }
+							icon: { id: 'foo', name: 'complete', isLineIcon: true }
 						},
 						{
 							id: 'number_two',
 							title: 'Takes all the props a List can take!',
-							icon: { name: 'complete', isLineIcon: true }
+							icon: { id: 'foo', name: 'complete', isLineIcon: true }
 						}
 					]
 				}
@@ -143,6 +152,7 @@ const cardJSON4: ICardBuilderProps = {
 			{
 				type: IHWCardBuilderBodyItemType.Text,
 				viewModel: {
+					id: 'lol',
 					text: 'Following up with text component!'
 				}
 			}
@@ -152,6 +162,7 @@ const cardJSON4: ICardBuilderProps = {
 		buttonGroup: {
 			actions: [
 				{
+					id: 'foo',
 					type: IHWButtonTypes.Button,
 					text: 'Do things',
 					kind: ButtonKinds.Secondary,
@@ -163,6 +174,7 @@ const cardJSON4: ICardBuilderProps = {
 }
 
 const cardJSON5: ICardBuilderProps = {
+	id: 'foo',
 	header: {
 		title: 'Danger Zone'
 	},
@@ -170,14 +182,15 @@ const cardJSON5: ICardBuilderProps = {
 		buttonGroup: {
 			actions: [
 				{
+					id: 'foo',
 					type: IHWButtonTypes.Button,
 					text: 'Delete this thing forever',
 					icon: {
+						id: 'foo',
 						name: 'remove'
 					},
 					kind: ButtonKinds.Caution,
-					isSmall: true,
-					onClick: () => {}
+					isSmall: true
 				}
 			]
 		},

--- a/packages/react-heartwood-components/src/components/Card/components/CardBuilder.tsx
+++ b/packages/react-heartwood-components/src/components/Card/components/CardBuilder.tsx
@@ -3,81 +3,39 @@ import {
 	IHWCardBuilder,
 	IHWCardBuilderBody,
 	IHWCardBuilderBodyItem,
-	IHWCardBuilderFooter,
-	IHWHeading,
-	IHWScoreCard
+	IHWCardBuilderFooter
 } from '@sprucelabs/spruce-types'
 import React from 'react'
+import { unionArray } from '../../..'
 // COMPONENTS THAT CAN GO INTO THIS COMPONENT, KEEP MINIMAL
-import Button, { IButtonProps } from '../../Button/Button'
-import ButtonGroup, { IButtonGroupProps } from '../../ButtonGroup/ButtonGroup'
+import Button from '../../Button/Button'
+import ButtonGroup from '../../ButtonGroup/ButtonGroup'
 import Heading from '../../Heading/Heading'
-import Image, { IImageProps } from '../../Image/Image'
-import List, { IListProps } from '../../List/List'
-import Text, { ITextProps } from '../../Text/Text'
-import Toast, { IToastProps } from '../../Toast/Toast'
+import Image from '../../Image/Image'
+import List from '../../List/List'
+import Text from '../../Text/Text'
+import Toast from '../../Toast/Toast'
 import Card from '../Card'
 import CardBody from './CardBody'
 import CardFooter from './CardFooter'
-import CardHeader, { ICardHeaderProps } from './CardHeader'
-import OnboardingCard, { IOnboardingCardProps } from './OnboardingCard'
+import CardHeader from './CardHeader'
+import OnboardingCard from './OnboardingCard'
 import Scores from './Scores'
-import { unionArray } from '../../..'
 
-export interface ICardBuilderFooter
-	extends Omit<IHWCardBuilderFooter, 'buttonGroup'> {
-	/** Render buttons in the Card Footer */
-	buttonGroup?: IButtonGroupProps | null
-}
-
-export type CardBuilderBodyItemViewModel =
-	| IButtonProps
-	| IImageProps
-	| IHWHeading
-	| ITextProps
-	| IHWScoreCard
-	| IToastProps
-	| IListProps
-
-export interface ICardBuilderBodyItem
-	extends Omit<IHWCardBuilderBodyItem, 'viewModel'> {
-	viewModel: CardBuilderBodyItemViewModel
-}
-
-export interface ICardBuilderBodyProps
-	extends Omit<IHWCardBuilderBody, 'items'> {
-	/** array of items to be rendered */
-	items?: ICardBuilderBodyItem[]
-
+// TODO: These three interfaces are deprecated; they were made for the
+// sake of overriding core type values but we're no longer doing that.
+export interface ICardBuilderFooter extends IHWCardBuilderFooter {}
+export interface ICardBuilderBodyItem extends IHWCardBuilderBodyItem {}
+export interface ICardBuilderBodyProps extends IHWCardBuilderBody {
 	/** optional child that will be rendered as the body */
 	children?: React.ReactNode
 }
 
-export interface ICardBuilderProps
-	extends Omit<
-		IHWCardBuilder,
-		'id' | 'header' | 'onboarding' | 'body' | 'footer' | 'headerImage'
-	> {
-	/** optional id for view caching */
-	id?: string
-
-	/** Card Header props */
-	header?: ICardHeaderProps | null
-
-	/** Image rendered as header */
-	headerImage?: IImageProps | null
-
-	/** all onboarding props */
-	onboarding?: IOnboardingCardProps | null
-
-	/** Card Body props */
-	body?: ICardBuilderBodyProps | null
-
-	/** Card Footer props */
-	footer?: ICardBuilderFooter | null
+export interface ICardBuilderProps extends IHWCardBuilder {
+	body?: IHWCardBuilder['body'] & { children?: any }
 
 	/** so we can use directly and set our own children */
-	children?: any
+	children?: React.ReactNode
 
 	/** optional, provide a handler for Actions */
 	onAction?: (action: IHWAction) => any
@@ -145,7 +103,7 @@ const CardBuilder = (props: ICardBuilderProps): React.ReactElement => {
 		hasBottomPadding: true
 	}
 
-	const { children } = (body as ICardBuilderProps) || { children: undefined }
+	const { children } = body || { children: undefined }
 
 	return (
 		<Card>

--- a/packages/react-heartwood-components/src/components/EventDetails/eventDetailsMock.ts
+++ b/packages/react-heartwood-components/src/components/EventDetails/eventDetailsMock.ts
@@ -462,12 +462,13 @@ export const warningAppointment: IEventDetailsProps = {
 								items: [
 									{
 										id: '1',
-										icon: { name: 'calendar', isLineIcon: true },
+										icon: { id: 'foo', name: 'calendar', isLineIcon: true },
 										title: 'Web, Nov 28, 2018',
 										subtitle: '11am–12:15pm',
 										actions: [
 											{
-												icon: { name: 'edit' },
+												id: 'foo',
+												icon: { id: 'foo', name: 'edit' },
 												kind: ButtonKinds.Simple,
 												action: {
 													type: IHWActionTypes.EmitEvent,

--- a/packages/spruce-types/src/generated/hw-gql.ts
+++ b/packages/spruce-types/src/generated/hw-gql.ts
@@ -266,6 +266,8 @@ export type IHWButton = IHWActionExecutor & {
   icon?: Maybe<IHWIcon>,
   /** Type attribute for HTML button element. Defaults to 'button'. */
   type?: Maybe<IHWButtonTypes>,
+  /** Otherwise unspecified attributes that will be applied to the underlying button element */
+  HTMLAttributes?: Maybe<Scalars['JSON']>,
   /** Set true to disable the button */
   isDisabled?: Maybe<Scalars['Boolean']>,
   /** Optional action to invoke when tapped */

--- a/packages/spruce-types/src/generated/hw-gql.ts
+++ b/packages/spruce-types/src/generated/hw-gql.ts
@@ -267,7 +267,7 @@ export type IHWButton = IHWActionExecutor & {
   /** Type attribute for HTML button element. Defaults to 'button'. */
   type?: Maybe<IHWButtonTypes>,
   /** Otherwise unspecified attributes that will be applied to the underlying button element */
-  HTMLAttributes?: Maybe<Scalars['JSON']>,
+  htmlAttributes?: Maybe<Scalars['JSON']>,
   /** Set true to disable the button */
   isDisabled?: Maybe<Scalars['Boolean']>,
   /** Optional action to invoke when tapped */

--- a/packages/spruce-types/src/gql/types/Button.gql
+++ b/packages/spruce-types/src/gql/types/Button.gql
@@ -45,7 +45,7 @@ type Button implements ActionExecutor {
 	type: ButtonTypes
 
 	"Otherwise unspecified attributes that will be applied to the underlying button element"
-	HTMLAttributes: JSON
+	htmlAttributes: JSON
 
 	"Set true to disable the button"
 	isDisabled: Boolean

--- a/packages/spruce-types/src/gql/types/Button.gql
+++ b/packages/spruce-types/src/gql/types/Button.gql
@@ -44,6 +44,9 @@ type Button implements ActionExecutor {
 	"Type attribute for HTML button element. Defaults to 'button'."
 	type: ButtonTypes
 
+	"Otherwise unspecified attributes that will be applied to the underlying button element"
+	HTMLAttributes: JSON
+
 	"Set true to disable the button"
 	isDisabled: Boolean
 


### PR DESCRIPTION
## What does this PR do?
- Formerly we tried omitting and overwriting props from spruce-types due to slight differences in the React vs. data-driven APIs.
- Since then we've upped our understanding of this type of extension, and it's less necessary. Most specifically I'm doing the correct union-type to allow extension of `children` onto CardBody, which was the big hold-up.
- It's important that builders do not modify our core types going forward, as we're using those as the source of truth. Variance here will lead to bugs, etc.

## Type

- [x] Feature
- [ ] Bug
- [ ] Tech debt