### PR TITLE
feat(SkillsKit): Only allow whitelabel stylesheets on guest pages (v7) [SDEV3-3094]

### DIFF
--- a/packages/react-sprucebot/src/skillskit/next/_document.js
+++ b/packages/react-sprucebot/src/skillskit/next/_document.js
@@ -18,9 +18,10 @@ export default class MyDocument extends Document {
 
 		let orgWhitelabel
 
-		//we have any whitelabelling happening?
+		// Shall we whitelabel?
 		if (
 			auth &&
+			auth.role === 'guest' &&
 			auth.Location &&
 			auth.Location.Organization &&
 			auth.Location.Organization.allowWhiteLabelling &&


### PR DESCRIPTION
v7 version of https://github.com/sprucelabsai/workspace.sprucebot-skills-kit/pull/825