### PR TITLE
feat(PageBuilder): Create basic architecture

### DIFF
--- a/packages/react-heartwood-components/src/components/PageBuilder/PageBuilder-story.tsx
+++ b/packages/react-heartwood-components/src/components/PageBuilder/PageBuilder-story.tsx
@@ -1,0 +1,93 @@
+import {
+	IHWButtonKinds,
+	IHWButtonTypes,
+	IHWCardBuilder,
+	IHWCardBuilderBodyItemType,
+	IHWPageBuilderSectionType
+} from '@sprucelabs/spruce-types'
+import { withKnobs } from '@storybook/addon-knobs'
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { ButtonKinds } from '../Button/Button'
+import Layout, { LayoutSection } from '../Layout'
+import Page, { PageContent } from '../Page'
+import { PageBuilder } from './PageBuilder'
+
+const stories = storiesOf('PageBuilder', module)
+
+const cardJSON: IHWCardBuilder = {
+	id: 'foo',
+	header: {
+		title: 'Introducing the Card Builder! (Note: WIP)',
+		labelText: '',
+		actions: [
+			{
+				id: 'foo',
+				type: IHWButtonTypes.Button,
+				text: 'More Info',
+				href: '#',
+				htmlAttributes: {
+					target: '_blank'
+				},
+				isSmall: true
+			}
+		]
+	},
+	body: {
+		items: [
+			{
+				type: IHWCardBuilderBodyItemType.Text,
+				viewModel: {
+					id: 'first',
+					text: `The Card Builder enables Skill devs to build cards using JSON. It should not be used for core cards.`
+				}
+			}
+		]
+	},
+	footer: {
+		buttonGroup: {
+			actions: [
+				{
+					id: 'foo',
+					type: IHWButtonTypes.Button,
+					text: 'Fire a JS Callback!',
+					htmlAttributes: {
+						onClick: () => window.alert('clicked!')
+					},
+					kind: ButtonKinds.Secondary,
+					isSmall: true
+				}
+			]
+		}
+	}
+}
+stories.addDecorator(story => (
+	<Page>
+		<PageContent>
+			<Layout>
+				<LayoutSection>{story()}</LayoutSection>
+			</Layout>
+		</PageContent>
+	</Page>
+))
+
+stories.addDecorator(withKnobs)
+
+stories.add('default', () => (
+	<PageBuilder
+		sections={[
+			{
+				type: IHWPageBuilderSectionType.CardBuilder,
+				viewModel: cardJSON
+			},
+			{
+				type: IHWPageBuilderSectionType.Button,
+				viewModel: {
+					id: 'new-button',
+					text: 'My cool button',
+					kind: IHWButtonKinds.Primary
+				}
+			}
+		]}
+	/>
+))

--- a/packages/react-heartwood-components/src/components/PageBuilder/PageBuilder.tsx
+++ b/packages/react-heartwood-components/src/components/PageBuilder/PageBuilder.tsx
@@ -1,0 +1,42 @@
+import {
+	IHWButton,
+	IHWCardBuilder,
+	IHWPageBuilder,
+	IHWPageBuilderSectionType,
+	Maybe
+} from '@sprucelabs/spruce-types'
+import React from 'react'
+import Button from '../Button/Button'
+import { CardBuilder } from '../Card'
+
+// Strictly associate valid types to their correct viewModel;
+// GQL doesn't support this level of association, so we just need to
+// make sure we're establish the correct mappings while adhering to the
+// general data layotu defined in the GQL.
+type ValidPageBuilderSectionConfigs =
+	| {
+			type: IHWPageBuilderSectionType.Button
+			viewModel: IHWButton
+	  }
+	| {
+			type: IHWPageBuilderSectionType.CardBuilder
+			viewModel: IHWCardBuilder
+	  }
+
+interface IPageBuilderProps extends IHWPageBuilder {
+	sections: Maybe<ValidPageBuilderSectionConfigs>[]
+}
+
+export const PageBuilder = ({ sections }: IPageBuilderProps) => (
+	<div>
+		{sections.map(section => {
+			if (section) {
+				if (section.type === IHWPageBuilderSectionType.CardBuilder) {
+					return <CardBuilder {...section.viewModel} />
+				} else if (section.type === IHWPageBuilderSectionType.Button) {
+					return <Button {...section.viewModel} />
+				}
+			}
+		})}
+	</div>
+)

--- a/packages/spruce-types/src/generated/hw-gql.ts
+++ b/packages/spruce-types/src/generated/hw-gql.ts
@@ -802,6 +802,28 @@ export type IHWOnboardingCardStep = {
   isComplete?: Maybe<Scalars['Boolean']>,
 };
 
+/** The builder for all things cards */
+export type IHWPageBuilder = {
+  __typename?: 'PageBuilder',
+  /** An array of sections to render */
+  sections: Array<Maybe<IHWPageBuilderSection>>,
+};
+
+export type IHWPageBuilderSection = {
+  __typename?: 'PageBuilderSection',
+  /** The type of the section */
+  type?: Maybe<IHWPageBuilderSectionType>,
+  /** Data to render the section */
+  viewModel?: Maybe<IHWPageBuilderSectionViewModel>,
+};
+
+export enum IHWPageBuilderSectionType {
+  CardBuilder = 'cardBuilder',
+  Button = 'button'
+}
+
+export type IHWPageBuilderSectionViewModel = IHWCardBuilder | IHWButton;
+
 /** A radio control. Give a bunch the same name to keep them as part of the same group */
 export type IHWRadio = IHWActionExecutor & {
   __typename?: 'Radio',

--- a/packages/spruce-types/src/gql/types/PageBuilder.gql
+++ b/packages/spruce-types/src/gql/types/PageBuilder.gql
@@ -1,0 +1,20 @@
+union PageBuilderSectionViewModel = CardBuilder | Button
+
+enum PageBuilderSectionType {
+	cardBuilder
+	button
+}
+
+type PageBuilderSection {
+	"The type of the section"
+	type: PageBuilderSectionType
+
+	"Data to render the section"
+	viewModel: PageBuilderSectionViewModel
+}
+
+"The builder for all things cards"
+type PageBuilder {
+	"An array of sections to render"
+	sections: [PageBuilderSection]!
+}


### PR DESCRIPTION
![Screen Shot 2020-03-26 at 3 38 24 PM](https://user-images.githubusercontent.com/1161192/77694349-dd21e980-6f77-11ea-9434-6d34988af00b.png)

☝️ demonstration of this PR, with two sections being pushed into the PageBuilder (a CardBuilder and a Button)

- This is a bare-bones layout for how we'll add items to PageBuilder 
with proper type-checking.
- I threw `Button` in there to demonstrate multiple types; it's not 
something we specifically talked about but adding a simple button 
section could be handy.
- The best way to think about this is as a data/component scaffold; once we add components that have multiple sections, i.e. `TwoColLayout`, each column could contain a `PageBuilder` of its own. Keeping this system basic should allow for infinite layout combinations once we have the proper components fueling it.